### PR TITLE
[RPRBLND-1693] limit blender shader nodes menu to supported only

### DIFF
--- a/src/hdusd/__init__.py
+++ b/src/hdusd/__init__.py
@@ -36,7 +36,7 @@ log = logging.Log(tag='init')
 log.info(f"Loading USD Hydra addon version={bl_info['version']}, build={version_build}")
 
 
-from . import engine, properties, ui, usd_nodes, mx_nodes
+from . import engine, properties, ui, usd_nodes, mx_nodes, bl_nodes
 
 
 def register():
@@ -44,6 +44,7 @@ def register():
     log("register")
 
     engine.register()
+    bl_nodes.register()
     mx_nodes.register()
     usd_nodes.register()
     properties.register()
@@ -56,6 +57,7 @@ def unregister():
 
     mx_nodes.unregister()
     usd_nodes.unregister()
+    bl_nodes.unregister()
     ui.unregister()
     properties.unregister()
     engine.unregister()

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -30,7 +30,7 @@ class HdUSD_CompatibleShaderNodeCategory(NodeCategory):
     """ Appear with an active USD plugin in Material shader editor only """
     @classmethod
     def poll(cls, context):
-        return context.scene.render.engine == "USD"\
+        return context.scene.render.engine == "HdUSD"\
                and context.space_data.tree_type == 'ShaderNodeTree'
 
 

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -66,15 +66,19 @@ old_shader_node_category_poll = None
 
 
 def register():
-    # hide Cycles
+    # hide Cycles/Eevee menu
     global old_shader_node_category_poll
     old_shader_node_category_poll = ShaderNodeCategory.poll
     ShaderNodeCategory.poll = hide_cycles_and_eevee_poll(ShaderNodeCategory.poll)
 
+    # use custom menu
     register_node_categories("RPR_NODES", node_categories)
 
 
 def unregister():
+    # restore Cycles/Eevee menu
     if old_shader_node_category_poll and ShaderNodeCategory.poll is not old_shader_node_category_poll:
         ShaderNodeCategory.poll = old_shader_node_category_poll
+
+    # remove custom menu
     unregister_node_categories("RPR_NODES")

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -12,12 +12,44 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+from nodeitems_utils import (
+    NodeCategory,
+    NodeItem,
+    register_node_categories,
+    unregister_node_categories,
+)
 from nodeitems_builtins import (
     ShaderNodeCategory,
 )
 
 from ..utils import logging
 log = logging.Log("bl_nodes")
+
+
+class HdUSD_CompatibleShaderNodeCategory(NodeCategory):
+    """ Appear with an active USD plugin in Material shader editor only """
+    @classmethod
+    def poll(cls, context):
+        return context.scene.render.engine == "USD"\
+               and context.space_data.tree_type == 'ShaderNodeTree'
+
+
+# add nodes here once they are supported
+# TODO support Textures
+# TODO support Color->MixRGB and other color-operations
+# TODO support Vector operations and Bumb/Normal
+# TODO support Converter->Math and other values-operations
+# TODO support reroute
+node_categories = [
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_OUTPUT', "Output", items=[
+        NodeItem('ShaderNodeOutputMaterial'),
+    ], ),
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_SHADERS', "Shader", items=[
+        NodeItem('ShaderNodeBsdfPrincipled'),
+        NodeItem('ShaderNodeBsdfDiffuse'),
+        NodeItem('ShaderNodeEmission'),
+    ]),
+]
 
 
 # some nodes are hidden from plugins by Cycles itself(like Material Output), some we could not support.
@@ -39,7 +71,10 @@ def register():
     old_shader_node_category_poll = ShaderNodeCategory.poll
     ShaderNodeCategory.poll = hide_cycles_and_eevee_poll(ShaderNodeCategory.poll)
 
+    register_node_categories("RPR_NODES", node_categories)
+
 
 def unregister():
     if old_shader_node_category_poll and ShaderNodeCategory.poll is not old_shader_node_category_poll:
         ShaderNodeCategory.poll = old_shader_node_category_poll
+    unregister_node_categories("RPR_NODES")

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -12,5 +12,34 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+from nodeitems_builtins import (
+    ShaderNodeCategory,
+)
+
 from ..utils import logging
 log = logging.Log("bl_nodes")
+
+
+# some nodes are hidden from plugins by Cycles itself(like Material Output), some we could not support.
+# thus we'll hide 'em all to show only selected set of supported Blender nodes
+# custom HdUSD_CompatibleShaderNodeCategory will be used instead
+def hide_cycles_and_eevee_poll(method):
+    @classmethod
+    def func(cls, context):
+        return not context.scene.render.engine == 'HdUSD' and method(context)
+    return func
+
+
+old_shader_node_category_poll = None
+
+
+def register():
+    # hide Cycles
+    global old_shader_node_category_poll
+    old_shader_node_category_poll = ShaderNodeCategory.poll
+    ShaderNodeCategory.poll = hide_cycles_and_eevee_poll(ShaderNodeCategory.poll)
+
+
+def unregister():
+    if old_shader_node_category_poll and ShaderNodeCategory.poll is not old_shader_node_category_poll:
+        ShaderNodeCategory.poll = old_shader_node_category_poll

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -33,7 +33,7 @@ class MaterialProperties(HdUSDProperties):
     def export(self, obj: bpy.types.Object) -> [mx.Document, None]:
         material = self.id_data
         output_node = next((node for node in material.node_tree.nodes if
-                            node.bl_idname == ShaderNodeOutputMaterial.__name__), None)
+                            node.bl_idname == ShaderNodeOutputMaterial.__name__ and node.is_active_output), None)
 
         if not output_node:
             return None


### PR DESCRIPTION
### PURPOSE
The existing Cycles/Eevee shader nodes menu doesn't works correctly with HdUSD plugin - it displays lots of nodes we aren't supporting while display no nodes in Shader category. The custom menu should be used instead.
Hide the Shader Editor nodes from menu that aren't supported by plugin. Display the supported nodes.

### EFFECT OF CHANGE
- limited Shade Editor shader nodes menu to nodes supported by plugin;
- fixed issue with rendering Blender material using the firstmost output node instead of active.

### TECHNICAL STEPS
- added check for output shader node activity state;
- disable Cycles shader nodes menu categories;
- added custom menu with supported shader nodes.
