### PR TITLE
Fixed paths on CIS build and error with loading hdRPR

### DIFF
--- a/src/hdusd/engine/__init__.py
+++ b/src/hdusd/engine/__init__.py
@@ -28,6 +28,7 @@ os.environ['PXR_PLUGINPATH_NAME'] = str(utils.HDUSD_LIBS_DIR / 'plugins')
 os.environ['RPR'] = str(utils.HDUSD_LIBS_DIR / 'hdrpr')
 
 sys.path.append(str(utils.HDUSD_LIBS_DIR / 'usd/python'))
+sys.path.append(str(utils.HDUSD_LIBS_DIR / 'hdrpr/lib/python'))
 sys.path.append(str(utils.HDUSD_LIBS_DIR / 'materialx/python'))
 
 if utils.IS_WIN:

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -38,7 +38,7 @@ PLUGIN_ROOT_DIR = Path(hdusd.__file__).parent
 BLENDER_DATA_DIR = Path(bpy.utils.resource_path('LOCAL'))
 
 HDUSD_DEBUG_MODE = bool(int(os.environ.get('HDUSD_BLENDER_DEBUG', 0)))
-HDUSD_LIBS_DIR = Path(os.environ['HDUSD_LIBS_DIR']) if HDUSD_DEBUG_MODE else \
+HDUSD_LIBS_DIR = Path(os.environ['HDUSD_LIBS_DIR']).absolute() if HDUSD_DEBUG_MODE else \
                  PLUGIN_ROOT_DIR / 'libs'
 
 

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -19,7 +19,8 @@ from pathlib import Path
 from collections import defaultdict
 
 
-libs_dir = Path(os.environ['HDUSD_LIBS_DIR'])
+libs_dir = Path(os.environ['HDUSD_LIBS_DIR']).absolute()
+
 repo_dir = Path(__file__).parent.parent
 
 


### PR DESCRIPTION
### PURPOSE
HDUSD_LIBS_DIR could be relative, this is used in CIS, therefore made appropriate changes.
Also there is a warning in log during loading hdRPR.

### EFFECT OF CHANGE
Fixed log warning in loading hdRPR.

### TECHNICAL STEPS
Added absolute() to HDUSD_LIBS_DIR path.
Added HDUSD_LIBS_DIR/hdrpr/lib/python to system paths during loading plugin.
