### PR TITLE
Fixed activation plugin for Blender 2.91+

### DIFF
--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -142,7 +142,7 @@ class ShadingData:
         if not self.use_scene_world:
             self.studio_light = shading.selected_studio_light.path
             if not self.studio_light:
-                self.studio_light = str(utils.BLENDER_DATA_DIR / "studiolights/world" /
+                self.studio_light = str(utils.BLENDER_DATA_DIR / "datafiles/studiolights/world" /
                                         shading.studio_light)
             self.studio_light_rotate_z = shading.studiolight_rotate_z
             self.studio_light_background_alpha = shading.studiolight_background_alpha

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -36,9 +36,7 @@ IS_LINUX = OS == 'Linux'
 BLENDER_VERSION = f'{bpy.app.version[0]}.{bpy.app.version[1]}'
 
 PLUGIN_ROOT_DIR = Path(hdusd.__file__).parent
-BLENDER_ROOT_DIR = (Path(sys.executable).parent / "../Resources") if IS_MAC \
-                   else Path(sys.executable).parent
-BLENDER_DATA_DIR = next(BLENDER_ROOT_DIR.glob("2.*/datafiles"))
+BLENDER_DATA_DIR = Path(bpy.utils.resource_path('LOCAL'))
 
 HDUSD_DEBUG_MODE = bool(int(os.environ.get('HDUSD_BLENDER_DEBUG', 0)))
 HDUSD_LIBS_DIR = Path(os.environ['HDUSD_LIBS_DIR']) if HDUSD_DEBUG_MODE else \


### PR DESCRIPTION
### EFFECT OF CHANGE
Fixed possible issue with plugin activation. Issue #18.

### TECHNICAL STEPS
Used bpy.utils.resource_path('LOCAL') instead of sys.executable (which could reference to blender.ex e or python.exe).