### PR TITLE
RPRBLND-1479: MaterialX network

### DIFF
--- a/cmd_tools/create_hdusd_libs.py
+++ b/cmd_tools/create_hdusd_libs.py
@@ -18,7 +18,7 @@ from pathlib import Path
 import argparse
 
 
-def enumerate_libs(usd_dir, hdrpr_dir):
+def enumerate_libs(usd_dir, hdrpr_dir, mx_dir):
     # USD libraries
     for f in (usd_dir / "lib").glob("**/*"):
         if f.is_dir():
@@ -63,6 +63,15 @@ def enumerate_libs(usd_dir, hdrpr_dir):
 
         yield f, Path("plugins") / f.relative_to(hdrpr_dir / "./plugin")
 
+    # MaterialX libraries
+    for f in (mx_dir / "python/MaterialX").glob("*"):
+        if f.is_dir():
+            continue
+        if f.suffix in (".lib",):
+            continue
+
+        yield f, Path("materialx") / f.relative_to(mx_dir)
+
 
 def main():
     ap = argparse.ArgumentParser()
@@ -72,6 +81,8 @@ def main():
                     help="USD dir")
     ap.add_argument("-hdrpr", required=True, metavar="",
                     help="HdRPR dir")
+    ap.add_argument("-mx", required=True, metavar="",
+                    help="MaterialX dir")
     ap.add_argument("-libs", required=False, metavar="",
                     help="Libs dir")
     args = ap.parse_args()
@@ -84,7 +95,7 @@ def main():
         shutil.rmtree(str(libs_dir))
 
     print("Copying libs to:", libs_dir)
-    for f, relative in enumerate_libs(Path(args.usd), Path(args.hdrpr)):
+    for f, relative in enumerate_libs(Path(args.usd), Path(args.hdrpr), Path(args.mx)):
         print(f, '->', relative)
 
         f_copy = libs_dir / relative

--- a/cmd_tools/create_hdusd_libs.py
+++ b/cmd_tools/create_hdusd_libs.py
@@ -72,6 +72,22 @@ def enumerate_libs(usd_dir, hdrpr_dir, mx_dir):
 
         yield f, Path("materialx") / f.relative_to(mx_dir)
 
+    for f in (mx_dir / "libraries").glob("**/*"):
+        if f.is_dir():
+            continue
+        if f.suffix in (".lib",):
+            continue
+
+        yield f, Path("materialx") / f.relative_to(mx_dir)
+
+    for f in (mx_dir / "resources").glob("**/*"):
+        if f.is_dir():
+            continue
+        if f.suffix in (".lib",):
+            continue
+
+        yield f, Path("materialx") / f.relative_to(mx_dir)
+
 
 def main():
     ap = argparse.ArgumentParser()

--- a/src/hdusd/__init__.py
+++ b/src/hdusd/__init__.py
@@ -36,7 +36,7 @@ log = logging.Log(tag='init')
 log.info("Loading USD Hydra addon {}".format(bl_info['version']))
 
 
-from . import engine, properties, ui, usd_nodes
+from . import engine, properties, ui, usd_nodes, mx_nodes
 
 
 def register():
@@ -46,6 +46,7 @@ def register():
     engine.register()
     properties.register()
     ui.register()
+    mx_nodes.register()
     usd_nodes.register()
 
 
@@ -53,6 +54,7 @@ def unregister():
     """ Unregister all addon classes from Blender """
     log("unregister")
 
+    mx_nodes.unregister()
     usd_nodes.unregister()
     ui.unregister()
     properties.unregister()

--- a/src/hdusd/engine/__init__.py
+++ b/src/hdusd/engine/__init__.py
@@ -21,11 +21,12 @@ from .. import utils
 
 
 os.environ['PATH'] = f"{utils.HDUSD_LIBS_DIR / 'usd'};{utils.HDUSD_LIBS_DIR / 'plugins'};" \
-                     f"{utils.HDUSD_LIBS_DIR / 'hdrpr'};{os.environ['PATH']}"
+                     f"{utils.HDUSD_LIBS_DIR / 'hdrpr'};" \
+                     f"{os.environ['PATH']}"
 os.environ['PXR_PLUGINPATH_NAME'] = str(utils.HDUSD_LIBS_DIR / 'plugins')
 
 sys.path.append(str(utils.HDUSD_LIBS_DIR / 'usd/python'))
-
+sys.path.append(str(utils.HDUSD_LIBS_DIR / 'materialx/python'))
 
 from . import engine, handlers
 

--- a/src/hdusd/mx_nodes/__init__.py
+++ b/src/hdusd/mx_nodes/__init__.py
@@ -24,6 +24,7 @@ register_trees, unregister_trees = bpy.utils.register_classes_factory([
     node_tree.MxNodeTree,
 
     ui.HDUSD_MX_OP_import_file,
+    ui.HDUSD_MX_OP_create_node_type,
     ui.HDUSD_MX_MATERIAL_PT_import_export,
 ])
 

--- a/src/hdusd/mx_nodes/__init__.py
+++ b/src/hdusd/mx_nodes/__init__.py
@@ -24,7 +24,6 @@ register_trees, unregister_trees = bpy.utils.register_classes_factory([
     node_tree.MxNodeTree,
 
     ui.HDUSD_MX_OP_import_file,
-    ui.HDUSD_MX_OP_create_node_type,
     ui.HDUSD_MX_MATERIAL_PT_import_export,
 ])
 

--- a/src/hdusd/mx_nodes/__init__.py
+++ b/src/hdusd/mx_nodes/__init__.py
@@ -23,7 +23,7 @@ from . import node_tree, nodes, ui
 register_trees, unregister_trees = bpy.utils.register_classes_factory([
     node_tree.MxNodeTree,
 
-    ui.HDUSD_OP_MX_import_material,
+    ui.HDUSD_MX_OP_import_file,
     ui.HDUSD_MX_MATERIAL_PT_import_export,
 ])
 

--- a/src/hdusd/mx_nodes/__init__.py
+++ b/src/hdusd/mx_nodes/__init__.py
@@ -1,0 +1,36 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import bpy
+
+from ..utils import logging
+log = logging.Log("mx_nodes")
+
+from . import node_tree, nodes
+
+
+register_trees, unregister_trees = bpy.utils.register_classes_factory([
+    node_tree.MxNodeTree,
+    # node_tree.RenderTaskTree,
+])
+
+
+def register():
+    register_trees()
+    nodes.register()
+
+
+def unregister():
+    unregister_trees()
+    nodes.unregister()

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -1,0 +1,29 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import bpy
+
+
+class MxNodeTree(bpy.types.ShaderNodeTree):
+    """
+    MaterialX NodeTree
+    """
+    bl_label = "MaterialX"
+    bl_icon = "NODETREE"
+    bl_idname = "hdusd.MxNodeTree"
+    COMPAT_ENGINES = {'HdUSD'}
+
+    @classmethod
+    def poll(cls, context):
+        return context.engine in cls.COMPAT_ENGINES

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -20,7 +20,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
     MaterialX NodeTree
     """
     bl_label = "MaterialX"
-    bl_icon = "NODETREE"
+    bl_icon = "NODE_MATERIAL"
     bl_idname = "hdusd.MxNodeTree"
     COMPAT_ENGINES = {'HdUSD'}
 

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -38,8 +38,8 @@ class MxNodeCategory(NodeCategory):
 
 
 node_categories = [
-    MxNodeCategory('HdUSD_INPUT', "Input", items=[
-        NodeItem('usd.ReadBlendDataNode'),
+    MxNodeCategory('HdUSD_MX_INPUT', "Input", items=[
+        NodeItem('hdusd.MX_standard_surface'),
         NodeItem('usd.ReadUsdFileNode'),
     ]),
     # MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
@@ -54,17 +54,7 @@ node_categories = [
 ]
 
 # nodes to register
-register_nodes, unregister_nodes = bpy.utils.register_classes_factory([
-    # read_blend_data.ReadBlendDataNode,
-    # read_usd_file.ReadUsdFileNode,
-    # write_file.WriteFileNode,
-    # merge.MergeNode,
-    # print_file.PrintFileNode,
-    # filter.FilterNode,
-    # usd_to_blender.USDToBlenderNode,
-    # hydra_render.HydraRenderNode,
-    # rpr_render_settings.RprRenderSettingsNode,
-])
+register_nodes, unregister_nodes = bpy.utils.register_classes_factory(node_types)
 
 
 def register():

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -25,6 +25,12 @@ from .. import log
 # )
 
 
+from .base_node import create_node_types
+
+
+node_types = create_node_types()
+
+
 class MxNodeCategory(NodeCategory):
     @classmethod
     def poll(cls, context):
@@ -36,15 +42,15 @@ node_categories = [
         NodeItem('usd.ReadBlendDataNode'),
         NodeItem('usd.ReadUsdFileNode'),
     ]),
-    MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
-        NodeItem('usd.HydraRenderNode'),
-        NodeItem('usd.WriteFileNode'),
-        NodeItem('usd.PrintFileNode'),
-    ]),
-    MxNodeCategory('HdUSD_CONVERTER', 'Converter', items=[
-        NodeItem('usd.MergeNode'),
-        # NodeItem('usd.FilterNode'),
-    ]),
+    # MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
+    #     NodeItem('usd.HydraRenderNode'),
+    #     NodeItem('usd.WriteFileNode'),
+    #     NodeItem('usd.PrintFileNode'),
+    # ]),
+    # MxNodeCategory('HdUSD_CONVERTER', 'Converter', items=[
+    #     NodeItem('usd.MergeNode'),
+    #     # NodeItem('usd.FilterNode'),
+    # ]),
 ]
 
 # nodes to register

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -1,0 +1,71 @@
+# **********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import bpy
+import nodeitems_utils
+from nodeitems_utils import NodeCategory, NodeItem
+
+from .. import log
+
+# classes to register
+# from . import (
+#     read_usd_file, read_blend_data, write_file, merge, print_file, filter, usd_to_blender,
+#     hydra_render, rpr_render_settings
+# )
+
+
+class MxNodeCategory(NodeCategory):
+    @classmethod
+    def poll(cls, context):
+        return context.space_data.tree_type == 'hdusd.MxNodeTree'
+
+
+node_categories = [
+    MxNodeCategory('HdUSD_INPUT', "Input", items=[
+        NodeItem('usd.ReadBlendDataNode'),
+        NodeItem('usd.ReadUsdFileNode'),
+    ]),
+    MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
+        NodeItem('usd.HydraRenderNode'),
+        NodeItem('usd.WriteFileNode'),
+        NodeItem('usd.PrintFileNode'),
+    ]),
+    MxNodeCategory('HdUSD_CONVERTER', 'Converter', items=[
+        NodeItem('usd.MergeNode'),
+        # NodeItem('usd.FilterNode'),
+    ]),
+]
+
+# nodes to register
+register_nodes, unregister_nodes = bpy.utils.register_classes_factory([
+    # read_blend_data.ReadBlendDataNode,
+    # read_usd_file.ReadUsdFileNode,
+    # write_file.WriteFileNode,
+    # merge.MergeNode,
+    # print_file.PrintFileNode,
+    # filter.FilterNode,
+    # usd_to_blender.USDToBlenderNode,
+    # hydra_render.HydraRenderNode,
+    # rpr_render_settings.RprRenderSettingsNode,
+])
+
+
+def register():
+    register_nodes()
+    nodeitems_utils.register_node_categories("MX_NODES", node_categories)
+
+
+def unregister():
+    nodeitems_utils.unregister_node_categories("MX_NODES")
+    unregister_nodes()

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -16,19 +16,15 @@ import bpy
 import nodeitems_utils
 from nodeitems_utils import NodeCategory, NodeItem
 
+from ...utils import HDUSD_LIBS_DIR
 from .. import log
-
-# classes to register
-# from . import (
-#     read_usd_file, read_blend_data, write_file, merge, print_file, filter, usd_to_blender,
-#     hydra_render, rpr_render_settings
-# )
-
-
 from .base_node import create_node_types, MxNodeSocket
 
 
-node_types = create_node_types()
+node_types = create_node_types([
+    HDUSD_LIBS_DIR / "materialx/libraries/bxdf/standard_surface.mtlx",
+    # HDUSD_LIBS_DIR / "materialx/libraries/pbrlib/pbrlib_defs.mtlx",
+])
 
 
 class MxNodeCategory(NodeCategory):
@@ -41,15 +37,6 @@ node_categories = [
     MxNodeCategory('HdUSD_MX_SHADERS', "Shaders", items=[
         NodeItem(node_type.bl_idname) for node_type in node_types
     ]),
-    # MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
-    #     NodeItem('usd.HydraRenderNode'),
-    #     NodeItem('usd.WriteFileNode'),
-    #     NodeItem('usd.PrintFileNode'),
-    # ]),
-    # MxNodeCategory('HdUSD_CONVERTER', 'Converter', items=[
-    #     NodeItem('usd.MergeNode'),
-    #     # NodeItem('usd.FilterNode'),
-    # ]),
 ]
 
 # nodes to register

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -25,7 +25,7 @@ from .. import log
 # )
 
 
-from .base_node import create_node_types
+from .base_node import create_node_types, MxNodeSocket
 
 
 node_types = create_node_types()
@@ -38,9 +38,8 @@ class MxNodeCategory(NodeCategory):
 
 
 node_categories = [
-    MxNodeCategory('HdUSD_MX_INPUT', "Input", items=[
-        NodeItem('hdusd.MX_standard_surface'),
-        NodeItem('usd.ReadUsdFileNode'),
+    MxNodeCategory('HdUSD_MX_SHADERS', "Shaders", items=[
+        NodeItem(node_type.bl_idname) for node_type in node_types
     ]),
     # MxNodeCategory('HdUSD_OUTPUT', 'Output', items=[
     #     NodeItem('usd.HydraRenderNode'),
@@ -55,9 +54,13 @@ node_categories = [
 
 # nodes to register
 register_nodes, unregister_nodes = bpy.utils.register_classes_factory(node_types)
+register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
+    MxNodeSocket,
+])
 
 
 def register():
+    register_sockets()
     register_nodes()
     nodeitems_utils.register_node_categories("MX_NODES", node_categories)
 
@@ -65,3 +68,4 @@ def register():
 def unregister():
     nodeitems_utils.unregister_node_categories("MX_NODES")
     unregister_nodes()
+    unregister_sockets()

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -17,7 +17,6 @@ import MaterialX as mx
 import bpy
 
 from . import log
-from ...utils import HDUSD_LIBS_DIR
 
 
 def prettify_string(str):
@@ -169,14 +168,10 @@ def get_param(mx_param):
 
 
 def create_node_type(mx_nodedef):
-    ''' Create Subtype MxNode for this node def
-        The parameters and inputs of the node def are saved as Blender properties
-    '''
-    data = {
-        'bl_label': prettify_string(mx_nodedef.getNodeString()),
-        'bl_idname': "hdusd.MX_" + mx_nodedef.getNodeString(),
-        'mx_nodedef': mx_nodedef
-    }
+    """
+    Create Subtype MxNode for this node def
+    The parameters and inputs of the node def are saved as Blender properties
+    """
 
     # properties are stored as annotations on the custom type
     annotations = {}
@@ -187,28 +182,23 @@ def create_node_type(mx_nodedef):
         if created_property is not None:
             annotations[mx_input.getName()] = created_property
 
-    if len(annotations):
-        data['__annotations__'] = annotations
+    data = {
+        'bl_label': prettify_string(mx_nodedef.getNodeString()),
+        'bl_idname': "hdusd.MX_" + mx_nodedef.getNodeString(),
+        'mx_nodedef': mx_nodedef,
+        '__annotations__': annotations
+    }
 
     node_type = type('MX_' + mx_nodedef.getNodeString(), (MxNode,), data)
     return node_type
 
 
-def create_node_types():
-    mx_lib_path =  HDUSD_LIBS_DIR / "materialx/libraries"
-    file_paths = [
-        mx_lib_path / "bxdf/standard_surface.mtlx",
-        # mx_lib_path / "pbrlib/pbrlib_defs.mtlx",
-    ]
-
+def create_node_types(file_paths):
     node_types = []
     for p in file_paths:
         doc = mx.createDocument()
         mx.readFromXmlFile(doc, str(p))
         mx_node_defs = doc.getNodeDefs()
-        if not mx_node_defs:
-            continue
-
         for mx_node_def in mx_node_defs:
             node_type = create_node_type(mx_node_def)
             node_types.append(node_type)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -1,0 +1,170 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import MaterialX as mx
+
+import bpy
+
+
+def prettify_string(str):
+    return str.replace('_', ' ').title()
+
+
+class MxNode(bpy.types.ShaderNode):
+    """Base node from which all MaterialX nodes will be made"""
+    bl_compatibility = {'HdUSD'}
+    bl_icon = 'MATERIAL'
+    bl_label = 'mx'
+
+    # holds the materialx nodedef object
+    mx_nodedef: mx.NodeDef
+
+    def init(self, context):
+        ''' generates inputs and outputs from ones specified '''
+        for mx_input in self.mx_nodedef.getInputs():
+            name = mx_input.getName()
+            input = self.inputs.new(name=prettify_string(name), type='mx.NodeSocket')
+            if hasattr(self, name.lower()):
+                input.property_name = name.lower()
+
+        for output in self.mx_nodedef.getOutputs():
+            name = output.getName()
+            self.outputs.new(name=prettify_string(name), type='mx.NodeSocket')
+
+    def draw_buttons(self, context, layout):
+        for mx_param in self.mx_nodedef.getParameters():
+            layout.prop(self, mx_param.getName())
+
+    @classmethod
+    def poll(cls, ntree):
+        if hasattr(ntree, 'bl_idname'):
+            return ntree.bl_idname == 'mx.NodeTree'
+        else:
+            return True
+
+    @staticmethod
+    def import_from_mx(nt, mx_node: mx.Node):
+        ''' creates a node from a Mx node spec
+            sets the params and inputs based on spec '''
+
+        try:
+            node_type = 'mx.' + mx_node.getCategory()
+            blender_node = nt.nodes.new(node_type)
+            blender_node.label = mx_node.getName()
+            # get params from
+            return blender_node
+        except:
+            # TODO custom nodedefs in file
+            return None
+
+
+def parse_value(mx_type, val_str, only_first=False):
+    val = None
+    if mx_type == 'float':
+        val = float(val_str)
+    elif mx_type.startswith('color') or mx_type.startswith('vector') and 'array' not in mx_type:
+        val = [float(x) for x in val_str.split(',')]
+    elif mx_type == 'string':
+        val = val_str
+    elif mx_type == 'integer':
+        val = int(val_str)
+    elif mx_type == 'filename':
+        val = val_str
+    elif mx_type == 'boolean':
+        val = val_str.lower() == 'true'
+
+    if only_first and isinstance(val, list):
+        val = val[0]
+
+    return val
+
+
+def get_param(mx_param):
+    ''' convert a mx param into a blender property '''
+    mx_param_type = mx_param.getType()
+    name = mx_param.getName()
+    prop_attrs = {
+        'name': prettify_string(name)
+    }
+
+    # handle ui attrs:
+    if mx_param.hasValueString():
+        prop_attrs['default'] = parse_value(mx_param_type, mx_param.getValueString())
+    if mx_param.hasAttribute('uimin'):
+        prop_attrs['min'] = parse_value(mx_param_type, mx_param.getAttribute('uimin'),
+                                        only_first=True)
+    if mx_param.hasAttribute('uimax'):
+        prop_attrs['max'] = parse_value(mx_param_type, mx_param.getAttribute('uimax'),
+                                        only_first=True)
+    if mx_param.hasAttribute('uisoftmin'):
+        prop_attrs['soft_min'] = parse_value(mx_param_type, mx_param.getAttribute('uisoftmin'),
+                                             only_first=True)
+    if mx_param.hasAttribute('uisoftmax'):
+        prop_attrs['soft_max'] = parse_value(mx_param_type, mx_param.getAttribute('uisoftmax'),
+                                             only_first=True)
+
+    if mx_param_type == 'float':
+        return bpy.props.FloatProperty, prop_attrs
+
+    elif mx_param_type.startswith('color'):
+        prop_attrs['size'] = int(mx_param_type[-1])
+        prop_attrs['subtype'] = 'COLOR'
+        return bpy.props.FloatVectorProperty, prop_attrs
+
+    elif mx_param_type == 'string':
+        return bpy.props.StringProperty, prop_attrs
+
+    elif mx_param_type == 'integer':
+        return bpy.props.IntProperty, prop_attrs
+
+    elif mx_param_type == 'filename':
+        prop_attrs['subtype'] = 'FILE_NAME'
+        return bpy.props.StringProperty, prop_attrs
+
+    elif mx_param_type == 'boolean':
+        return bpy.props.BoolProperty, prop_attrs
+
+    elif mx_param_type.startswith('vector') and 'array' not in mx_param_type:
+        prop_attrs['size'] = int(mx_param_type[-1])
+        prop_attrs['subtype'] = 'XYZ'
+        return bpy.props.FloatVectorProperty, prop_attrs
+
+    else:
+        raise TypeError('unknown type', mx_param_type)
+
+
+def create_node_type(mx_nodedef):
+    ''' Create Subtype MxNode for this node def
+        The parameters and inputs of the node def are saved as Blender properties
+    '''
+    data = {
+        'bl_label': prettify_string(mx_nodedef.getNodeString()),
+        'bl_idname': "hdusd.mx_" + mx_nodedef.getNodeString(),
+        'mx_nodedef': mx_nodedef
+    }
+
+    # properties are stored as annotations on the custom type
+    annotations = {}
+    for mx_param in mx_nodedef.getParameters():
+        annotations[mx_param.getName()] = get_param(mx_param)
+    for mx_input in mx_nodedef.getInputs():
+        created_property = get_param(mx_input)
+        if created_property is not None:
+            annotations[mx_input.getName()] = created_property
+
+    if len(annotations):
+        data['__annotations__'] = annotations
+
+    node_type = type(mx_nodedef.getNodeString(), (MxNode,), data)
+    return node_type

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -16,6 +16,9 @@ import MaterialX as mx
 
 import bpy
 
+from . import log
+from ...utils import HDUSD_LIBS_DIR
+
 
 def prettify_string(str):
     return str.replace('_', ' ').title()
@@ -141,7 +144,7 @@ def get_param(mx_param):
         return bpy.props.FloatVectorProperty, prop_attrs
 
     else:
-        raise TypeError('unknown type', mx_param_type)
+        log.error('Unknown type', mx_param_type)
 
 
 def create_node_type(mx_nodedef):
@@ -168,3 +171,25 @@ def create_node_type(mx_nodedef):
 
     node_type = type(mx_nodedef.getNodeString(), (MxNode,), data)
     return node_type
+
+
+def create_node_types():
+    mx_lib_path =  HDUSD_LIBS_DIR / "materialx/libraries"
+    file_paths = [
+        mx_lib_path / "bxdf/standard_surface.mtlx",
+        mx_lib_path / "pbrlib/pbrlib_defs.mtlx",
+    ]
+
+    node_types = []
+    for p in file_paths:
+        doc = mx.createDocument()
+        mx.readFromXmlFile(doc, str(p))
+        mx_node_defs = doc.getNodeDefs()
+        if not mx_node_defs:
+            continue
+
+        for mx_node_def in mx_node_defs:
+            node_type = create_node_type(mx_node_def)
+            node_types.append(node_type)
+
+    return node_types

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -153,7 +153,7 @@ def create_node_type(mx_nodedef):
     '''
     data = {
         'bl_label': prettify_string(mx_nodedef.getNodeString()),
-        'bl_idname': "hdusd.mx_" + mx_nodedef.getNodeString(),
+        'bl_idname': "hdusd.MX_" + mx_nodedef.getNodeString(),
         'mx_nodedef': mx_nodedef
     }
 
@@ -169,7 +169,7 @@ def create_node_type(mx_nodedef):
     if len(annotations):
         data['__annotations__'] = annotations
 
-    node_type = type(mx_nodedef.getNodeString(), (MxNode,), data)
+    node_type = type('MX_' + mx_nodedef.getNodeString(), (MxNode,), data)
     return node_type
 
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -57,7 +57,8 @@ class MxNode(bpy.types.ShaderNode):
     mx_nodedef: mx.NodeDef
 
     def init(self, context):
-        ''' generates inputs and outputs from ones specified '''
+        """generates inputs and outputs from ones specified in the mx_nodedef"""
+        
         for mx_input in self.mx_nodedef.getInputs():
             name = mx_input.getName()
             input = self.inputs.new(name=prettify_string(name), type='hdusd.MxNodeSocket')

--- a/src/hdusd/mx_nodes/ui.py
+++ b/src/hdusd/mx_nodes/ui.py
@@ -14,25 +14,28 @@
 #********************************************************************
 import bpy
 
-from ..utils import logging
-log = logging.Log("mx_nodes")
-
-from . import node_tree, nodes, ui
+from ..ui import HdUSD_Panel
+from .node_tree import MxNodeTree
 
 
-register_trees, unregister_trees = bpy.utils.register_classes_factory([
-    node_tree.MxNodeTree,
+class HDUSD_OP_MX_import_material(bpy.types.Operator):
+    """Expand USD item"""
+    bl_idname = "hdusd.mx_import_material"
+    bl_label = "Import Material"
 
-    ui.HDUSD_OP_MX_import_material,
-    ui.HDUSD_MX_MATERIAL_PT_import_export,
-])
-
-
-def register():
-    register_trees()
-    nodes.register()
+    def execute(self, context):
+        return {'FINISHED'}
 
 
-def unregister():
-    unregister_trees()
-    nodes.unregister()
+class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
+    bl_label = "MaterialX Import/Export"
+    bl_space_type = "NODE_EDITOR"
+    bl_region_type = "UI"
+    bl_category = "Tool"
+
+    @classmethod
+    def poll(cls, context):
+        return isinstance(bpy.context.space_data.edit_tree, MxNodeTree)
+
+    def draw(self, context):
+        self.layout.operator('hdusd.mx_import_material')

--- a/src/hdusd/mx_nodes/ui.py
+++ b/src/hdusd/mx_nodes/ui.py
@@ -43,32 +43,34 @@ class HDUSD_MX_OP_import_file(bpy.types.Operator):
         doc = mx.createDocument()
         try:
             mx.readFromXmlFile(doc, self.filepath)
+
         except mx.ExceptionFileMissing as err:
             log.error(err, self.filepath)
             return {'CANCELLED'}
+
         except mx.ExceptionParseError as err:
-            log.error("Invalid valid MaterialX XML file", self.filepath, err)
+            log.error("Invalid MaterialX XML file", self.filepath, err)
             return {'CANCELLED'}
 
         # # create sub node graphs
         # for sub_ng in doc.getNodeGraphs():
         #     create_node_graph(doc, sub_ng)
 
-        """ for mat in materials:
-            # material in materialx takes the first node as the shader
-            print("creating mat", mat.getName())
+        # for mat in materials:
+        #     # material in materialx takes the first node as the shader
+        #     print("creating mat", mat.getName())
+        #
+        #     # create material nodetree
+        #     nt = bpy.data.node_groups.new(mat.getName(), 'mx.NodeTree')
+        #     mat_node = nt.nodes.new("mx.surfacematerial")
+        #
+        #     # surface
+        #     for i, s_ref in enumerate(mat.getShaderRefs()):
+        #         created_item = create_item_from_shaderref(doc, s_ref, nt)
+        #         if created_item:
+        #             # TODO should be smarter about hooking up types
+        #             nt.links.new(mat_node.inputs[i], created_item.outputs[0])
 
-            # create material nodetree
-            nt = bpy.data.node_groups.new(mat.getName(), 'mx.NodeTree')
-            mat_node = nt.nodes.new("mx.surfacematerial")
-
-            # surface
-            for i, s_ref in enumerate(mat.getShaderRefs()):
-                created_item = create_item_from_shaderref(doc, s_ref, nt)
-                if created_item:
-                    # TODO should be smarter about hooking up types
-                    nt.links.new(mat_node.inputs[i], created_item.outputs[0])
-         """
         return {"FINISHED"}
 
 
@@ -78,12 +80,7 @@ class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
     bl_region_type = "UI"
     bl_category = "Tool"
 
-    @classmethod
-    def poll(cls, context):
-        return isinstance(bpy.context.space_data.edit_tree, MxNodeTree)
-
     def draw(self, context):
         layout = self.layout
 
         op = layout.operator('hdusd.mx_import_file')
-

--- a/src/hdusd/mx_nodes/ui.py
+++ b/src/hdusd/mx_nodes/ui.py
@@ -74,50 +74,6 @@ class HDUSD_MX_OP_import_file(bpy.types.Operator):
         return {"FINISHED"}
 
 
-class HDUSD_MX_OP_create_node_type(bpy.types.Operator):
-    bl_idname = "hdusd.mx_create_node_type"
-    bl_label = "Create NodeType"
-    bl_description = "Import selected mtlx file"
-
-    filepath: bpy.props.StringProperty(subtype="FILE_PATH")
-    filename_ext = ".mtlx"
-    filter_glob: bpy.props.StringProperty(default="*.mtlx", options={'HIDDEN'}, )
-
-    @classmethod
-    def poll(cls, context):
-        return isinstance(bpy.context.space_data.edit_tree, MxNodeTree)
-
-    def invoke(self, context, event):
-        context.window_manager.fileselect_add(self)
-        return {'RUNNING_MODAL'}
-
-    # Perform the operator action.
-    def execute(self, context):
-        doc = mx.createDocument()
-        try:
-            mx.readFromXmlFile(doc, self.filepath)
-
-        except mx.ExceptionFileMissing as err:
-            log.error(err, self.filepath)
-            return {'CANCELLED'}
-
-        except mx.ExceptionParseError as err:
-            log.error("Invalid MaterialX XML file", self.filepath, err)
-            return {'CANCELLED'}
-
-        from .nodes.base_node import create_node_type
-        nodedefs = doc.getNodeDefs()
-        if not nodedefs:
-            log.warn("No nodedefs in", self.filepath)
-            return {'CANCELLED'}
-
-        nodetype = create_node_type(nodedefs[0])
-        bpy.utils.register_class(nodetype)
-        print(nodetype)
-
-        return {"FINISHED"}
-
-
 class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
     bl_label = "MaterialX Import/Export"
     bl_space_type = "NODE_EDITOR"
@@ -128,4 +84,3 @@ class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
         layout = self.layout
 
         op = layout.operator('hdusd.mx_import_file')
-        op = layout.operator('hdusd.mx_create_node_type')

--- a/src/hdusd/usd_nodes/nodes/__init__.py
+++ b/src/hdusd/usd_nodes/nodes/__init__.py
@@ -31,16 +31,16 @@ class USDNodeCategory(NodeCategory):
 
 
 node_categories = [
-    USDNodeCategory('HdUSD_INPUT', "Input", items=[
+    USDNodeCategory('HdUSD_USD_INPUT', "Input", items=[
         NodeItem('usd.ReadBlendDataNode'),
         NodeItem('usd.ReadUsdFileNode'),
     ]),
-    USDNodeCategory('HdUSD_OUTPUT', 'Output', items=[
+    USDNodeCategory('HdUSD_USD_OUTPUT', 'Output', items=[
         NodeItem('usd.HydraRenderNode'),
         NodeItem('usd.WriteFileNode'),
         NodeItem('usd.PrintFileNode'),
     ]),
-    USDNodeCategory('HdUSD_CONVERTER', 'Converter', items=[
+    USDNodeCategory('HdUSD_USD_CONVERTER', 'Converter', items=[
         NodeItem('usd.MergeNode'),
         # NodeItem('usd.FilterNode'),
     ]),

--- a/src/hdusd/usd_nodes/nodes/base_node.py
+++ b/src/hdusd/usd_nodes/nodes/base_node.py
@@ -18,10 +18,6 @@ from pxr import Usd
 from . import log
 
 
-class USDError(BaseException):
-    pass
-
-
 class USDNode(bpy.types.Node):
     """Base class for parsing USD nodes"""
 

--- a/src/hdusd/usd_nodes/nodes/base_node.py
+++ b/src/hdusd/usd_nodes/nodes/base_node.py
@@ -22,14 +22,13 @@ class USDNode(bpy.types.Node):
     """Base class for parsing USD nodes"""
 
     bl_compatibility = {'HdUSD'}
-    tree_idname = 'hdusd.USDTree'
 
     input_names = ("Input",)
     output_name = "Output"
 
     @classmethod
-    def poll(cls, tree: bpy.types.NodeTree):
-        return tree.bl_idname == cls.tree_idname
+    def poll(cls, tree):
+        return tree.bl_idname == 'hdusd.USDTree'
 
     def init(self, context):
         for name in self.input_names:
@@ -115,8 +114,3 @@ class USDNode(bpy.types.Node):
 
     def free(self):
         self.cached_stage.clear()
-
-
-class RenderTaskNode(USDNode):
-    """Base class for all hydra render task nodes"""
-    tree_idname = 'hdusd.RenderTaskTree'

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -17,7 +17,6 @@ import tempfile
 import os
 import shutil
 import platform
-import sys
 import numpy as np
 import math
 


### PR DESCRIPTION
### PURPOSE
Add support to create MaterialX network and nodes with generated node types. 

### EFFECT OF CHANGE
Added new MaterialX node tree. Available to create Standard Surface shader. 

### TECHNICAL STEPS
1. Added copying MaterialX libs and supported files in create_hdusd_libs.py script.
2. Added MaterialX nodetree as MxNodeTree class.
3. Implemented MaterialX node as MxNode from mx.NodeDef structure.
4. Added creation of Standard Surface shader from standard_surface.mtlx.
5. Made some code cleanup.

### NOTES FOR REVIEWERS
This is an intermediate PR, new MaterialX node tree network isn't functional. Other nodes and its functionality, material assigning etc propose to create in next tasks.