### PR TITLE
PRBLND-1612: Improve UI for assigning MaterialX to mesh

### DIFF
--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -207,6 +207,8 @@ def sync_mx(materials_prim, mx_node_tree, input_socket_key='Surface', *,
 
     mx_file = utils.get_temp_file(".mtlx")
     mx.writeToXmlFile(doc, str(mx_file))
+    surfacematerial = next(node for node in doc.getNodes()
+                           if node.getNodeName() == 'surfacematerial')
 
     stage = materials_prim.GetStage()
     mat_path = f"{materials_prim.GetPath()}/{sdf_name(mx_node_tree)}"
@@ -215,7 +217,6 @@ def sync_mx(materials_prim, mx_node_tree, input_socket_key='Surface', *,
     shader.CreateIdAttr("rpr_materialx_node")
 
     shader.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(f"./{mx_file.name}")
-    surfacematerial = doc.getNodes()[-1]    # surfacematerial is the last node
     shader.CreateInput("surfaceElement", Sdf.ValueTypeNames.String).Set(surfacematerial.getName())
 
     out = usd_mat.CreateSurfaceOutput("rpr")

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -42,43 +42,43 @@ def get_material_output_node(material):
                 None)
 
 
-def get_material_input_node(material, input_socket_key: str):
+def get_material_input_node(mat):
     """ Find the material node attached to output node 'input_socket_key' input """
-    output_node = get_material_output_node(material)
+    output_node = get_material_output_node(mat)
     if not output_node:
         return None
 
-    socket_in = output_node.inputs[input_socket_key]
+    socket_in = output_node.inputs['Surface']
     if not socket_in.is_linked or not socket_in.links[0].is_valid:
         return None
 
     return socket_in.links[0].from_node
 
 
-def sync(materials_prim, mat: bpy.types.Material, input_socket_key='Surface', *,
-         obj: bpy.types.Object = None):
+def sync(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
     """
     If material exists: returns existing material unless force_update is used
     In other cases: returns None
     """
 
-    log(f"sync {mat} '{input_socket_key}'; obj {obj}")
+    log("sync", mat, obj)
+
+    if mat.hdusd.mx_node_tree:
+        return sync_mx(materials_prim, mat.hdusd.mx_node_tree, obj)
 
     output_node = get_material_output_node(mat)
     if not output_node:
         log("No output node", mat)
         return None
 
-    node = get_material_input_node(mat, input_socket_key)
+    node = get_material_input_node(mat)
     if not node:
         return None
 
-    # TODO store refs to existing materials for reuse
     stage = materials_prim.GetStage()
     mat_path = f"{materials_prim.GetPath()}/{sdf_name(mat)}"
     usd_mat = UsdShade.Material.Define(stage, mat_path)
 
-    # TODO use MaterialX for material
     # create appropriate USD shader
     if node.bl_idname == 'ShaderNodeBsdfPrincipled':
         create_principled_shader(usd_mat, node)
@@ -87,31 +87,23 @@ def sync(materials_prim, mat: bpy.types.Material, input_socket_key='Surface', *,
     elif node.bl_idname == 'ShaderNodeBsdfDiffuse':  # used by Material Preview
         create_diffuse_shader(usd_mat, node)
     else:
-        log.info(f"unsupported node {node.bl_idname} of material {mat.name_full}")
-
-    # TODO export volumetric and displacement
+        log.warn("Unsupported node", node, mat)
 
     return usd_mat
 
 
-# TODO move parsing to shader nodes parser
 def get_input_default(node, socket_key):
-    def _parse_val(val):
-        """ Turn a blender node val or default value for input into something that works well with USD """
+    val = node.inputs[socket_key].default_value
+    if isinstance(val, (int, float)):
+        return float(val)
 
-        if isinstance(val, (int, float)):
-            return float(val)
+    if len(val) in (3, 4):
+        return tuple(val[:3])
 
-        if len(val) in (3, 4):
-            return tuple(val[:3])
+    if isinstance(val, str):
+        return val
 
-        if isinstance(val, str):
-            return val
-
-        raise TypeError("Unknown value type to pass to rpr", val)
-
-    socket_in = node.inputs[socket_key]
-    return _parse_val(socket_in.default_value)
+    raise TypeError("Unknown value type", val)
 
 
 def create_principled_shader(usd_mat, node):
@@ -160,7 +152,7 @@ def create_emission_shader(usd_mat, node):
     usd_mat.CreateSurfaceOutput().ConnectToSource(pbr_shader, "surface")
 
 
-def sync_update(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object = None):
+def sync_update(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
     """ Recreates existing material """
 
     log("sync_update", mat)
@@ -171,34 +163,11 @@ def sync_update(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object =
     if usd_mat.IsValid():
         stage.RemovePrim(mat_path)
 
-    sync(materials_prim, mat, obj=obj)
-
-    # TODO update displacement
-    # TODO update volume
+    sync(materials_prim, mat, obj)
 
 
-def create_materialx_shader(usd_mat):
-    import shutil
-    from .. import utils
-
-    stage = usd_mat.GetPrim().GetStage()
-    shader_key = f"{usd_mat.GetPath()}/rpr_materialx_node"
-
-    shader = UsdShade.Shader.Define(stage, shader_key)
-    shader.CreateIdAttr("rpr_materialx_node")
-
-    shutil.copyfile("standard_surface_carpaint.mtlx", str(utils.temp_pid_dir() / "standard_surface_carpaint.mtlx"))
-
-    shader.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(r"./standard_surface_carpaint.mtlx")
-    shader.CreateInput("surfaceElement", Sdf.ValueTypeNames.String).Set("Car_Paint")
-    
-    out = usd_mat.CreateSurfaceOutput("rpr")
-    out.ConnectToSource(shader, "surface")
-
-
-def sync_mx(materials_prim, mx_node_tree, input_socket_key='Surface', *,
-            obj: bpy.types.Object = None):
-    log(f"sync_mx {mx_node_tree} '{input_socket_key}'; obj {obj}")
+def sync_mx(materials_prim, mx_node_tree, obj):
+    log("sync_mx", mx_node_tree, obj)
 
     doc = mx_node_tree.export()
     if not doc:

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -208,7 +208,7 @@ def sync_mx(materials_prim, mx_node_tree, input_socket_key='Surface', *,
     mx_file = utils.get_temp_file(".mtlx")
     mx.writeToXmlFile(doc, str(mx_file))
     surfacematerial = next(node for node in doc.getNodes()
-                           if node.getNodeName() == 'surfacematerial')
+                           if node.getNamePath() == 'surfacematerial')
 
     stage = materials_prim.GetStage()
     mat_path = f"{materials_prim.GetPath()}/{sdf_name(mx_node_tree)}"

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -20,7 +20,7 @@ import MaterialX as mx
 from . import sdf_path
 from .. import utils
 from ..utils import logging
-log = logging.Log(tag='export.Material')
+log = logging.Log(tag='export.material')
 
 
 def sdf_name(mat: bpy.types.Material, input_socket_key='Surface'):

--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -227,11 +227,8 @@ def sync(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **kwargs)
 
 def _assign_materials(obj_prim, obj, usd_mesh):
     usd_mat = None
-    if obj.hdusd.material_x:
-        usd_mat = material.sync_mx(obj_prim, obj.hdusd.material_x, obj=obj)
-
-    elif obj.material_slots and obj.material_slots[0].material:
-        usd_mat = material.sync(obj_prim, obj.material_slots[0].material, obj=obj)
+    if obj.material_slots and obj.material_slots[0].material:
+        usd_mat = material.sync(obj_prim, obj.material_slots[0].material, obj)
 
     if usd_mat:
         UsdShade.MaterialBindingAPI(usd_mesh).Bind(usd_mat)

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -35,7 +35,13 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
     @property
     def output_node(self):
-        return next((node for node in self.nodes if isinstance(node, MxNode_Output)), None)
+        return next((node for node in self.nodes
+                     if node.bl_idname == 'hdusd.MxNode_ND_surfacematerial'), None)
+
+    @property
+    def output_node_volume(self):
+        return next((node for node in self.nodes
+                     if node.bl_idname == 'hdusd.MxNode_ND_volumematerial'), None)
 
     def export(self) -> mx.Document:
         output_node = self.output_node

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -51,14 +51,8 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         doc = mx.createDocument()
         doc.setVersionString("1.38")
 
-        surface = output_node.compute(None, doc=doc)
-        if not surface:
+        surfacematerial = output_node.compute('Out', doc=doc)
+        if not surfacematerial:
             return None
-
-        mat_name = utils.code_str(self.name)
-
-        surfacematerial = doc.addNode('surfacematerial', mat_name, 'material')
-        input = surfacematerial.addInput('surfaceshader', surface.getType())
-        input.setNodeName(surface.getName())
 
         return doc

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -33,12 +33,12 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
     @property
     def output_node(self):
         return next((node for node in self.nodes
-                     if node.bl_idname == 'hdusd.MxNode_ND_surfacematerial'), None)
+                     if node.bl_idname == 'hdusd.MxNode_surfacematerial'), None)
 
     @property
     def output_node_volume(self):
         return next((node for node in self.nodes
-                     if node.bl_idname == 'hdusd.MxNode_ND_volumematerial'), None)
+                     if node.bl_idname == 'hdusd.MxNode_volumematerial'), None)
 
     def export(self) -> mx.Document:
         output_node = self.output_node
@@ -53,3 +53,25 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
             return None
 
         return doc
+
+    def create_basic_nodes(self, node_name='standard_surface'):
+        """ Reset basic node tree structure using scene or USD file as an input """
+        self.nodes.clear()
+        SEP_WIDTH = 70
+
+        mat_node = self.nodes.new('hdusd.MxNode_surfacematerial')
+        if node_name == 'standard_surface':
+            node = self.nodes.new('hdusd.MxNode_standard_surface')
+            node.location = (mat_node.location[0] - node.width - SEP_WIDTH,
+                             mat_node.location[1])
+            self.links.new(node.outputs[0], mat_node.inputs[0])
+        else:
+            surface_node = self.nodes.new('hdusd.MxNode_surface')
+            surface_node.location = (mat_node.location[0] - surface_node.width - SEP_WIDTH,
+                                     mat_node.location[1])
+            self.links.new(surface_node.outputs[0], mat_node.inputs[0])
+
+            node = self.nodes.new('hdusd.MxNode_' + node_name)
+            node.location = (surface_node.location[0] - node.width - SEP_WIDTH,
+                             surface_node.location[1])
+            self.links.new(node.outputs[0], surface_node.inputs[0])

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -16,9 +16,6 @@ import bpy
 
 import MaterialX as mx
 
-from .. import utils
-from .nodes.base_node import MxNode_Output
-
 
 class MxNodeTree(bpy.types.ShaderNodeTree):
     """
@@ -51,7 +48,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         doc = mx.createDocument()
         doc.setVersionString("1.38")
 
-        surfacematerial = output_node.compute('Out', doc=doc)
+        surfacematerial = output_node.compute(0, doc=doc)
         if not surfacematerial:
             return None
 

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -20,7 +20,7 @@ from .. import log
 from . import base_node, categories
 
 
-nodedef_types, node_types = base_node.create_node_types([
+NodeDef_classes, MxNode_classes = base_node.create_node_types([
     HDUSD_LIBS_DIR / "materialx/libraries/bxdf/standard_surface.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/stdlib/stdlib_defs.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/pbrlib/pbrlib_defs.mtlx",
@@ -31,11 +31,8 @@ register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
     base_node.MxNodeInputSocket,
     base_node.MxNodeOutputSocket,
 ])
-register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(nodedef_types)
-register_nodes, unregister_nodes = bpy.utils.register_classes_factory([
-    *node_types,
-    base_node.MxNode_Output
-])
+register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(NodeDef_classes)
+register_nodes, unregister_nodes = bpy.utils.register_classes_factory(MxNode_classes)
 
 
 def register():

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -17,11 +17,10 @@ import nodeitems_utils
 
 from ...utils import HDUSD_LIBS_DIR
 from .. import log
-from .base_node import create_node_types, MxNodeSocket, MxNode_Output
-from . import categories
+from . import base_node, categories
 
 
-nodedef_types, node_types = create_node_types([
+nodedef_types, node_types = base_node.create_node_types([
     HDUSD_LIBS_DIR / "materialx/libraries/bxdf/standard_surface.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/stdlib/stdlib_defs.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/pbrlib/pbrlib_defs.mtlx",
@@ -29,12 +28,13 @@ nodedef_types, node_types = create_node_types([
 
 
 register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
-    MxNodeSocket,
+    base_node.MxNodeInputSocket,
+    base_node.MxNodeOutputSocket,
 ])
 register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(nodedef_types)
 register_nodes, unregister_nodes = bpy.utils.register_classes_factory([
     *node_types,
-    MxNode_Output
+    base_node.MxNode_Output
 ])
 
 

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -20,7 +20,7 @@ from .. import log
 from . import base_node, categories
 
 
-NodeDef_classes, MxNode_classes = base_node.create_node_types([
+node_def_classes, mx_node_classes = base_node.create_node_types([
     HDUSD_LIBS_DIR / "materialx/libraries/bxdf/standard_surface.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/stdlib/stdlib_defs.mtlx",
     HDUSD_LIBS_DIR / "materialx/libraries/pbrlib/pbrlib_defs.mtlx",
@@ -31,8 +31,8 @@ register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
     base_node.MxNodeInputSocket,
     base_node.MxNodeOutputSocket,
 ])
-register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(NodeDef_classes)
-register_nodes, unregister_nodes = bpy.utils.register_classes_factory(MxNode_classes)
+register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(node_def_classes)
+register_nodes, unregister_nodes = bpy.utils.register_classes_factory(mx_node_classes)
 
 
 def register():

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -33,15 +33,42 @@ from ...utils import title_str, code_str
 from . import log
 
 
-class MxNodeSocket(bpy.types.NodeSocket):
-    bl_idname = 'hdusd.MxNodeSocket'
-    bl_label = "MaterialX Node Socket"
+class MxNodeInputSocket(bpy.types.NodeSocket):
+    bl_idname = 'hdusd.MxNodeInputSocket'
+    bl_label = "MX Input Socket"
 
     # TODO different type for draw color
     # socket_type: bpy.props.EnumProperty()
 
     # corresponding property name (if any) on node
     node_prop_name: bpy.props.StringProperty(default='')
+    mx_input: mx.Input
+
+    def draw(self, context, layout, node, text):
+        # if not linked, we get custom property from the node
+        # rather than use the default val like blender sockets
+        # this allows custom property UI
+
+        if self.is_linked or self.name.endswith("shader"):
+            layout.label(text=self.name)
+        else:
+            layout.prop(node.prop, self.node_prop_name)
+
+    def draw_color(self, context, node):
+        # TODO get from type
+        return (0.78, 0.78, 0.16, 1.0)
+
+
+class MxNodeOutputSocket(bpy.types.NodeSocket):
+    bl_idname = 'hdusd.MxNodeOutputSocket'
+    bl_label = "MX Output Socket"
+
+    # TODO different type for draw color
+    # socket_type: bpy.props.EnumProperty()
+
+    # corresponding property name (if any) on node
+    node_prop_name: bpy.props.StringProperty(default='')
+    mx_output: mx.Output
 
     def draw(self, context, layout, node, text):
         # if not linked, we get custom property from the node
@@ -390,7 +417,7 @@ class MxNode(bpy.types.ShaderNode):
         return prop_name, prop_type, prop_attrs
 
     def create_input(self, mx_input):
-        input = self.inputs.new('hdusd.MxNodeSocket',
+        input = self.inputs.new(MxNodeInputSocket.bl_idname,
                                 mx_input.getAttribute('uiname') if mx_input.hasAttribute('uiname')
                                 else title_str(mx_input.getName()))
         input.node_prop_name = self._input_prop(mx_input.getName())

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -262,15 +262,15 @@ class MxNode(bpy.types.ShaderNode):
         return tree.bl_idname == 'hdusd.MxNodeTree'
 
     @staticmethod
-    def new(NodeDef_classes):
-        mx_nodedefs = tuple(NodeDef_cls.mx_nodedef for NodeDef_cls in NodeDef_classes)
+    def new(node_def_classes):
+        mx_nodedefs = tuple(NodeDef_cls.mx_nodedef for NodeDef_cls in node_def_classes)
         nd = mx_nodedefs[0]
         node_name = nd.getNodeString()
 
         annotations = {}
         data_type_items = []
         index_default = 0
-        for i, NodeDef_cls in enumerate(NodeDef_classes):
+        for i, NodeDef_cls in enumerate(node_def_classes):
             nd_name = NodeDef_cls.mx_nodedef.getName()
             data_type = MxNode._nodedef_data_type(NodeDef_cls.mx_nodedef)
             annotations[MxNode._nodedef_prop(nd_name)] = (PointerProperty, {'type': NodeDef_cls})
@@ -434,7 +434,7 @@ def parse_val(prop_type, val, first_only=False):
 def create_node_types(file_paths):
     IGNORE_NODEDEF_DATA_TYPE = ('matrix33', 'matrix44')
 
-    NodeDef_classes = []
+    node_def_classes = []
     for p in file_paths:
         doc = mx.createDocument()
         mx.readFromXmlFile(doc, str(p))
@@ -443,17 +443,17 @@ def create_node_types(file_paths):
             if MxNode._nodedef_data_type(mx_nodedef) in IGNORE_NODEDEF_DATA_TYPE:
                 continue
 
-            NodeDef_classes.append(MxNode.NodeDef.new(mx_nodedef))
+            node_def_classes.append(MxNode.NodeDef.new(mx_nodedef))
 
-    # grouping NodeDef_classes by node and nodegroup
+    # grouping node_def_classes by node and nodegroup
     d = defaultdict(list)
-    for NodeDef_cls in NodeDef_classes:
+    for NodeDef_cls in node_def_classes:
         nd = NodeDef_cls.mx_nodedef
         d[(nd.getNodeString(), nd.getAttribute('nodegroup'))].append(NodeDef_cls)
 
     # creating MxNode types
-    MxNode_classes = []
+    mx_node_classes = []
     for node_name, nd_types in d.items():
-        MxNode_classes.append(MxNode.new(nd_types))
+        mx_node_classes.append(MxNode.new(nd_types))
 
-    return NodeDef_classes, MxNode_classes
+    return node_def_classes, mx_node_classes

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -301,7 +301,7 @@ class MxNode(bpy.types.ShaderNode):
 
         data = {
             'bl_label': title_str(nd.getNodeString()),
-            'bl_idname': f"{MxNode.bl_idname}_{nd.getName()}",
+            'bl_idname': f"{MxNode.bl_idname}_{nd.getNodeString()}",
             'bl_description': nd.getAttribute('doc') if nd.hasAttribute('doc')
                    else title_str(nd.getName()),
             'bl_width_default': 250 if len(ui_folders) > 2 else 200,

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -242,16 +242,16 @@ class MxNode(bpy.types.ShaderNode):
         return self.get_input_default(in_key)
 
     def get_input_default(self, in_key: [str, int]):
-        return getattr(self.prop, self._input_prop(self.inputs[in_key].name))
+        return getattr(self.prop, self._input_prop(self.inputs[in_key].identifier))
 
     def get_param_value(self, name):
         return getattr(self.prop, self._param_prop(name))
 
     def get_nodedef_input(self, in_key: [str, int]):
-        return self.prop.mx_nodedef.getInput(self.inputs[in_key].name)
+        return self.prop.mx_nodedef.getInput(self.inputs[in_key].identifier)
 
     def get_nodedef_output(self, out_key: [str, int]):
-        return self.prop.mx_nodedef.getOutput(self.outputs[out_key].name)
+        return self.prop.mx_nodedef.getOutput(self.outputs[out_key].identifier)
 
     @property
     def prop(self):
@@ -404,74 +404,6 @@ class MxNode(bpy.types.ShaderNode):
         return prop_name, prop_type, prop_attrs
 
     def create_input(self, mx_input):
-        mx_type = mx_input.getType()
-        input = None
-
-        # while True:     # one way loop just for having break instead using nested 'if else'
-        #     if mx_type == 'string':
-        #         if mx_param.hasAttribute('enum'):
-        #             prop_type = EnumProperty
-        #             items = parse_val(prop_type, mx_param.getAttribute('enum'))
-        #             prop_attrs['items'] = tuple((it, title_str(it), title_str(it))
-        #                                         for it in items)
-        #             break
-        #         prop_type = StringProperty
-        #         break
-        #     if mx_type == 'filename':
-        #         prop_type = StringProperty
-        #         prop_attrs['subtype'] = 'FILE_PATH'
-        #         break
-        #     if mx_type == 'integer':
-        #         prop_type = IntProperty
-        #         break
-        #     if mx_type == 'float':
-        #         prop_type = FloatProperty
-        #         break
-        #     if mx_type == 'boolean':
-        #         prop_type = BoolProperty
-        #         break
-        #     if mx_type in ('surfaceshader', 'displacementshader', 'volumeshader', 'lightshader',
-        #                    'material', 'BSDF', 'VDF', 'EDF'):
-        #         prop_type = StringProperty
-        #         break
-        #
-        #     m = re.fullmatch('matrix(\d)(\d)', mx_type)
-        #     if m:
-        #         prop_type = FloatVectorProperty
-        #         prop_attrs['subtype'] = 'MATRIX'
-        #         prop_attrs['size'] = int(m[1]) * int(m[2])
-        #         break
-        #
-        #     m = re.fullmatch('color(\d)', mx_type)
-        #     if m:
-        #         prop_type = FloatVectorProperty
-        #         prop_attrs['subtype'] = 'COLOR'
-        #         prop_attrs['size'] = int(m[1])
-        #         break
-        #
-        #     m = re.fullmatch('vector(\d)', mx_type)
-        #     if m:
-        #         prop_type = FloatVectorProperty
-        #         dim = int(m[1])
-        #         prop_attrs['subtype'] = 'XYZ' if dim == 3 else 'NONE'
-        #         prop_attrs['size'] = dim
-        #         break
-        #
-        #     m = re.fullmatch('(.+)array', mx_type)
-        #     if m:
-        #         prop_type = StringProperty
-        #         # TODO: Change to CollectionProperty
-        #         break
-        #
-        #     prop_type = StringProperty
-        #     log.warn("Unsupported mx_type", mx_type, mx_param, mx_param.getParent().getName())
-        #     break
-
-        if mx_type.endswith('shader'):
-            input = self.inputs.new('NodeSocketShader', mx_input.getName())
-            input.name = title_str(mx_input.getName())
-            return input
-
         return self.inputs.new(MxNodeInputSocket.bl_idname, mx_input.getName())
 
     def create_output(self, mx_output):

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -48,10 +48,6 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
     def get_color(type_name):
         return (0.78, 0.78, 0.16, 1.0) if is_shader_type(type_name) else (0.16, 0.78, 0.16, 1.0)
 
-    @property
-    def default_value(self):
-        return (0.0, 0.0, 0.0, 0.0)
-
     def draw(self, context, layout, node, text):
         mx_input = node.prop.mx_nodedef.getInput(self.name)
         nd_type = mx_input.getType()
@@ -408,6 +404,74 @@ class MxNode(bpy.types.ShaderNode):
         return prop_name, prop_type, prop_attrs
 
     def create_input(self, mx_input):
+        mx_type = mx_input.getType()
+        input = None
+
+        # while True:     # one way loop just for having break instead using nested 'if else'
+        #     if mx_type == 'string':
+        #         if mx_param.hasAttribute('enum'):
+        #             prop_type = EnumProperty
+        #             items = parse_val(prop_type, mx_param.getAttribute('enum'))
+        #             prop_attrs['items'] = tuple((it, title_str(it), title_str(it))
+        #                                         for it in items)
+        #             break
+        #         prop_type = StringProperty
+        #         break
+        #     if mx_type == 'filename':
+        #         prop_type = StringProperty
+        #         prop_attrs['subtype'] = 'FILE_PATH'
+        #         break
+        #     if mx_type == 'integer':
+        #         prop_type = IntProperty
+        #         break
+        #     if mx_type == 'float':
+        #         prop_type = FloatProperty
+        #         break
+        #     if mx_type == 'boolean':
+        #         prop_type = BoolProperty
+        #         break
+        #     if mx_type in ('surfaceshader', 'displacementshader', 'volumeshader', 'lightshader',
+        #                    'material', 'BSDF', 'VDF', 'EDF'):
+        #         prop_type = StringProperty
+        #         break
+        #
+        #     m = re.fullmatch('matrix(\d)(\d)', mx_type)
+        #     if m:
+        #         prop_type = FloatVectorProperty
+        #         prop_attrs['subtype'] = 'MATRIX'
+        #         prop_attrs['size'] = int(m[1]) * int(m[2])
+        #         break
+        #
+        #     m = re.fullmatch('color(\d)', mx_type)
+        #     if m:
+        #         prop_type = FloatVectorProperty
+        #         prop_attrs['subtype'] = 'COLOR'
+        #         prop_attrs['size'] = int(m[1])
+        #         break
+        #
+        #     m = re.fullmatch('vector(\d)', mx_type)
+        #     if m:
+        #         prop_type = FloatVectorProperty
+        #         dim = int(m[1])
+        #         prop_attrs['subtype'] = 'XYZ' if dim == 3 else 'NONE'
+        #         prop_attrs['size'] = dim
+        #         break
+        #
+        #     m = re.fullmatch('(.+)array', mx_type)
+        #     if m:
+        #         prop_type = StringProperty
+        #         # TODO: Change to CollectionProperty
+        #         break
+        #
+        #     prop_type = StringProperty
+        #     log.warn("Unsupported mx_type", mx_type, mx_param, mx_param.getParent().getName())
+        #     break
+
+        if mx_type.endswith('shader'):
+            input = self.inputs.new('NodeSocketShader', mx_input.getName())
+            input.name = title_str(mx_input.getName())
+            return input
+
         return self.inputs.new(MxNodeInputSocket.bl_idname, mx_input.getName())
 
     def create_output(self, mx_output):

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -34,9 +34,10 @@ def get_node_categories():
         d[nodegroup].append(MxNode_cls)
 
     categories = []
-    for nodegroup,  cat_classes in d.items():
+    for nodegroup,  category_classes in d.items():
         categories.append(
             MxNodeCategory('HdUSD_MX_NG_' + nodegroup, title_str(nodegroup),
-                           items=[NodeItem(MxNode_cls.bl_idname) for MxNode_cls in cat_classes]))
+                           items=[NodeItem(MxNode_cls.bl_idname)
+                                  for MxNode_cls in category_classes]))
 
     return categories

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -17,7 +17,6 @@ from collections import defaultdict
 from nodeitems_utils import NodeCategory, NodeItem
 
 from ...utils import title_str
-from .base_node import MxNode_Output
 
 
 class MxNodeCategory(NodeCategory):
@@ -27,10 +26,10 @@ class MxNodeCategory(NodeCategory):
 
 
 def get_node_categories():
-    from . import node_types
+    from . import MxNode_classes
 
     d = defaultdict(list)
-    for n_type in node_types:
+    for n_type in MxNode_classes:
         nodegroup = n_type.mx_nodedefs[0].getAttribute('nodegroup')
         d[nodegroup].append(n_type)
 
@@ -40,6 +39,4 @@ def get_node_categories():
             MxNodeCategory('HdUSD_MX_NG_' + nodegroup, title_str(nodegroup),
                            items=[NodeItem(n_type.bl_idname) for n_type in n_types]))
 
-    categories.append(
-        MxNodeCategory('HdUSD_MX_NG_output', "Output", items=[NodeItem(MxNode_Output.bl_idname)]))
     return categories

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -26,17 +26,17 @@ class MxNodeCategory(NodeCategory):
 
 
 def get_node_categories():
-    from . import MxNode_classes
+    from . import mx_node_classes
 
     d = defaultdict(list)
-    for n_type in MxNode_classes:
-        nodegroup = n_type.mx_nodedefs[0].getAttribute('nodegroup')
-        d[nodegroup].append(n_type)
+    for MxNode_cls in mx_node_classes:
+        nodegroup = MxNode_cls.mx_nodedefs[0].getAttribute('nodegroup')
+        d[nodegroup].append(MxNode_cls)
 
     categories = []
-    for nodegroup, n_types in d.items():
+    for nodegroup,  cat_classes in d.items():
         categories.append(
             MxNodeCategory('HdUSD_MX_NG_' + nodegroup, title_str(nodegroup),
-                           items=[NodeItem(n_type.bl_idname) for n_type in n_types]))
+                           items=[NodeItem(MxNode_cls.bl_idname) for MxNode_cls in cat_classes]))
 
     return categories

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -44,7 +44,7 @@ class CachedStageProp(bpy.types.PropertyGroup, stage_cache.CachedStage):
         pass
 
 
-from . import scene, object, node, usd_list
+from . import scene, object, node, usd_list, material
 register, unregister = bpy.utils.register_classes_factory((
     CachedStageProp,
 
@@ -57,5 +57,7 @@ register, unregister = bpy.utils.register_classes_factory((
     scene.RenderSettings,
     scene.SceneProperties,
 
-    object.ObjectProperties
+    object.ObjectProperties,
+
+    material.MaterialProperties,
 ))

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -22,7 +22,3 @@ class MaterialProperties(HdUSDProperties):
     bl_type = bpy.types.Material
 
     mx_node_tree: bpy.props.PointerProperty(type=MxNodeTree)
-    use_mx_node_tree: bpy.props.BoolProperty(
-        name="Use MaterialX Node Tree",
-        default=False,
-    )

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -1,0 +1,28 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import bpy
+
+from . import HdUSDProperties
+from ..mx_nodes.node_tree import MxNodeTree
+
+
+class MaterialProperties(HdUSDProperties):
+    bl_type = bpy.types.Material
+
+    mx_node_tree: bpy.props.PointerProperty(type=MxNodeTree)
+    use_mx_node_tree: bpy.props.BoolProperty(
+        name="Use MaterialX Node Tree",
+        default=False,
+    )

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -29,8 +29,6 @@ class ObjectProperties(HdUSDProperties):
     sdf_path: bpy.props.StringProperty(default="/")
     cached_stage: bpy.props.PointerProperty(type=CachedStageProp)
 
-    material_x: bpy.props.PointerProperty(type=MxNodeTree)
-
     def sync_from_prim(self, prim, context):
         prim_obj = self.id_data
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -83,7 +83,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     mx_nodes.HDUSD_MX_OP_import_file,
     mx_nodes.HDUSD_MX_OP_export_file,
     mx_nodes.HDUSD_MX_OP_export_console,
-    mx_nodes.HDUSD_MX_OP_assign_to_object,
     mx_nodes.HDUSD_MX_MATERIAL_PT_import_export,
 ])
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -68,9 +68,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,
-    material.HDUSD_MATERIAL_PT_mx_output_surface,
-    material.HDUSD_MATERIAL_PT_mx_output_displacement,
-    material.HDUSD_MATERIAL_PT_mx_output_volume,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -83,6 +83,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     mx_nodes.HDUSD_MX_OP_import_file,
     mx_nodes.HDUSD_MX_OP_export_file,
     mx_nodes.HDUSD_MX_OP_export_console,
+    mx_nodes.HDUSD_MX_OP_create_basic_nodes,
     mx_nodes.HDUSD_MX_MATERIAL_PT_import_export,
 ])
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -63,10 +63,14 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     material.HDUSD_MATERIAL_PT_context,
     material.HDUSD_MATERIAL_PT_preview,
+    material.HDUSD_MATERIAL_OP_new_mx_node_tree,
     material.HDUSD_MATERIAL_PT_material,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,
+    material.HDUSD_MATERIAL_PT_mx_output_surface,
+    material.HDUSD_MATERIAL_PT_mx_output_displacement,
+    material.HDUSD_MATERIAL_PT_mx_output_volume,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -34,6 +34,12 @@ class HdUSD_Panel(bpy.types.Panel):
         return context.engine in cls.COMPAT_ENGINES
 
 
+class HdUSD_ChildPanel(bpy.types.Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_parent_id = ''
+
+
 from . import (
     panels,
     render,
@@ -57,9 +63,10 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     material.HDUSD_MATERIAL_PT_context,
     material.HDUSD_MATERIAL_PT_preview,
-    material.HDUSD_MATERIAL_PT_surface,
-    material.HDUSD_MATERIAL_PT_displacement,
-    material.HDUSD_MATERIAL_PT_volume,
+    material.HDUSD_MATERIAL_PT_material,
+    material.HDUSD_MATERIAL_PT_output_surface,
+    material.HDUSD_MATERIAL_PT_output_displacement,
+    material.HDUSD_MATERIAL_PT_output_volume,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -176,7 +176,17 @@ class HDUSD_MATERIAL_PT_mx_output_node(HdUSD_ChildPanel):
         return bool(context.material.hdusd.mx_node_tree)
 
     def draw(self, context):
-        pass
+        node_tree = context.material.hdusd.mx_node_tree
+        output_node = node_tree.output_node
+
+        layout = self.layout
+
+        if not output_node:
+            layout.label(text="No output node")
+            return
+
+        input = output_node.inputs[0]
+        layout.template_node_view(node_tree, output_node, input)
 
 
 class HDUSD_MATERIAL_PT_mx_output_surface(HDUSD_MATERIAL_PT_mx_output_node):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -47,8 +47,8 @@ class HDUSD_MATERIAL_PT_context(HdUSD_Panel):
 
             row = layout.row()
 
-            row.template_list("MATERIAL_UL_matslots", "", object, "material_slots", object, "active_material_index",
-                              rows=rows)
+            row.template_list("MATERIAL_UL_matslots", "", object, "material_slots", object,
+                              "active_material_index", rows=rows)
 
             col = row.column(align=True)
             col.operator("object.material_slot_add", icon='ADD', text="")
@@ -122,7 +122,7 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
         layout = self.layout
 
         col = layout.column(align=True)
-        col.label(text="MaterialX")
+        col.label(text="MaterialX Node Tree:")
         col.template_ID(mat_hdusd, "mx_node_tree",
                         new=HDUSD_MATERIAL_OP_new_mx_node_tree.bl_idname)
 
@@ -164,40 +164,4 @@ class HDUSD_MATERIAL_PT_output_displacement(HDUSD_MATERIAL_PT_output_node):
 
 class HDUSD_MATERIAL_PT_output_volume(HDUSD_MATERIAL_PT_output_node):
     bl_label = "Volume"
-    bl_options = {'DEFAULT_CLOSED'}
-
-
-class HDUSD_MATERIAL_PT_mx_output_node(HdUSD_ChildPanel):
-    bl_label = ""
-    bl_parent_id = 'HDUSD_MATERIAL_PT_material'
-
-    @classmethod
-    def poll(cls, context):
-        return bool(context.material.hdusd.mx_node_tree)
-
-    def draw(self, context):
-        node_tree = context.material.hdusd.mx_node_tree
-        output_node = node_tree.output_node
-
-        layout = self.layout
-
-        if not output_node:
-            layout.label(text="No output node")
-            return
-
-        input = output_node.inputs[0]
-        layout.template_node_view(node_tree, output_node, input)
-
-
-class HDUSD_MATERIAL_PT_mx_output_surface(HDUSD_MATERIAL_PT_mx_output_node):
-    bl_label = "MX Surface"
-
-
-class HDUSD_MATERIAL_PT_mx_output_displacement(HDUSD_MATERIAL_PT_mx_output_node):
-    bl_label = "MX Displacement"
-    bl_options = {'DEFAULT_CLOSED'}
-
-
-class HDUSD_MATERIAL_PT_mx_output_volume(HDUSD_MATERIAL_PT_mx_output_node):
-    bl_label = "MX Volume"
     bl_options = {'DEFAULT_CLOSED'}

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -12,8 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+import bpy
 
-from . import HdUSD_Panel
+from . import HdUSD_Panel, HdUSD_ChildPanel
 from ..export.material import get_material_output_node
 
 
@@ -94,13 +95,30 @@ class HDUSD_MATERIAL_PT_preview(HdUSD_Panel):
         self.layout.template_preview(context.material)
 
 
-class HDUSD_MaterialOutputSocket(HdUSD_Panel):
+class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
     bl_label = ""
     bl_context = "material"
 
     @classmethod
     def poll(cls, context):
         return context.material and super().poll(context)
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+
+        pass
+
+    def draw_header(self, context):
+        layout = self.layout
+        layout.label(text=f"Material: {context.material.name}")
+
+
+class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
+    bl_label = ""
+    bl_parent_id = 'HDUSD_MATERIAL_PT_material'
 
     def draw(self, context):
         layout = self.layout
@@ -116,14 +134,28 @@ class HDUSD_MaterialOutputSocket(HdUSD_Panel):
         layout.template_node_view(node_tree, output_node, input)
 
 
-class HDUSD_MATERIAL_PT_surface(HDUSD_MaterialOutputSocket):
+class HDUSD_MATERIAL_PT_output_surface(HDUSD_MATERIAL_PT_output_node):
     bl_label = "Surface"
 
 
-class HDUSD_MATERIAL_PT_displacement(HDUSD_MaterialOutputSocket):
+class HDUSD_MATERIAL_PT_output_displacement(HDUSD_MATERIAL_PT_output_node):
     bl_label = "Displacement"
+    bl_options = {'DEFAULT_CLOSED'}
 
 
-class HDUSD_MATERIAL_PT_volume(HDUSD_MaterialOutputSocket):
+class HDUSD_MATERIAL_PT_output_volume(HDUSD_MATERIAL_PT_output_node):
     bl_label = "Volume"
+    bl_options = {'DEFAULT_CLOSED'}
+
+
+class HDUSD_MATERIAL_PT_mx_output_node(HdUSD_ChildPanel):
+    bl_label = ""
+    bl_parent_id = 'HDUSD_MATERIAL_PT_material'
+
+    @classmethod
+    def poll(cls, context):
+        return context.material and super().poll(context)
+
+    def draw(self, context):
+        pass
 

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -103,8 +103,20 @@ class HDUSD_MATERIAL_OP_new_mx_node_tree(bpy.types.Operator):
 
     def execute(self, context):
         mat = context.material
-        node_tree = bpy.data.node_groups.new(f"MX_{mat.name}", type=MxNodeTree.bl_idname)
-        mat.hdusd.mx_node_tree = node_tree
+        mx_node_tree = bpy.data.node_groups.new(f"MX_{mat.name}", type=MxNodeTree.bl_idname)
+        mx_node_tree.create_basic_nodes()
+        mat.hdusd.mx_node_tree = mx_node_tree
+
+        # trying to show MaterialX area with created node tree
+        screen = context.screen
+        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
+        if not area:
+            area = next((a for a in screen.areas if a.ui_type == 'ShaderNodeTree'), None)
+
+        if area:
+            area.ui_type = 'hdusd.MxNodeTree'
+            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
+            space.node_tree = mx_node_tree
 
         return {"FINISHED"}
 

--- a/src/hdusd/ui/mx_nodes.py
+++ b/src/hdusd/ui/mx_nodes.py
@@ -117,20 +117,15 @@ class HDUSD_MX_OP_export_console(HdUSD_Operator):
         return bool(context.space_data.edit_tree.output_node)
 
 
-class HDUSD_MX_OP_assign_to_object(HdUSD_Operator):
-    bl_idname = "hdusd.mx_assign_to_object"
-    bl_label = "Assign to Object"
-    bl_description = "Assign MaterialX to selected object"
+class HDUSD_MX_OP_create_basic_nodes(HdUSD_Operator):
+    bl_idname = "hdusd.mx_create_basic_nodes"
+    bl_label = "Create Basic Nodes"
+    bl_description = "Create basic MaterialX nodes"
 
-    # Perform the operator action.
     def execute(self, context):
-        context.object.hdusd.material_x = context.space_data.edit_tree
+        mx_node_tree = context.space_data.edit_tree
+        mx_node_tree.create_basic_nodes()
         return {"FINISHED"}
-
-    @staticmethod
-    def enabled(context):
-        return bool(context.object and context.object.type in ('MESH',)
-                    and context.space_data.edit_tree.output_node)
 
 
 class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
@@ -146,8 +141,8 @@ class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
 
     def draw(self, context):
         layout = self.layout
-        tree = context.space_data.edit_tree
-        obj = context.object
+
+        layout.operator(HDUSD_MX_OP_create_basic_nodes.bl_idname)
 
         col = layout.column()
         col.enabled = HDUSD_MX_OP_export_file.enabled(context)

--- a/src/hdusd/ui/mx_nodes.py
+++ b/src/hdusd/ui/mx_nodes.py
@@ -134,7 +134,7 @@ class HDUSD_MX_OP_assign_to_object(HdUSD_Operator):
 
 
 class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
-    bl_label = "MaterialX Import/Export"
+    bl_label = "Import/Export"
     bl_space_type = "NODE_EDITOR"
     bl_region_type = "UI"
     bl_category = "Tool"
@@ -148,13 +148,6 @@ class HDUSD_MX_MATERIAL_PT_import_export(HdUSD_Panel):
         layout = self.layout
         tree = context.space_data.edit_tree
         obj = context.object
-
-        col = layout.column(align=True)
-        col.enabled = HDUSD_MX_OP_assign_to_object.enabled(context)
-        col.operator(HDUSD_MX_OP_assign_to_object.bl_idname)
-
-        if obj and obj.hdusd.material_x and obj.hdusd.material_x.name == tree.name:
-            col.label(text="Assigned")
 
         col = layout.column()
         col.enabled = HDUSD_MX_OP_export_file.enabled(context)


### PR DESCRIPTION
### PURPOSE
Assigning MaterialX (MX) node tree to object was working in developer mode, this process has to be made more user friendly.

### EFFECT OF CHANGE
1. Made MX node tree assign to blender material instead of object. Created panel for showing current Material with blender nodes or MX node tree. Added operator to select to use MX node tree or create new MX node tree.
2. Set Surfacematerial node as output node. Removed MX output node.
3. Implemented operator to create basic MX nodes in node tree.
4. During creating MX node tree in Material panel it also creates basic MX nodes and tries to open MX node tree window in blender UI.
5. Improved showing MX node sockets: output type, color. 

### TECHNICAL STEPS
1. Moved link mx_node_tree from object properties to material properties.
2. Created MxNodeInputSocket and MxNodeOutputSocket. Simplified and improved MxNodeInputSocket comparing to previous MxNodeSocket.
3. Made Surfacematerial node as output node. Removed MxNode_Output as not needed.
4. Adjusted export/material.py code
5. Implemented MxNodeTree.create_basic_nodes(). Added operator HDUSD_MX_OP_create_basic_nodes.
6. Created operator HDUSD_MATERIAL_OP_new_mx_node_tree which creates new MX node tree, assigns to material and tries to open MX node editor with created node tree.
7. Fixed some bugs and made code improvement.

### NOTES FOR REVIEWERS
In material panel MX node inputs aren't shown because our socket classes aren't supported by UILayout.template_node_view(). Showing MX nodes in this panel has to be made in separate task.