### PR TITLE
[RPRBLND-1505] Fix Mesh normals

### DIFF
--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -211,7 +211,7 @@ def sync(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **kwargs)
 
     usd_mesh.CreateSubdivisionSchemeAttr(UsdGeom.Tokens.none)
     usd_mesh.CreateNormalsAttr(data.normals)
-    usd_mesh.SetNormalsInterpolation(UsdGeom.Tokens.varying)
+    usd_mesh.SetNormalsInterpolation(UsdGeom.Tokens.faceVarying)
 
     for name, uv_layer in data.uv_layers.items():
         uv_primvar = usd_mesh.CreatePrimvar(sdf_path(name),


### PR DESCRIPTION
PURPOSE
Mesh normals are ignored by GL and RPR render delegates. Fix it.

CHANGES MADE
- correctly applied mesh normals.

TECHNICAL STEPS
- disabled mesh automatic subdivision mode.