### PR TITLE
[RPRBLND-1677] Convert useful Blender nodes to materialX

### DIFF
--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -54,6 +54,7 @@ node_categories = [
         NodeItem('ShaderNodeBsdfPrincipled'),
     ]),
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_COLOR', "Color", items=[
+        NodeItem('ShaderNodeInvert'),
         NodeItem('ShaderNodeMixRGB'),
     ], ),
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_CONVERTER', "Converter", items=[

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -36,19 +36,29 @@ class HdUSD_CompatibleShaderNodeCategory(NodeCategory):
 
 # add nodes here once they are supported
 # TODO support Textures
-# TODO support Color->MixRGB and other color-operations
 # TODO support Vector operations and Bumb/Normal
 # TODO support Converter->Math and other values-operations
 # TODO support reroute
 node_categories = [
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_INPUT', "Input", items=[
+        NodeItem('ShaderNodeRGB'),
+        NodeItem('ShaderNodeValue'),
+    ], ),
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_OUTPUT', "Output", items=[
         NodeItem('ShaderNodeOutputMaterial'),
     ], ),
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_SHADERS', "Shader", items=[
-        NodeItem('ShaderNodeBsdfPrincipled'),
         NodeItem('ShaderNodeBsdfDiffuse'),
+        NodeItem('ShaderNodeBsdfGlass'),
         NodeItem('ShaderNodeEmission'),
+        NodeItem('ShaderNodeBsdfPrincipled'),
     ]),
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_COLOR', "Color", items=[
+        NodeItem('ShaderNodeMixRGB'),
+    ], ),
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_CONVERTER', "Converter", items=[
+        NodeItem('ShaderNodeMixRGB'),
+    ], ),
 ]
 
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -45,9 +45,6 @@ class NodeItem:
             log.error(f"Unable to find node class def(id {id})")
             raise
 
-    def __repr__(self):
-        return f"NodeItem(ID [{self.id}], data {self.data}, nodedef {self.nodedef}; doc {self.doc})"
-
     def node_item(self, value):
         if isinstance(value, NodeItem):
             return value

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -38,12 +38,8 @@ class NodeItem:
         self.id = id
         self.doc = doc
         self.data = data
-        try:
-            self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
-                if isinstance(data, mx.Node) else None
-        except:
-            log.error(f"Unable to find node class def(id {id})")
-            raise
+        self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
+            if isinstance(data, mx.Node) else None
 
     def node_item(self, value):
         if isinstance(value, NodeItem):

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -41,6 +41,9 @@ class NodeItem:
         self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
             if isinstance(data, mx.Node) else None
 
+    def __repr__(self):
+        return f"NodeItem(ID [{self.id}], data {self.data}, nodedef {self.nodedef}; doc {self.doc})"
+
     def node_item(self, value):
         if isinstance(value, NodeItem):
             return value
@@ -66,8 +69,12 @@ class NodeItem:
         set_param_value(input, val_data, input.getType())
 
     def set_inputs(self, inputs):
-        for name, value in inputs.items():
-            self.set_input(name, value)
+        try:
+            for name, value in inputs.items():
+                self.set_input(name, value)
+        except Exception as e:
+            log.error(f"set_inputs error. Name {name}, value {value}")
+            raise
 
     # MATH OPERATIONS
     def _arithmetic_helper(self, other, op_node, func):

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -236,6 +236,10 @@ class NodeItem:
     def log(self):
         return self._arithmetic_helper(None, 'ln', lambda a: math.log(a))
 
+    def blend(self, value1, value2):
+        """ Line interpolate value between value1(0.0) and value2(1.0) by self.data as factor """
+        return self * value2 + (1.0 - self) * value1
+
 
 class NodeParser:
     """

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -152,7 +152,7 @@ class NodeItem:
         return self._arithmetic_helper(None, 'floor', lambda a: float(math.floor(a)))
 
     def ceil(self):
-        return self._arithmetic_helper(None, 'ceil', lambda a: float(math.floor(a)))
+        return self._arithmetic_helper(None, 'ceil', lambda a: float(math.ceil(a)))
 
     # right hand methods for doing something like 1.0 - Node
     def __radd__(self, other):
@@ -211,9 +211,9 @@ class NodeItem:
     def max(self, other):
         return self._arithmetic_helper(other, 'max', lambda a, b: max(a, b))
 
-    # def clamp(self, min_val=0.0, max_val=1.0):
-    #     ''' clamp data to min/max '''
-    #     return self.min(max_val).max(min_val)
+    def clamp(self, min_val=0.0, max_val=1.0):
+        """ clamp data to min/max """
+        return self.min(max_val).max(min_val)
 
     def sin(self):
         return self._arithmetic_helper(None, 'sin', lambda a: math.sin(a))
@@ -223,6 +223,18 @@ class NodeItem:
 
     def tan(self):
         return self._arithmetic_helper(None, 'tan', lambda a: math.tan(a))
+
+    def asin(self):
+        return self._arithmetic_helper(None, 'asin', lambda a: math.asin(a))
+
+    def acos(self):
+        return self._arithmetic_helper(None, 'acos', lambda a: math.acos(a))
+
+    def atan(self):
+        return self._arithmetic_helper(None, 'atan', lambda a: math.atan(a))
+
+    def log(self):
+        return self._arithmetic_helper(None, 'ln', lambda a: math.log(a))
 
 
 class NodeParser:

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -38,8 +38,12 @@ class NodeItem:
         self.id = id
         self.doc = doc
         self.data = data
-        self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
-            if isinstance(data, mx.Node) else None
+        try:
+            self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
+                if isinstance(data, mx.Node) else None
+        except:
+            log.error(f"Unable to find node class def(id {id})")
+            raise
 
     def __repr__(self):
         return f"NodeItem(ID [{self.id}], data {self.data}, nodedef {self.nodedef}; doc {self.doc})"
@@ -65,6 +69,9 @@ class NodeItem:
 
         val_data = value.data if isinstance(value, NodeItem) else value
         nd_input = self.nodedef.getInput(name)
+        if nd_input is None:
+            log.error(f"[{self.id}] Unable to find input {name} for nodedef {self.nodedef}")
+            return
         input = self.data.addInput(name, nd_input.getType())
         set_param_value(input, val_data, input.getType())
 
@@ -323,6 +330,7 @@ class NodeParser:
     def get_input_default(self, in_key):
         """ Returns default value of input socket """
 
+        assert in_key in self.node.inputs, f"no input socket '{in_key}' found in {self}"
         socket_in = self.node.inputs[in_key]
         return self.node_item(self._parse_val(socket_in.default_value))
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -310,7 +310,14 @@ class NodeParser:
     # Child classes should use them to do their export
     def get_output_default(self):
         """ Returns default value of output socket """
-        socket_out = self.node.outputs[self.out_key]
+        if self.out_key:
+            assert self.out_key in self.node.inputs, f"no output socket '{self.out_key}' found in {self}"
+            socket_out = self.node.outputs[self.out_key]
+        elif len(self.node.outputs) > 0:
+            socket_out = self.node.outputs[0]
+        else:
+            raise IndexError(f"[{self}] no output sockets found")
+
         return self.node_item(self._parse_val(socket_out.default_value))
 
     def get_input_default(self, in_key):

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -321,7 +321,6 @@ class NodeParser:
     def get_input_default(self, in_key):
         """ Returns default value of input socket """
 
-        assert in_key in self.node.inputs, f"no input socket '{in_key}' found in {self}"
         socket_in = self.node.inputs[in_key]
         return self.node_item(self._parse_val(socket_in.default_value))
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -283,7 +283,7 @@ class NodeParser:
         # getting corresponded NodeParser class
         NodeParser_cls = self.get_node_parser_cls(node.bl_idname)
         if NodeParser_cls:
-            node_parser = NodeParser_cls(self.id, self.doc, self.material, node, out_key,
+            node_parser = NodeParser_cls(self.id, self.doc, self.material, node, self.object, out_key,
                                          group_nodes, **self.kwargs)
             return node_parser.export()
 
@@ -314,13 +314,7 @@ class NodeParser:
     # Child classes should use them to do their export
     def get_output_default(self):
         """ Returns default value of output socket """
-        if self.out_key:
-            assert self.out_key in self.node.inputs, f"no output socket '{self.out_key}' found in {self}"
-            socket_out = self.node.outputs[self.out_key]
-        elif len(self.node.outputs) > 0:
-            socket_out = self.node.outputs[0]
-        else:
-            raise IndexError(f"[{self}] no output sockets found")
+        socket_out = self.node.outputs[self.out_key]
 
         return self.node_item(self._parse_val(socket_out.default_value))
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -344,8 +344,9 @@ class NodeParser:
         link = socket_in.links[0]
 
         # # check if linked is correct
-        # if not self.is_link_allowed(link):
-        #     raise MaterialError("Invalid link found", link, socket_in, self.node, self.material)
+        if not link.is_valid:
+            log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
+            return None
 
         return self._export_node(link.from_node, link.from_socket.identifier)
 

--- a/src/hdusd/bl_nodes/nodes/__init__.py
+++ b/src/hdusd/bl_nodes/nodes/__init__.py
@@ -12,6 +12,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+from ...utils import logging
+log = logging.Log("bl_nodes.nodes")
+
 from .output import *
 from .shader import *
 from .texture import *

--- a/src/hdusd/bl_nodes/nodes/color.py
+++ b/src/hdusd/bl_nodes/nodes/color.py
@@ -1,0 +1,87 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from ..node_parser import NodeParser
+from . import log
+
+
+class ShaderNodeInvert(NodeParser):
+    def export(self):
+        fac = self.get_input_value('Fac')
+        color = self.get_input_value('Color')
+
+        return fac.blend(color, 1.0 - color)
+
+
+class ShaderNodeMixRGB(NodeParser):
+
+    def export(self):
+        fac = self.get_input_value('Fac')
+        color1 = self.get_input_value('Color1')
+        color2 = self.get_input_value('Color2')
+
+        # these mix types are copied from cycles OSL
+        blend_type = self.node.blend_type
+
+        if blend_type in ('MIX', 'COLOR'):
+            res = fac.blend(color1, color2)
+
+        elif blend_type == 'ADD':
+            res = fac.blend(color1, color1 + color2)
+
+        elif blend_type == 'MULTIPLY':
+            res = fac.blend(color1, color1 * color2)
+
+        elif blend_type == 'SUBTRACT':
+            res = fac.blend(color1, color1 - color2)
+
+        elif blend_type == 'DIVIDE':
+            res = fac.blend(color1, color1 / color2)
+
+        elif blend_type == 'DIFFERENCE':
+            res = fac.blend(color1, abs(color1 - color2))
+
+        elif blend_type == 'DARKEN':
+            res = fac.blend(color1, color1.min(color2))
+
+        elif blend_type == 'LIGHTEN':
+            res = fac.blend(color1, color1.max(color2))
+
+        elif blend_type == 'VALUE':
+            res = color1
+
+        elif blend_type == 'SCREEN':
+            tm = 1.0 - fac
+            res = 1.0 - (tm + fac * (1.0 - color2)) * (1.0 - color1)
+
+        elif blend_type == 'SOFT_LIGHT':
+            tm = 1.0 - fac
+            scr = 1.0 - (1.0 - color2) * (1.0 - color1)
+            res = tm * color1 + fac * ((1.0 - color1) * color2 * color1 + color1 * scr)
+
+        elif blend_type == 'LINEAR_LIGHT':
+            test_val = color2 > 0.5
+            res = test_val.if_else(color1 + fac * (2.0 * (color2 - 0.5)),
+                                   color1 + fac * (2.0 * color2 - 1.0))
+
+        else:
+            # TODO: support operations SATURATION, HUE, SCREEN, BURN, OVERLAY
+            log.warn("Ignoring unsupported Blend Type", blend_type, self.node, self.material,
+                     "mix will be used")
+            res = fac.blend(color1, color2)
+
+        if self.node.use_clamp:
+            res = res.clamp()
+
+        return res

--- a/src/hdusd/bl_nodes/nodes/converter.py
+++ b/src/hdusd/bl_nodes/nodes/converter.py
@@ -1,0 +1,82 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from ..node_parser import NodeParser
+from . import log
+
+
+class ShaderNodeMath(NodeParser):
+    """ Map Blender operations to MaterialX definitions, see the stdlib_defs.mtlx in MaterialX """
+
+    def export(self):
+        op = self.node.operation
+        in1 = self.get_input_value(0)
+        # single operand operations
+        if op == 'SINE':
+            res = in1.sin()
+        elif op == 'COSINE':
+            res = in1.cos()
+        elif op == 'TANGENT':
+            res = in1.tan()
+        elif op == 'ARCSINE':
+            res = in1.asin()
+        elif op == 'ARCCOSINE':
+            res = in1.acos()
+        elif op == 'ARCTANGENT':
+            res = in1.atan()
+        elif op == 'LOGARITHM':
+            res = in1.log()
+        elif op == 'ABSOLUTE':
+            res = abs(in1)
+        elif op == 'FLOOR':
+            res = in1.floor()
+        elif op == 'FRACT':
+            res = in1 % 1.0
+        elif op == 'CEIL':
+            res = in1.ceil()
+        elif op == 'ROUND':
+            f = in1.floor()
+            res = (in1 % 1.0 < 0.5).if_else(f, f + 1.0)
+
+        else:  # 2-operand operations
+            in2 = self.get_input_value(1)
+
+            if op == 'ADD':
+                res = in1 + in2
+            elif op == 'SUBTRACT':
+                res = in1 - in2
+            elif op == 'MULTIPLY':
+                res = in1 * in2
+            elif op == 'DIVIDE':
+                res = in1 / in2
+            elif op == 'POWER':
+                res = in1 ** in2
+            elif op == 'MINIMUM':
+                res = in1.min(in2)
+            elif op == 'MAXIMUM':
+                res = in1.max(in2)
+
+            else:
+                in3 = self.get_input_value(2)
+
+                if op == 'MULTIPLY_ADD':
+                    res = in1 * in2 + in3
+                else:
+                    log.warn("Unsupported math operation", op)
+                    return None
+
+        if self.node.use_clamp:
+            res = res.clamp()
+
+        return res

--- a/src/hdusd/bl_nodes/nodes/input.py
+++ b/src/hdusd/bl_nodes/nodes/input.py
@@ -12,12 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from ...utils import logging
-log = logging.Log("bl_nodes.nodes")
+import os
 
-from .input import *
-from .output import *
-from .shader import *
-from .texture import *
-from .color import *
-from .converter import *
+from ..node_parser import NodeParser
+from . import log
+
+
+class ShaderNodeValue(NodeParser):
+    """ Returns float value """
+
+    def export(self):
+        return self.get_output_default()
+
+
+class ShaderNodeRGB(NodeParser):
+    """ Returns color value """
+
+    def export(self):
+        return self.get_output_default()

--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -25,8 +25,6 @@ class ShaderNodeOutputMaterial(NodeParser):
         if surface is None:
             return None
 
-        log.info(f"[{self.material}] surface: {surface}")
-
         if surface.type == 'BSDF':
             surface = self.create_node('surface', 'surfaceshader', {
                 'bsdf': surface,

--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -23,6 +23,8 @@ class ShaderNodeOutputMaterial(NodeParser):
     def export(self):
         surface = self.get_input_link('Surface')
 
+        log.info(f"[{self.material}] surface: {surface}")
+
         if surface.type == 'BSDF':
             surface = self.create_node('surface', 'surfaceshader', {
                 'bsdf': surface,

--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -22,6 +22,8 @@ class ShaderNodeOutputMaterial(NodeParser):
 
     def export(self):
         surface = self.get_input_link('Surface')
+        if surface is None:
+            return None
 
         log.info(f"[{self.material}] surface: {surface}")
 

--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 from ..node_parser import NodeParser, Id
+from . import log
 
 
 class ShaderNodeOutputMaterial(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -15,27 +15,7 @@
 import math
 
 from ..node_parser import NodeParser
-from ...utils import logging
-log = logging.Log(tag='export.bl_nodes.nodes')
-
-
-# INPUTS
-
-class ShaderNodeValue(NodeParser):
-    """ simply return val """
-
-    def export(self):
-        return self.get_output_default()
-
-
-class ShaderNodeRGB(NodeParser):
-    """ simply return val """
-
-    def export(self):
-        return self.get_output_default()
-
-
-# TEXTURES
+from . import log
 
 
 # SHADERS
@@ -226,147 +206,6 @@ class ShaderNodeEmission(NodeParser):
         return result
 
 
-# COLOR
-
-class ShaderNodeInvert(NodeParser):
-    def export(self):
-        fac = self.get_input_value('Fac')
-        color = self.get_input_value('Color')
-
-        return fac.blend(color, 1.0 - color)
-
-
-class ShaderNodeMixRGB(NodeParser):
-
-    def export(self):
-        fac = self.get_input_value('Fac')
-        color1 = self.get_input_value('Color1')
-        color2 = self.get_input_value('Color2')
-
-        # these mix types are copied from cycles OSL
-        blend_type = self.node.blend_type
-
-        if blend_type in ('MIX', 'COLOR'):
-            res = fac.blend(color1, color2)
-
-        elif blend_type == 'ADD':
-            res = fac.blend(color1, color1 + color2)
-
-        elif blend_type == 'MULTIPLY':
-            res = fac.blend(color1, color1 * color2)
-
-        elif blend_type == 'SUBTRACT':
-            res = fac.blend(color1, color1 - color2)
-
-        elif blend_type == 'DIVIDE':
-            res = fac.blend(color1, color1 / color2)
-
-        elif blend_type == 'DIFFERENCE':
-            res = fac.blend(color1, abs(color1 - color2))
-
-        elif blend_type == 'DARKEN':
-            res = fac.blend(color1, color1.min(color2))
-
-        elif blend_type == 'LIGHTEN':
-            res = fac.blend(color1, color1.max(color2))
-
-        elif blend_type == 'VALUE':
-            res = color1
-
-        elif blend_type == 'SCREEN':
-            tm = 1.0 - fac
-            res = 1.0 - (tm + fac * (1.0 - color2)) * (1.0 - color1)
-
-        elif blend_type == 'SOFT_LIGHT':
-            tm = 1.0 - fac
-            scr = 1.0 - (1.0 - color2) * (1.0 - color1)
-            res = tm * color1 + fac * ((1.0 - color1) * color2 * color1 + color1 * scr)
-
-        elif blend_type == 'LINEAR_LIGHT':
-            test_val = color2 > 0.5
-            res = test_val.if_else(color1 + fac * (2.0 * (color2 - 0.5)),
-                                   color1 + fac * (2.0 * color2 - 1.0))
-
-        else:
-            # TODO: support operations SATURATION, HUE, SCREEN, BURN, OVERLAY
-            log.warn("Ignoring unsupported Blend Type", blend_type, self.node, self.material,
-                     "mix will be used")
-            res = fac.blend(color1, color2)
-
-        if self.node.use_clamp:
-            res = res.clamp()
-
-        return res
-
-
-# CONVERTER
-
-class ShaderNodeMath(NodeParser):
-    """ Map Blender operations to MaterialX definitions, see the stdlib_defs.mtlx in MaterialX """
-
-    def export(self):
-        op = self.node.operation
-        in1 = self.get_input_value(0)
-        # single operand operations
-        if op == 'SINE':
-            res = in1.sin()
-        elif op == 'COSINE':
-            res = in1.cos()
-        elif op == 'TANGENT':
-            res = in1.tan()
-        elif op == 'ARCSINE':
-            res = in1.asin()
-        elif op == 'ARCCOSINE':
-            res = in1.acos()
-        elif op == 'ARCTANGENT':
-            res = in1.atan()
-        elif op == 'LOGARITHM':
-            res = in1.log()
-        elif op == 'ABSOLUTE':
-            res = abs(in1)
-        elif op == 'FLOOR':
-            res = in1.floor()
-        elif op == 'FRACT':
-            res = in1 % 1.0
-        elif op == 'CEIL':
-            res = in1.ceil()
-        elif op == 'ROUND':
-            f = in1.floor()
-            res = (in1 % 1.0 < 0.5).if_else(f, f + 1.0)
-
-        else:  # 2-operand operations
-            in2 = self.get_input_value(1)
-
-            if op == 'ADD':
-                res = in1 + in2
-            elif op == 'SUBTRACT':
-                res = in1 - in2
-            elif op == 'MULTIPLY':
-                res = in1 * in2
-            elif op == 'DIVIDE':
-                res = in1 / in2
-            elif op == 'POWER':
-                res = in1 ** in2
-            elif op == 'MINIMUM':
-                res = in1.min(in2)
-            elif op == 'MAXIMUM':
-                res = in1.max(in2)
-
-            else:
-                in3 = self.get_input_value(2)
-
-                if op == 'MULTIPLY_ADD':
-                    res = in1 * in2 + in3
-                else:
-                    log.warn("Unsupported math operation", op)
-                    return None
-
-        if self.node.use_clamp:
-            res = res.clamp()
-
-        return res
-
-
 class ShaderNodeMixShader(NodeParser):
 
     def export(self):
@@ -383,7 +222,7 @@ class ShaderNodeMixShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('mix_bsdf', 'surfaceshader', {
+        result = self.create_node('mix', 'BSDF', {
             'fg': shader1,
             'bg': shader2,
             'mix': factor
@@ -409,7 +248,7 @@ class ShaderNodeAddShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('add_bsdf', 'surfaceshader', {
+        result = self.create_node('add', 'BSDF', {
             'in1': shader1,
             'in2': shader2
         })

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -228,6 +228,69 @@ class ShaderNodeEmission(NodeParser):
 
 # COLOR
 
+class ShaderNodeMixRGB(NodeParser):
+
+    def export(self):
+        fac = self.get_input_value('Fac')
+        color1 = self.get_input_value('Color1')
+        color2 = self.get_input_value('Color2')
+
+        # these mix types are copied from cycles OSL
+        blend_type = self.node.blend_type
+
+        if blend_type in ('MIX', 'COLOR'):
+            res = fac.blend(color1, color2)
+
+        elif blend_type == 'ADD':
+            res = fac.blend(color1, color1 + color2)
+
+        elif blend_type == 'MULTIPLY':
+            res = fac.blend(color1, color1 * color2)
+
+        elif blend_type == 'SUBTRACT':
+            res = fac.blend(color1, color1 - color2)
+
+        elif blend_type == 'DIVIDE':
+            res = fac.blend(color1, color1 / color2)
+
+        elif blend_type == 'DIFFERENCE':
+            res = fac.blend(color1, abs(color1 - color2))
+
+        elif blend_type == 'DARKEN':
+            res = fac.blend(color1, color1.min(color2))
+
+        elif blend_type == 'LIGHTEN':
+            res = fac.blend(color1, color1.max(color2))
+
+        elif blend_type == 'VALUE':
+            res = color1
+
+        elif blend_type == 'SCREEN':
+            tm = 1.0 - fac
+            res = 1.0 - (tm + fac * (1.0 - color2)) * (1.0 - color1)
+
+        elif blend_type == 'SOFT_LIGHT':
+            tm = 1.0 - fac
+            scr = 1.0 - (1.0 - color2) * (1.0 - color1)
+            res = tm * color1 + fac * ((1.0 - color1) * color2 * color1 + color1 * scr)
+
+        elif blend_type == 'LINEAR_LIGHT':
+            test_val = color2 > 0.5
+            res = test_val.if_else(color1 + fac * (2.0 * (color2 - 0.5)),
+                                   color1 + fac * (2.0 * color2 - 1.0))
+
+        else:
+            # TODO: support operations SATURATION, HUE, SCREEN, BURN, OVERLAY
+            log.warn("Ignoring unsupported Blend Type", blend_type, self.node, self.material,
+                     "mix will be used")
+            res = fac.blend(color1, color2)
+
+        if self.node.use_clamp:
+            res = res.clamp()
+
+        return res
+
+
 # CONVERTER
 
 class ShaderNodeMath(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -197,50 +197,66 @@ class ShaderNodeMath(NodeParser):
     """ Map Blender operations to MaterialX definitions, see the stdlib_defs.mtlx in MaterialX """
 
     def export(self):
-        result = None
-        node_name = ''
-        node_type = ''
-        node_data = {}
-
         op = self.node.operation
         in1 = self.get_input_value(0)
-        in2 = None
-        in3 = None
-        in1_type = ''
-        operands_type = ''
-        in2_type = ''
-        in3_type = ''
-        if in1:
-            log.info(f"in1.data: {in1.data}; {type(in1)}")
-            if isinstance(in1.data, float):
-                operands_type = 'float'
-            elif isinstance(in1.data, tuple):
-                if len(in1.data) == 2:
-                    operands_type = 'vector2'
-                elif len(in1.data) == 3:
-                    operands_type = 'vector3'
-                elif len(in1.data) == 4:
-                    operands_type = 'vector4'
-            in2 = self.get_input_value(0)
-        log.info(f"operatands_type = {operands_type}")
+        # single operand operations
+        if op == 'SINE':
+            res = in1.sin()
+        elif op == 'COSINE':
+            res = in1.cos()
+        elif op == 'TANGENT':
+            res = in1.tan()
+        elif op == 'ARCSINE':
+            res = in1.asin()
+        elif op == 'ARCCOSINE':
+            res = in1.acos()
+        elif op == 'ARCTANGENT':
+            res = in1.atan()
+        elif op == 'LOGARITHM':
+            res = in1.log()
+        elif op == 'ABSOLUTE':
+            res = abs(in1)
+        elif op == 'FLOOR':
+            res = in1.floor()
+        elif op == 'FRACT':
+            res = in1 % 1.0
+        elif op == 'CEIL':
+            res = in1.ceil()
+        elif op == 'ROUND':
+            f = in1.floor()
+            res = (in1 % 1.0 < 0.5).if_else(f, f + 1.0)
 
-        if op == 'ADD':
-            node_name = 'add'
-            node_type = 'surfaceshader'
-            node_data = {
-                'in1': in1,
-                'in2': in2,
-            }
+        else:  # 2-operand operations
+            in2 = self.get_input_value(1)
 
-        if node_name and node_type:
-            node_name = f"{node_name}_{operands_type}"
-            node_type = operands_type
-            result = self.create_node(node_name, node_type, node_data)
+            if op == 'ADD':
+                res = in1 + in2
+            elif op == 'SUBTRACT':
+                res = in1 - in2
+            elif op == 'MULTIPLY':
+                res = in1 * in2
+            elif op == 'DIVIDE':
+                res = in1 / in2
+            elif op == 'POWER':
+                res = in1 ** in2
+            elif op == 'MINIMUM':
+                res = in1.min(in2)
+            elif op == 'MAXIMUM':
+                res = in1.max(in2)
 
-        log.info(f"node_name {node_name}; node_type {node_type}")
-        log.info(f"result {result}")
+            else:
+                in3 = self.get_input_value(2)
 
-        return result
+                if op == 'MULTIPLY_ADD':
+                    res = in1 * in2 + in3
+                else:
+                    log.warn("Unsupported math operation", op)
+                    return None
+
+        if self.node.use_clamp:
+            res = res.clamp()
+
+        return res
 
 
 class ShaderNodeMixShader(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -214,6 +214,22 @@ class ShaderNodeBsdfGlass(NodeParser):
         return result
 
 
+class ShaderNodeEmission(NodeParser):
+    def export(self):
+        color = self.get_input_value('Color')
+        strength = self.get_input_value('Strength')
+
+        result = self.create_node('uniform_edf', 'EDF', {
+            'color': color * strength,
+        })
+
+        return result
+
+
+# COLOR
+
+# CONVERTER
+
 class ShaderNodeMath(NodeParser):
     """ Map Blender operations to MaterialX definitions, see the stdlib_defs.mtlx in MaterialX """
 
@@ -326,16 +342,4 @@ class ShaderNodeAddShader(NodeParser):
             'in1': shader1,
             'in2': shader2
         })
-        return result
-
-
-class ShaderNodeEmission(NodeParser):
-    def export(self):
-        color = self.get_input_value('Color')
-        strength = self.get_input_value('Strength')
-
-        result = self.create_node('uniform_edf', 'EDF', {
-            'color': color * strength,
-        })
-
         return result

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -259,9 +259,9 @@ class ShaderNodeMixShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('mix_shader', 'ND_mix_bsdf', {
-            'in1': shader1,
-            'in2': shader2,
+        result = self.create_node('mix_bsdf', 'surfaceshader', {
+            'fg': shader1,
+            'bg': shader2,
             'mix': factor
         })
         return result
@@ -282,7 +282,7 @@ class ShaderNodeAddShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('mix_shader', 'ND_add_bsdf', {
+        result = self.create_node('add_bsdf', 'surfaceshader', {
             'in1': shader1,
             'in2': shader2
         })

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -273,6 +273,9 @@ class ShaderNodeAddShader(NodeParser):
         shader1 = self.get_input_link(0)
         shader2 = self.get_input_link(1)
 
+        log.info(f"shader1 {shader1}")
+        log.info(f"shader2 {shader2}")
+
         if shader1 is None and shader2 is None:
             return None
 

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -15,6 +15,8 @@
 import math
 
 from ..node_parser import NodeParser
+from ...utils import logging
+log = logging.Log(tag='export.bl_nodes.nodes')
 
 
 class ShaderNodeBsdfPrincipled(NodeParser):
@@ -161,6 +163,31 @@ class ShaderNodeBsdfDiffuse(NodeParser):
             'color': color,
             'roughness': roughness,
             'normal': normal,
+        })
+
+        return result
+
+
+class ShaderNodeBsdfGlass(NodeParser):
+    def export(self):
+        color = self.get_input_value('Color')
+        roughness = self.get_input_value('Roughness')
+        ior = self.get_input_value('IOR')
+        normal = self.get_input_link('Normal')
+
+        # CREATING STANDARD SURFACE
+        result = self.create_node('standard_surface', 'surfaceshader', {
+            'base': 0.0,
+            'normal': normal,
+            'specular': 1.0,
+            'specular_color': color,
+            'specular_roughness': roughness,
+            'specular_IOR': ior,
+            'specular_anisotropy': 0.0,
+            'specular_rotation': 0.0,
+            'transmission': 1.0,
+            'transmission_color': color,
+            'transmission_extra_roughness': roughness,
         })
 
         return result

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -236,9 +236,6 @@ class ShaderNodeAddShader(NodeParser):
         shader1 = self.get_input_link(0)
         shader2 = self.get_input_link(1)
 
-        log.info(f"shader1 {shader1}")
-        log.info(f"shader2 {shader2}")
-
         if shader1 is None and shader2 is None:
             return None
 

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -193,6 +193,56 @@ class ShaderNodeBsdfGlass(NodeParser):
         return result
 
 
+class ShaderNodeMath(NodeParser):
+    """ Map Blender operations to MaterialX definitions, see the stdlib_defs.mtlx in MaterialX """
+
+    def export(self):
+        result = None
+        node_name = ''
+        node_type = ''
+        node_data = {}
+
+        op = self.node.operation
+        in1 = self.get_input_value(0)
+        in2 = None
+        in3 = None
+        in1_type = ''
+        operands_type = ''
+        in2_type = ''
+        in3_type = ''
+        if in1:
+            log.info(f"in1.data: {in1.data}; {type(in1)}")
+            if isinstance(in1.data, float):
+                operands_type = 'float'
+            elif isinstance(in1.data, tuple):
+                if len(in1.data) == 2:
+                    operands_type = 'vector2'
+                elif len(in1.data) == 3:
+                    operands_type = 'vector3'
+                elif len(in1.data) == 4:
+                    operands_type = 'vector4'
+            in2 = self.get_input_value(0)
+        log.info(f"operatands_type = {operands_type}")
+
+        if op == 'ADD':
+            node_name = 'add'
+            node_type = 'surfaceshader'
+            node_data = {
+                'in1': in1,
+                'in2': in2,
+            }
+
+        if node_name and node_type:
+            node_name = f"{node_name}_{operands_type}"
+            node_type = operands_type
+            result = self.create_node(node_name, node_type, node_data)
+
+        log.info(f"node_name {node_name}; node_type {node_type}")
+        log.info(f"result {result}")
+
+        return result
+
+
 class ShaderNodeMixShader(NodeParser):
 
     def export(self):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -228,6 +228,14 @@ class ShaderNodeEmission(NodeParser):
 
 # COLOR
 
+class ShaderNodeInvert(NodeParser):
+    def export(self):
+        fac = self.get_input_value('Fac')
+        color = self.get_input_value('Color')
+
+        return fac.blend(color, 1.0 - color)
+
+
 class ShaderNodeMixRGB(NodeParser):
 
     def export(self):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -19,6 +19,27 @@ from ...utils import logging
 log = logging.Log(tag='export.bl_nodes.nodes')
 
 
+# INPUTS
+
+class ShaderNodeValue(NodeParser):
+    """ simply return val """
+
+    def export(self):
+        return self.get_output_default()
+
+
+class ShaderNodeRGB(NodeParser):
+    """ simply return val """
+
+    def export(self):
+        return self.get_output_default()
+
+
+# TEXTURES
+
+
+# SHADERS
+
 class ShaderNodeBsdfPrincipled(NodeParser):
     def export(self):
         def enabled(val):

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -193,6 +193,52 @@ class ShaderNodeBsdfGlass(NodeParser):
         return result
 
 
+class ShaderNodeMixShader(NodeParser):
+
+    def export(self):
+        factor = self.get_input_value(0)
+        shader1 = self.get_input_link(1)
+        shader2 = self.get_input_link(2)
+
+        if shader1 is None and shader2 is None:
+            return None
+
+        if shader1 is None:
+            return shader2
+
+        if shader2 is None:
+            return shader1
+
+        result = self.create_node('mix_shader', 'ND_mix_bsdf', {
+            'in1': shader1,
+            'in2': shader2,
+            'mix': factor
+        })
+        return result
+
+
+class ShaderNodeAddShader(NodeParser):
+
+    def export(self):
+        shader1 = self.get_input_link(0)
+        shader2 = self.get_input_link(1)
+
+        if shader1 is None and shader2 is None:
+            return None
+
+        if shader1 is None:
+            return shader2
+
+        if shader2 is None:
+            return shader1
+
+        result = self.create_node('mix_shader', 'ND_add_bsdf', {
+            'in1': shader1,
+            'in2': shader2
+        })
+        return result
+
+
 class ShaderNodeEmission(NodeParser):
     def export(self):
         color = self.get_input_value('Color')

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -63,7 +63,7 @@ class Engine:
             try:
                 object.sync(objects_prim, obj, **kwargs)
             except Exception as e:
-                log.error(e)
+                log.error(e, 'EXCEPTION:', traceback.format_exc())
 
         world.sync(root_prim, depsgraph.scene.world, **kwargs)
 

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -96,7 +96,7 @@ class FinalEngine(Engine):
 
         draw_target.Unbind()
 
-        # its important to clear data explicitly
+        # it's important to clear data explicitly
         draw_target = None
         renderer = None
 

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -208,8 +208,11 @@ def sync_as_mx(materials_prim, mat, obj):
 
     mx_file = utils.get_temp_file(".mtlx")
     mx.writeToXmlFile(doc, str(mx_file))
-    surfacematerial = next(node for node in doc.getNodes()
-                           if node.getCategory() == 'surfacematerial')
+    surfacematerial = next((node for node in doc.getNodes()
+                           if node.getCategory() == 'surfacematerial'), None)
+    if surfacematerial is None:
+        log.warn(f"No valid Surface shader found for material {mat.name}")
+        return None
 
     stage = materials_prim.GetStage()
     mat_path = f"{materials_prim.GetPath()}/{sdf_name(mat)}"

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -69,9 +69,19 @@ def get_node_def_cls(node_name, nd_type):
         return node_def_cls
 
     nd_name = f"ND_{node_name}"
-    return next(cls for cls in mx_nodedef_classes if cls.__name__.endswith(nd_name))
+    node_def_cls = next((cls for cls in mx_nodedef_classes if cls.__name__.endswith(nd_name)), None)
+
+    if node_def_cls:
+        return node_def_cls
+
+    raise KeyError("Unable to find MaterialX nodedef class", node_name, nd_type)
 
 
 def get_mx_node_cls(node_name, nd_type):
-    return next(cls for cls in mx_node_classes if cls.__name__.endswith(node_name) and
-                nd_type in cls._data_types)
+    node_cls = next((cls for cls in mx_node_classes if cls.__name__.endswith(node_name) and
+                nd_type in cls._data_types),
+                None)
+    if node_cls:
+        return node_cls
+
+    raise KeyError("Unable to find MaterialX node class", node_name, nd_type)

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -38,6 +38,7 @@ class MaterialProperties(HdUSDProperties):
         material = self.id_data
         output_node = next((node for node in material.node_tree.nodes if
                             node.bl_idname == ShaderNodeOutputMaterial.__name__ and node.is_active_output), None)
+        log.info(f"[{material}] output_node: {output_node}")
 
         if not output_node:
             return None

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -20,6 +20,10 @@ from ..mx_nodes.node_tree import MxNodeTree
 from ..bl_nodes.nodes import ShaderNodeOutputMaterial
 
 
+from ..utils import logging
+log = logging.Log(tag='export.material')
+
+
 class MaterialProperties(HdUSDProperties):
     bl_type = bpy.types.Material
 

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -38,7 +38,6 @@ class MaterialProperties(HdUSDProperties):
         material = self.id_data
         output_node = next((node for node in material.node_tree.nodes if
                             node.bl_idname == ShaderNodeOutputMaterial.__name__ and node.is_active_output), None)
-        log.info(f"[{material}] output_node: {output_node}")
 
         if not output_node:
             return None


### PR DESCRIPTION
### PURPOSE
Added export as MaterialX for Blender nodes Invert, MixRGB, Math, Glass BSDF, Value, RGB.

### EFFECT OF CHANGE
- added export as MaterialX for Blender nodes Invert, MixRGB, Math, Glass BSDF, Value, RGB.

### TECHNICAL STEPS
- added more arithmetic helper operations using MaterialX;
- used arithmetic helper for MixRGB, Invert and Math nodes;
- added newly supported nodes to nodes menu;
- enabled check for node link validity to prevent loops parsing;
- added better errors logging for nodes parsing;
- fixed output socket parsing issue.

### NOTES FOR REVIEWERS
Textures requires additional work, will be added as a separate pull request