### PR TITLE
RPRBLND-1663: Implement importing MaterialX files

### DIFF
--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -17,7 +17,7 @@ import math
 import bpy
 import MaterialX as mx
 
-from ..utils import set_mx_param_value
+from ..utils.mx import set_param_value
 from ..mx_nodes.nodes import get_node_def_cls
 from . import log
 
@@ -63,7 +63,7 @@ class NodeItem:
         val_data = value.data if isinstance(value, NodeItem) else value
         nd_input = self.nodedef.getInput(name)
         input = self.data.addInput(name, nd_input.getType())
-        set_mx_param_value(input, val_data, input.getType())
+        set_param_value(input, val_data, input.getType())
 
     def set_inputs(self, inputs):
         for name, value in inputs.items():
@@ -84,7 +84,7 @@ class NodeItem:
                 result_data = self.doc.addNode(op_node, f"{op_node}_{self.id()}",
                                                self.data.getType())
                 input = result_data.addInput('in', self.data.getType())
-                set_mx_param_value(input, self.data, self.data.getType())
+                set_param_value(input, self.data, self.data.getType())
 
         else:
             other_data = other.data if isinstance(other, NodeItem) else other
@@ -110,9 +110,9 @@ class NodeItem:
                 result_data = self.doc.addNode(op_node, f"{op_node}_{self.id()}",
                                                self.data.getType())
                 input1 = result_data.addInput('in1', self.data.getType())
-                set_mx_param_value(input1, self.data, self.data.getType())
+                set_param_value(input1, self.data, self.data.getType())
                 input2 = result_data.addInput('in2', self.data.getType())
-                set_mx_param_value(input2, other_data, self.data.getType())
+                set_param_value(input2, other_data, self.data.getType())
 
         return self.node_item(result_data)
 

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -96,6 +96,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                     new_node = import_node(new_mx_node, layer + 1)
                     self.links.new(new_node.outputs[0], node.inputs[input_name])
 
+            node.ui_folders_check()
             return node
 
         mx_node = next(n for n in doc.getNodes() if n.getCategory() == 'surfacematerial')

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -22,7 +22,9 @@ from .nodes import get_mx_node_cls
 from ..utils import mx as mx_utils
 
 
-NODE_SEPARATION_WIDTH = 70
+NODE_LAYER_SEPARATION_WIDTH = 280
+NODE_LAYER_SHIFT_X = 30
+NODE_LAYER_SHIFT_Y = 100
 
 
 class MxNodeTree(bpy.types.ShaderNodeTree):
@@ -109,13 +111,14 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         loc_x = 0
         for i, node_names in enumerate(node_layers):
-            width = max(self.nodes[name].bl_width_default for name in node_names)
-            loc_x -= (width + NODE_SEPARATION_WIDTH) if i > 0 else 0
             loc_y = 0
             for name in node_names:
                 node = self.nodes[name]
                 node.location = (loc_x, loc_y)
-                loc_y -= node.height + NODE_SEPARATION_WIDTH
+                loc_y -= NODE_LAYER_SHIFT_Y
+                loc_x -= NODE_LAYER_SHIFT_X
+
+            loc_x -= NODE_LAYER_SEPARATION_WIDTH
 
     def create_basic_nodes(self, node_name='PBR_standard_surface'):
         """ Reset basic node tree structure using scene or USD file as an input """
@@ -124,16 +127,16 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         mat_node = self.nodes.new('hdusd.MxNode_STD_surfacematerial')
         if node_name == 'PBR_standard_surface':
             node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (mat_node.location[0] - node.bl_width_default - NODE_SEPARATION_WIDTH,
+            node.location = (mat_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
                              mat_node.location[1])
             self.links.new(node.outputs[0], mat_node.inputs[0])
         else:
             surface_node = self.nodes.new('hdusd.MxNode_PBR_surface')
-            surface_node.location = (mat_node.location[0] - surface_node.width -
-                                     NODE_SEPARATION_WIDTH, mat_node.location[1])
+            surface_node.location = (mat_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
+                                     mat_node.location[1])
             self.links.new(surface_node.outputs[0], mat_node.inputs[0])
 
             node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (surface_node.location[0] - node.width - NODE_SEPARATION_WIDTH,
+            node.location = (surface_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
                              surface_node.location[1])
             self.links.new(node.outputs[0], surface_node.inputs[0])

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -16,6 +16,8 @@ import bpy
 
 import MaterialX as mx
 
+from .nodes import get_mx_node_cls
+
 
 NODE_SEPARATION_WIDTH = 70
 
@@ -58,8 +60,15 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         return doc
 
     def import_(self, doc: mx.Document):
+        loc_x, loc_y = 0, 0
 
-        pass
+        for mx_node in reversed(doc.getNodes()):
+            MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
+            node = self.nodes.new(MxNode_cls.bl_idname)
+            node.import_values(mx_node)
+
+            node.location = (loc_x, loc_y)
+            loc_x -= node.width + NODE_SEPARATION_WIDTH
 
     def create_basic_nodes(self, node_name='PBR_standard_surface'):
         """ Reset basic node tree structure using scene or USD file as an input """

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -62,7 +62,9 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         return doc
 
-    def import_(self, doc: mx.Document):
+    def import_old(self, doc: mx.Document):
+        self.nodes.clear()
+
         loc_x, loc_y = 0, 0
 
         mx_nodes = [n for n in doc.getNodes() if n.getCategory() == 'surfacematerial']
@@ -76,6 +78,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
             for mx_node in mx_nodes:
                 MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
                 node = self.nodes.new(MxNode_cls.bl_idname)
+                node.name = mx_node.getName()
 
                 node.data_type = mx_node.getType()
                 for mx_param in mx_node.getParameters():
@@ -95,8 +98,8 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                         new_links.append((node_name, node.name, mx_input.getName()))
 
                 # setting links connected from created node
-                for mx_name, node_name, in_key in links:
-                    if mx_name == mx_node.getName():
+                for out_node_name, node_name, in_key in links:
+                    if out_node_name == node.name:
                         self.links.new(node.outputs[0], self.nodes[node_name].inputs[in_key])
 
                 node.location = (loc_x, loc_y)
@@ -106,6 +109,42 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
             loc_x -= layer_width + NODE_SEPARATION_WIDTH
             mx_nodes = new_mx_nodes
             links = new_links
+
+    def import_(self, doc: mx.Document):
+        self.nodes.clear()
+
+        def import_node(mx_node):
+            name = mx_node.getName()
+            if name in self:
+                return self[name]
+
+            MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
+            node = self.nodes.new(MxNode_cls.bl_idname)
+            node.name = name
+
+            node.data_type = mx_node.getType()
+            for mx_param in mx_node.getParameters():
+                node.set_param_value(mx_param.getName(),
+                                     mx_utils.parse_value(mx_param.getValue(), mx_param.getType()))
+
+            for mx_input in mx_node.getInputs():
+                input_name = mx_input.getName()
+                val = mx_input.getValue()
+                if val is not None:
+                    node.set_input_default(input_name,
+                                           mx_utils.parse_value(val, mx_input.getType()))
+                    continue
+
+                node_name = mx_input.getNodeName()
+                if node_name:
+                    new_mx_node = doc.getNode(node_name)
+                    new_node = import_node(new_mx_node)
+                    self.links.new(new_node.outputs[0], node.inputs[input_name])
+
+            return node
+
+        mx_node = next(n for n in doc.getNodes() if n.getCategory() == 'surfacematerial')
+        import_node(mx_node)
 
     def create_basic_nodes(self, node_name='PBR_standard_surface'):
         """ Reset basic node tree structure using scene or USD file as an input """

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -94,6 +94,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                         new_mx_nodes.append(doc.getNode(node_name))
                         new_links.append((node_name, node.name, mx_input.getName()))
 
+                # setting links connected from created node
                 for mx_name, node_name, in_key in links:
                     if mx_name == mx_node.getName():
                         self.links.new(node.outputs[0], self.nodes[node_name].inputs[in_key])

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -17,6 +17,9 @@ import bpy
 import MaterialX as mx
 
 
+NODE_SEPARATION_WIDTH = 70
+
+
 class MxNodeTree(bpy.types.ShaderNodeTree):
     """
     MaterialX NodeTree
@@ -54,24 +57,27 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         return doc
 
+    def import_(self, doc: mx.Document):
+
+        pass
+
     def create_basic_nodes(self, node_name='PBR_standard_surface'):
         """ Reset basic node tree structure using scene or USD file as an input """
         self.nodes.clear()
-        SEP_WIDTH = 70
 
         mat_node = self.nodes.new('hdusd.MxNode_STD_surfacematerial')
         if node_name == 'PBR_standard_surface':
             node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (mat_node.location[0] - node.width - SEP_WIDTH,
+            node.location = (mat_node.location[0] - node.width - NODE_SEPARATION_WIDTH,
                              mat_node.location[1])
             self.links.new(node.outputs[0], mat_node.inputs[0])
         else:
             surface_node = self.nodes.new('hdusd.MxNode_PBR_surface')
-            surface_node.location = (mat_node.location[0] - surface_node.width - SEP_WIDTH,
-                                     mat_node.location[1])
+            surface_node.location = (mat_node.location[0] - surface_node.width -
+                                     NODE_SEPARATION_WIDTH, mat_node.location[1])
             self.links.new(surface_node.outputs[0], mat_node.inputs[0])
 
             node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (surface_node.location[0] - node.width - SEP_WIDTH,
+            node.location = (surface_node.location[0] - node.width - NODE_SEPARATION_WIDTH,
                              surface_node.location[1])
             self.links.new(node.outputs[0], surface_node.inputs[0])

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -63,6 +63,15 @@ def get_node_def_cls(node_name, nd_type):
     return next(cls for cls in node_def_classes if cls.mx_nodedef.getName() == nd_name)
 
 
-def get_mx_node_cls(node_name, prefix='STD'):
-    name = f"MxNode_{prefix}_{node_name}"
-    return next(cls for cls in mx_node_classes if cls.__name__ == name)
+def get_mx_node_cls(node_name, nd_type):
+    nd_name = f"ND_{node_name}_{nd_type}"
+    for cls in mx_node_classes:
+        if next((nd for nd in cls.mx_nodedefs if nd.getName() == nd_name), None):
+            return cls
+
+    nd_name = f"ND_{node_name}"
+    for cls in mx_node_classes:
+        if next((nd for nd in cls.mx_nodedefs if nd.getName() == nd_name), None):
+            return cls
+
+    raise StopIteration(node_name, nd_type)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -434,22 +434,12 @@ class MxNode(bpy.types.ShaderNode):
             else title_str(prop_name)
         prop_attrs['description'] = mx_param.getAttribute('doc')
 
-        if mx_param.hasAttribute('uimin'):
-            prop_attrs['min'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('uimin'), mx_type, first_only=True)
-        if mx_param.hasAttribute('uimax'):
-            prop_attrs['max'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('uimax'), mx_type, first_only=True)
-        if mx_param.hasAttribute('uisoftmin'):
-            prop_attrs['soft_min'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('uisoftmin'), mx_type, first_only=True)
-        if mx_param.hasAttribute('uisoftmax'):
-            prop_attrs['soft_max'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('uisoftmax'), mx_type, first_only=True)
-
-        if mx_param.hasAttribute('value'):
-            prop_attrs['default'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('value'), mx_type)
+        for mx_attr, prop_attr in (('uimin', 'min'), ('uimax', 'max'),
+                                   ('uisoftmin', 'soft_min'), ('uisoftmax', 'soft_max'),
+                                   ('value', 'default')):
+            if mx_param.hasAttribute(mx_attr):
+                prop_attrs[prop_attr] = mx_utils.parse_value_str(
+                    mx_param.getAttribute(mx_attr), mx_type, first_only=mx_attr != 'value')
 
         return prop_name, prop_type, prop_attrs
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -437,6 +437,10 @@ class MxNode(bpy.types.ShaderNode):
             setattr(self.prop, self._input_prop(mx_input.getName()),
                     mx_utils.parse_value(val, mx_input.getType()))
 
+        for mx_param in mx_node.getParameters():
+            setattr(self.prop, self._param_prop(mx_param.getName()),
+                    mx_utils.parse_value(mx_param.getValue(), mx_param.getType()))
+
 
 def create_node_types(file_paths):
     IGNORE_NODEDEF_DATA_TYPE = ('matrix33', 'matrix44')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -262,6 +262,12 @@ class MxNode(bpy.types.ShaderNode):
     def get_nodedef_output(self, out_key: [str, int]):
         return self.prop.mx_nodedef.getOutput(self.outputs[out_key].identifier)
 
+    def set_input_default(self, in_key, value):
+        setattr(self.prop, self._input_prop(self.inputs[in_key].identifier), value)
+
+    def set_param_value(self, name, value):
+        setattr(self.prop, self._param_prop(name), value)
+
     @property
     def prop(self):
         return getattr(self, self._nodedef_prop(self.data_type))
@@ -415,9 +421,8 @@ class MxNode(bpy.types.ShaderNode):
                 mx_param.getAttribute('uisoftmax'), mx_type, first_only=True)
 
         if mx_param.hasAttribute('value'):
-            is_enum = prop_type == EnumProperty
             prop_attrs['default'] = mx_utils.parse_value_str(
-                mx_param.getAttribute('value'), mx_type, is_enum=is_enum, first_only=is_enum)
+                mx_param.getAttribute('value'), mx_type)
 
         return prop_name, prop_type, prop_attrs
 
@@ -426,20 +431,6 @@ class MxNode(bpy.types.ShaderNode):
 
     def create_output(self, mx_output):
         return self.outputs.new(MxNodeOutputSocket.bl_idname, mx_output.getName())
-
-    def import_values(self, mx_node):
-        self.data_type = mx_node.getType()
-        for mx_input in mx_node.getInputs():
-            val = mx_input.getValue()
-            if val is None:
-                continue
-
-            setattr(self.prop, self._input_prop(mx_input.getName()),
-                    mx_utils.parse_value(val, mx_input.getType()))
-
-        for mx_param in mx_node.getParameters():
-            setattr(self.prop, self._param_prop(mx_param.getName()),
-                    mx_utils.parse_value(mx_param.getValue(), mx_param.getType()))
 
 
 def create_node_types(file_paths):

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -224,9 +224,10 @@ class MxNode(bpy.types.ShaderNode):
         return node
 
     def _compute_node(self, node, out_key, **kwargs):
-        if not isinstance(node, MxNode):
-            log.warn("Ignoring unsupported node", node)
-            return None
+        doc = kwargs['doc']
+        mx_node = doc.getNode(code_str(node.name))
+        if mx_node:
+            return mx_node
 
         return node.compute(out_key, **kwargs)
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -119,7 +119,12 @@ class MxNode(bpy.types.ShaderNode):
 
     @staticmethod
     def _nodedef_data_type(nd):
-        return nd.getOutputs()[0].getType()
+        # nodedef name consists: ND_{node_name}_{data_type} therefore:
+        res = nd.getName()[(4 + len(nd.getNodeString())):]
+        if not res:
+            res = nd.getOutputs()[0].getType()
+
+        return res
 
     class NodeDef(bpy.types.PropertyGroup):
         mx_nodedef: mx.NodeDef  # holds the materialx nodedef object
@@ -333,7 +338,8 @@ class MxNode(bpy.types.ShaderNode):
             if mx_type == 'string':
                 if mx_param.hasAttribute('enum'):
                     prop_type = EnumProperty
-                    items = mx_utils.parse_value_str(prop_type, mx_param.getAttribute('enum'))
+                    items = mx_utils.parse_value_str(mx_param.getAttribute('enum'), mx_type,
+                                                     is_enum=True)
                     prop_attrs['items'] = tuple((it, title_str(it), title_str(it))
                                                 for it in items)
                     break
@@ -396,21 +402,22 @@ class MxNode(bpy.types.ShaderNode):
         prop_attrs['description'] = mx_param.getAttribute('doc')
 
         if mx_param.hasAttribute('uimin'):
-            prop_attrs['min'] = mx_utils.parse_value_str(prop_type,
-                mx_param.getAttribute('uimin'), True)
+            prop_attrs['min'] = mx_utils.parse_value_str(
+                mx_param.getAttribute('uimin'), mx_type, first_only=True)
         if mx_param.hasAttribute('uimax'):
-            prop_attrs['max'] = mx_utils.parse_value_str(prop_type,
-                mx_param.getAttribute('uimax'), True)
+            prop_attrs['max'] = mx_utils.parse_value_str(
+                mx_param.getAttribute('uimax'), mx_type, first_only=True)
         if mx_param.hasAttribute('uisoftmin'):
-            prop_attrs['soft_min'] = mx_utils.parse_value_str(prop_type,
-                mx_param.getAttribute('uisoftmin'), True)
+            prop_attrs['soft_min'] = mx_utils.parse_value_str(
+                mx_param.getAttribute('uisoftmin'), mx_type, first_only=True)
         if mx_param.hasAttribute('uisoftmax'):
-            prop_attrs['soft_max'] = mx_utils.parse_value_str(prop_type,
-                mx_param.getAttribute('uisoftmax'), True)
+            prop_attrs['soft_max'] = mx_utils.parse_value_str(
+                mx_param.getAttribute('uisoftmax'), mx_type, first_only=True)
 
         if mx_param.hasAttribute('value'):
-            prop_attrs['default'] = mx_utils.parse_value_str(prop_type,
-                mx_param.getAttribute('value'), prop_type == EnumProperty)
+            is_enum = prop_type == EnumProperty
+            prop_attrs['default'] = mx_utils.parse_value_str(
+                mx_param.getAttribute('value'), mx_type, is_enum=is_enum, first_only=is_enum)
 
         return prop_name, prop_type, prop_attrs
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -335,6 +335,32 @@ class MxNode(bpy.types.ShaderNode):
             if f:
                 self.inputs[i].hide = not getattr(self, self._folder_prop(f))
 
+    def ui_folders_check(self):
+        if not self.ui_folders:
+            return
+
+        for f in self.ui_folders:
+            setattr(self, self._folder_prop(f), False)
+
+        for in_key, mx_input in enumerate(self.prop.mx_nodedef.getInputs()):
+            f = mx_input.getAttribute('uifolder')
+            if not f:
+                continue
+
+            if self.inputs[in_key].links:
+                setattr(self, self._folder_prop(f), True)
+                continue
+
+            nd_input = self.get_nodedef_input(in_key)
+            val = self.get_input_default(in_key)
+            nd_val = nd_input.getValue()
+            if nd_val is None or mx_utils.is_value_equal(nd_val, val, nd_input.getType()):
+                continue
+
+            setattr(self, self._folder_prop(f), True)
+
+        self.ui_folders_update(None)
+
     @staticmethod
     def create_property(mx_param):
         mx_type = mx_param.getType()

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -130,18 +130,3 @@ def title_str(str):
 
 def code_str(str):
     return str.replace(' ', '_').replace('.', '_').lower()
-
-
-def set_mx_param_value(mx_param, val, nd_type):
-    import MaterialX as mx
-
-    if isinstance(val, mx.Node):
-        mx_param.setNodeName(val.getName())
-    elif nd_type == 'filename':
-        mx_param.setValueString(val)
-    else:
-        mx_type = getattr(mx, title_str(nd_type), None)
-        if mx_type:
-            mx_param.setValue(mx_type(val))
-        else:
-            mx_param.setValue(val)

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -129,4 +129,4 @@ def title_str(str):
 
 
 def code_str(str):
-    return str.replace(' ', '_').replace('.', '_').lower()
+    return str.replace(' ', '_').replace('.', '_')

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -51,55 +51,24 @@ def parse_value(mx_val, mx_type):
     return tuple(mx_val)
 
 
-def parse_value_str_new(val_str, mx_type, *, first_only=False, is_enum=False):
+def parse_value_str(val_str, mx_type, *, first_only=False, is_enum=False):
     if mx_type == 'string':
         if is_enum:
             res = tuple(x.strip() for x in val_str.split(','))
             return res[0] if first_only else res
         return val_str
 
-    if mx_type == 'filename':
-        return val_str
     if mx_type == 'integer':
         return int(val_str)
     if mx_type == 'float':
         return float(val_str)
     if mx_type == 'boolean':
         return val_str == "true"
+    if mx_type.endswith('array'):
+        return val_str
 
-    if mx_type.startswith('color') or mx_type.startswith('vector') or mx_type.endswith('array'):
+    if mx_type.startswith('color') or mx_type.startswith('vector') or mx_type.startswith('matrix'):
         res = tuple(float(x) for x in val_str.split(','))
-        if first_only:
-            return res[0]
-        return res
+        return res[0] if first_only else res
 
-
-def parse_value_str(prop_type, val, first_only=False):
-    from bpy.props import (
-        StringProperty,
-        IntProperty,
-        FloatProperty,
-        EnumProperty,
-        FloatVectorProperty,
-        BoolProperty,
-    )
-
-    if prop_type == StringProperty:
-        return val
-    if prop_type == IntProperty:
-        return int(val)
-    if prop_type == FloatProperty:
-        return float(val)
-    if prop_type == BoolProperty:
-        return val == "true"
-    if prop_type == FloatVectorProperty:
-        res = tuple(float(x) for x in val.split(','))
-        if first_only:
-            return res[0]
-        return res
-    if prop_type == EnumProperty:
-        res = tuple(x.strip() for x in val.split(','))
-        if first_only:
-            return res[0]
-        return res
-
+    return val_str

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -42,3 +42,64 @@ def is_shader_type(mx_type):
                 mx_type.startswith('color') or
                 mx_type.startswith('vector') or
                 mx_type.endswith('array'))
+
+
+def parse_value(mx_val, mx_type):
+    if mx_type in ('string', 'float', 'integer', 'boolean', 'filename'):
+        return mx_val
+
+    return tuple(mx_val)
+
+
+def parse_value_str_new(val_str, mx_type, *, first_only=False, is_enum=False):
+    if mx_type == 'string':
+        if is_enum:
+            res = tuple(x.strip() for x in val_str.split(','))
+            return res[0] if first_only else res
+        return val_str
+
+    if mx_type == 'filename':
+        return val_str
+    if mx_type == 'integer':
+        return int(val_str)
+    if mx_type == 'float':
+        return float(val_str)
+    if mx_type == 'boolean':
+        return val_str == "true"
+
+    if mx_type.startswith('color') or mx_type.startswith('vector') or mx_type.endswith('array'):
+        res = tuple(float(x) for x in val_str.split(','))
+        if first_only:
+            return res[0]
+        return res
+
+
+def parse_value_str(prop_type, val, first_only=False):
+    from bpy.props import (
+        StringProperty,
+        IntProperty,
+        FloatProperty,
+        EnumProperty,
+        FloatVectorProperty,
+        BoolProperty,
+    )
+
+    if prop_type == StringProperty:
+        return val
+    if prop_type == IntProperty:
+        return int(val)
+    if prop_type == FloatProperty:
+        return float(val)
+    if prop_type == BoolProperty:
+        return val == "true"
+    if prop_type == FloatVectorProperty:
+        res = tuple(float(x) for x in val.split(','))
+        if first_only:
+            return res[0]
+        return res
+    if prop_type == EnumProperty:
+        res = tuple(x.strip() for x in val.split(','))
+        if first_only:
+            return res[0]
+        return res
+

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -1,0 +1,44 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import MaterialX as mx
+
+from . import title_str
+
+
+def set_param_value(mx_param, val, nd_type):
+    if isinstance(val, mx.Node):
+        mx_param.setNodeName(val.getName())
+    elif nd_type == 'filename':
+        mx_param.setValueString(val)
+    else:
+        mx_type = getattr(mx, title_str(nd_type), None)
+        if mx_type:
+            mx_param.setValue(mx_type(val))
+        else:
+            mx_param.setValue(val)
+
+
+def is_value_equal(mx_val, val, nd_type):
+    if nd_type in ('string', 'float', 'integer', 'boolean', 'filename'):
+        return mx_val == val
+
+    return tuple(mx_val) == tuple(val)
+
+
+def is_shader_type(mx_type):
+    return not (mx_type in ('string', 'float', 'integer', 'boolean', 'filename') or
+                mx_type.startswith('color') or
+                mx_type.startswith('vector') or
+                mx_type.endswith('array'))


### PR DESCRIPTION
### PURPOSE
We are going to have possibility to import MaterialX (.mtlx) files into Blender MX node tree. Also this is needed for future MaterialX library.

### EFFECT OF CHANGE
1. Added possibility to import .mtlx files into Blender MX node tree.
2. Improved exporting MX nodes into .mtlx by not setting non-changed parameters and inputs.

### TECHNICAL STEPS
1. Added utils/mx.py with useful functionality related to MX, moved some functions there.
2. Implemented MxNodeTree.import_() function which creates and places MX nodes in node tree from mx.Document.
3. Fixes/improvements:
    - fixed double export of node by adding check if node was already exported;
    - improved exporting of MX node by not setting non-changed parameters and inputs;
    - improved showing some input sockets;

### NOTES FOR REVIEWERS
Currently it is available only to import .mtlx files when material is set by nodes, without `<material>` and `<shaderref>` statements. Files which we get by exporting MX nodes are suited well to import. Importing .mtlx files with <material> and `<shaderref>` statements requires conversion script from `<material>` and `<shaderref>` statements into nodes statements. I plan to do this in separate task.