### PR TITLE
RPRBLND-1697: Use the "flattened" USD stage rather than one with merge nodes etc

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -47,10 +47,7 @@ class Engine:
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
 
-        root_prim = stage.DefinePrim(f"/{sdf_path(depsgraph.scene.name)}")
-        stage.SetDefaultPrim(root_prim)
-
-        objects_prim = stage.DefinePrim(f"{root_prim.GetPath()}/objects")
+        root_prim = stage.GetPseudoRoot()
 
         objects_len = len(depsgraph.objects)
         for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights)):
@@ -61,7 +58,7 @@ class Engine:
                 sync_callback(f"Syncing object {i}/{objects_len}: {obj.name}")
 
             try:
-                object.sync(objects_prim, obj, **kwargs)
+                object.sync(root_prim, obj, **kwargs)
             except Exception as e:
                 log.error(e)
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -231,8 +231,7 @@ class ViewportEngine(Engine):
     def _sync_update_blend(self, context, depsgraph):
         scene = depsgraph.scene
 
-        root_prim = self.stage.GetPrimAtPath(f"/{sdf_path(scene.name)}")
-        objects_prim = root_prim.GetChild("objects")
+        root_prim = self.stage.GetPseudoRoot()
 
         # get supported updates and sort by priorities
         updates = []
@@ -268,7 +267,7 @@ class ViewportEngine(Engine):
                 if obj.type == 'LIGHT' and not self.shading_data.use_scene_lights:
                     continue
 
-                object.sync_update(objects_prim, obj,
+                object.sync_update(root_prim, obj,
                                    update.is_updated_geometry,
                                    update.is_updated_transform,
                                    is_gl_delegate=self.is_gl_delegate)

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -34,7 +34,7 @@ def sync(objects_prim, obj: bpy.types.Object, **kwargs):
     log("sync", obj, obj.type)
 
     stage = objects_prim.GetStage()
-    xform = UsdGeom.Xform.Define(stage, f"{objects_prim.GetPath()}/{sdf_name(obj)}")
+    xform = UsdGeom.Xform.Define(stage, objects_prim.GetPath().AppendChild(sdf_name(obj)))
     obj_prim = xform.GetPrim()
 
     # setting transform

--- a/src/hdusd/export/world.py
+++ b/src/hdusd/export/world.py
@@ -131,11 +131,10 @@ def sync(root_prim, world: bpy.types.World, **kwargs):
         return
 
     # create Dome light
-    xform = UsdGeom.Xform.Define(stage, f"{root_prim.GetPath()}/_world")
+    xform = UsdGeom.Xform.Define(stage, root_prim.GetPath().AppendChild("_world"))
     obj_prim = xform.GetPrim()
 
-    usd_light = UsdLux.DomeLight.Define(
-        stage, f"{obj_prim.GetPath()}/_world/{sdf_path(world.name)}")
+    usd_light = UsdLux.DomeLight.Define(stage, obj_prim.GetPath().AppendChild(sdf_path(world.name)))
     usd_light.ClearXformOpOrder()
     usd_light.OrientToStageUpAxis()
 

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -88,7 +88,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if node.bl_idname == 'usd.BlenderDataNode':
+            if hasattr(node, 'depsgraph_update'):
                 node.depsgraph_update(depsgraph)
 
     def add_basic_nodes(self, source='SCENE'):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -88,7 +88,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if node.bl_idname == 'usd.ReadBlendDataNode':
+            if node.bl_idname == 'usd.BlenderDataNode':
                 node.depsgraph_update(depsgraph)
 
     def add_basic_nodes(self, source='SCENE'):
@@ -96,9 +96,9 @@ class USDTree(bpy.types.ShaderNodeTree):
         self.nodes.clear()
 
         if source == 'USD_FILE':
-            input_node = self.nodes.new("usd.ReadUsdFileNode")
+            input_node = self.nodes.new("usd.UsdFileNode")
         else:  # default 'SCENE'
-            input_node = self.nodes.new("usd.ReadBlendDataNode")
+            input_node = self.nodes.new("usd.BlenderDataNode")
         input_node.location = (input_node.location[0] - 125, input_node.location[1])
 
         hydra_output = self.nodes.new("usd.HydraRenderNode")

--- a/src/hdusd/usd_nodes/nodes/__init__.py
+++ b/src/hdusd/usd_nodes/nodes/__init__.py
@@ -19,7 +19,7 @@ from .. import log
 
 # classes to register
 from . import (
-    read_usd_file, read_blend_data, write_file, merge, print_file, filter, usd_to_blender,
+    usd_file, blender_data, write_file, merge, print_file, filter, usd_to_blender,
     hydra_render, rpr_render_settings
 )
 
@@ -32,8 +32,8 @@ class USDNodeCategory(NodeCategory):
 
 node_categories = [
     USDNodeCategory('HdUSD_USD_INPUT', "Input", items=[
-        NodeItem('usd.ReadBlendDataNode'),
-        NodeItem('usd.ReadUsdFileNode'),
+        NodeItem('usd.BlenderDataNode'),
+        NodeItem('usd.UsdFileNode'),
     ]),
     USDNodeCategory('HdUSD_USD_OUTPUT', 'Output', items=[
         NodeItem('usd.HydraRenderNode'),
@@ -48,8 +48,8 @@ node_categories = [
 
 # nodes to register
 register_nodes, unregister_nodes = bpy.utils.register_classes_factory([
-    read_blend_data.ReadBlendDataNode,
-    read_usd_file.ReadUsdFileNode,
+    blender_data.BlenderDataNode,
+    usd_file.UsdFileNode,
     write_file.WriteFileNode,
     merge.MergeNode,
     # print_file.PrintFileNode,

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -38,12 +38,6 @@ class BlenderDataNode(USDNode):
         self._export_depsgraph(stage, depsgraph)
         self.hdusd.usd_list.update_items()
 
-    root_prim_name: bpy.props.StringProperty(
-        name="Root",
-        description="Name of Root prim",
-        default="",
-        update=update_export_data
-    )
     export_type: bpy.props.EnumProperty(
         name="Data",
         description="Blender Data to read",
@@ -68,8 +62,6 @@ class BlenderDataNode(USDNode):
     )
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'root_prim_name')
-
         col = layout.column(align=True)
         col.prop(self, 'export_type')
         if self.export_type == 'COLLECTION':
@@ -98,11 +90,7 @@ class BlenderDataNode(USDNode):
             self.hdusd.usd_list.update_items()
 
     def _export_depsgraph(self, stage, depsgraph):
-        if self.root_prim_name:
-            objects_prim = stage.DefinePrim(f"/{self.root_prim_name}")
-            stage.SetDefaultPrim(objects_prim)
-        else:
-            objects_prim = stage.GetPseudoRoot()
+        objects_prim = stage.GetPseudoRoot()
 
         if self.export_type == 'SCENE':
             for obj in depsgraph_objects(depsgraph):
@@ -127,10 +115,7 @@ class BlenderDataNode(USDNode):
     def _update_depsgraph(self, stage, depsgraph):
         ret = False
 
-        if self.root_prim_name:
-            objects_prim = stage.GetDefaultPrim()
-        else:
-            objects_prim = stage.GetPseudoRoot()
+        objects_prim = stage.GetPseudoRoot()
 
         for update in depsgraph.updates:
             if isinstance(update.id, bpy.types.Object):

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -22,10 +22,10 @@ from ...utils import depsgraph_objects
 from . import log
 
 
-class ReadBlendDataNode(USDNode):
+class BlenderDataNode(USDNode):
     """Blender data to USD can export whole scene, one collection or object"""
-    bl_idname = 'usd.ReadBlendDataNode'
-    bl_label = "Read Blend Data"
+    bl_idname = 'usd.BlenderDataNode'
+    bl_label = "Blender Data"
 
     input_names = ()
 

--- a/src/hdusd/usd_nodes/nodes/filter.py
+++ b/src/hdusd/usd_nodes/nodes/filter.py
@@ -48,7 +48,6 @@ class FilterNode(USDNode):
         layout.prop(self, 'filter_path')
 
     def compute(self, **kwargs):
-
         input_stage = self.get_input_link('Input', **kwargs)
         if not input_stage:
             return None
@@ -74,11 +73,15 @@ class FilterNode(USDNode):
         stage = self.cached_stage.create()
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-        filter_prim = stage.GetPseudoRoot()
-        stage.SetDefaultPrim(filter_prim)
+
+        if self.root_prim_name:
+            root_prim = stage.DefinePrim(f"/{self.root_prim_name}")
+            stage.SetDefaultPrim(root_prim)
+        else:
+            root_prim = stage.GetPseudoRoot()
 
         for i, prim in enumerate(prims, 1):
-            override_prim = stage.OverridePrim(filter_prim.GetPath().AppendChild(prim.GetName()))
+            override_prim = stage.OverridePrim(root_prim.GetPath().AppendChild(prim.GetName()))
             override_prim.GetReferences().AddReference(input_stage.GetRootLayer().realPath,
                                                        prim.GetPath())
 

--- a/src/hdusd/usd_nodes/nodes/filter.py
+++ b/src/hdusd/usd_nodes/nodes/filter.py
@@ -28,12 +28,6 @@ class FilterNode(USDNode):
     def update_data(self, context):
         pass
 
-    root_prim_name: bpy.props.StringProperty(
-        name="Root",
-        description="Name of Root prim",
-        default="",
-        update=update_data
-    )
     filter_path: bpy.props.StringProperty(
         name="Pattern",
         description="USD Path pattern. Use special characters means:\n"
@@ -44,7 +38,6 @@ class FilterNode(USDNode):
     )
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'root_prim_name')
         layout.prop(self, 'filter_path')
 
     def compute(self, **kwargs):
@@ -74,11 +67,7 @@ class FilterNode(USDNode):
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
 
-        if self.root_prim_name:
-            root_prim = stage.DefinePrim(f"/{self.root_prim_name}")
-            stage.SetDefaultPrim(root_prim)
-        else:
-            root_prim = stage.GetPseudoRoot()
+        root_prim = stage.GetPseudoRoot()
 
         for i, prim in enumerate(prims, 1):
             override_prim = stage.OverridePrim(root_prim.GetPath().AppendChild(prim.GetName()))

--- a/src/hdusd/usd_nodes/nodes/filter.py
+++ b/src/hdusd/usd_nodes/nodes/filter.py
@@ -15,8 +15,9 @@
 import re
 
 import bpy
+from pxr import Usd, UsdGeom
+
 from .base_node import USDNode
-from . import log
 
 
 class FilterNode(USDNode):
@@ -24,18 +25,29 @@ class FilterNode(USDNode):
     bl_idname = 'usd.FilterNode'
     bl_label = "Filter USD"
 
+    def update_data(self, context):
+        pass
+
+    root_prim_name: bpy.props.StringProperty(
+        name="Root",
+        description="Name of Root prim",
+        default="",
+        update=update_data
+    )
     filter_path: bpy.props.StringProperty(
         name="Pattern",
         description="USD Path pattern. Use special characters means:\n"
                     "  * - any word or subword\n"
                     "  ** - several words separated by '/' or subword",
-        default='**')
+        default='/*',
+        update=update_data
+    )
 
     def draw_buttons(self, context, layout):
+        layout.prop(self, 'root_prim_name')
         layout.prop(self, 'filter_path')
 
     def compute(self, **kwargs):
-        from pxr import Usd, UsdGeom
 
         input_stage = self.get_input_link('Input', **kwargs)
         if not input_stage:

--- a/src/hdusd/usd_nodes/nodes/merge.py
+++ b/src/hdusd/usd_nodes/nodes/merge.py
@@ -64,13 +64,13 @@ class MergeNode(USDNode):
         stage = self.cached_stage.create()
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-        merge_prim = stage.DefinePrim(f"/merge")
+        merge_prim = stage.GetPseudoRoot()
         stage.SetDefaultPrim(merge_prim)
 
-        for i, ref_stage in enumerate(ref_stages, 1):
-            # ref = stage.DefinePrim(f"/merge/ref{i}", 'Xform')
-            # default_prim = ref_stage.GetDefaultPrim()
-            override_prim = stage.OverridePrim(merge_prim.GetPath().AppendChild(f"ref{i}"))
-            override_prim.GetReferences().AddReference(ref_stage.GetRootLayer().realPath)
+        for ref_stage in ref_stages:
+            for prim in ref_stage.GetPseudoRoot().GetAllChildren():
+                override_prim = stage.OverridePrim(merge_prim.GetPath().AppendChild(prim.GetName()))
+                override_prim.GetReferences().AddReference(ref_stage.GetRootLayer().realPath, prim.GetPath())
 
         return stage
+

--- a/src/hdusd/usd_nodes/nodes/merge.py
+++ b/src/hdusd/usd_nodes/nodes/merge.py
@@ -26,9 +26,6 @@ class MergeNode(USDNode):
 
     input_names = ()
 
-    def update_data(self, context):
-        pass
-
     def update_inputs_number(self, context):
         if len(self.inputs) < self.inputs_number:
             for i in range(len(self.inputs), self.inputs_number):
@@ -38,12 +35,6 @@ class MergeNode(USDNode):
             for i in range(len(self.inputs), self.inputs_number, -1):
                 self.safe_call(self.inputs.remove, self.inputs[i - 1])
 
-    root_prim_name: bpy.props.StringProperty(
-        name="Root",
-        description="Name of Root prim",
-        default="",
-        update=update_data
-    )
     inputs_number: bpy.props.IntProperty(
         name="Inputs",
         min=2, max=10, default=2,
@@ -55,7 +46,6 @@ class MergeNode(USDNode):
         super().init(context)
 
     def draw_buttons(self, context, layout):
-        layout.prop(self, 'root_prim_name')
         layout.prop(self, 'inputs_number')
 
     def compute(self, **kwargs):
@@ -75,11 +65,7 @@ class MergeNode(USDNode):
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
 
-        if self.root_prim_name:
-            root_prim = stage.DefinePrim(f"/{self.root_prim_name}")
-            stage.SetDefaultPrim(root_prim)
-        else:
-            root_prim = stage.GetPseudoRoot()
+        root_prim = stage.GetPseudoRoot()
 
         for ref_stage in ref_stages:
             for prim in ref_stage.GetPseudoRoot().GetAllChildren():

--- a/src/hdusd/usd_nodes/nodes/merge.py
+++ b/src/hdusd/usd_nodes/nodes/merge.py
@@ -14,6 +14,8 @@
 # ********************************************************************
 import bpy
 
+from pxr import Usd, UsdGeom
+
 from .base_node import USDNode
 
 
@@ -24,6 +26,9 @@ class MergeNode(USDNode):
 
     input_names = ()
 
+    def update_data(self, context):
+        pass
+
     def update_inputs_number(self, context):
         if len(self.inputs) < self.inputs_number:
             for i in range(len(self.inputs), self.inputs_number):
@@ -33,6 +38,12 @@ class MergeNode(USDNode):
             for i in range(len(self.inputs), self.inputs_number, -1):
                 self.safe_call(self.inputs.remove, self.inputs[i - 1])
 
+    root_prim_name: bpy.props.StringProperty(
+        name="Root",
+        description="Name of Root prim",
+        default="",
+        update=update_data
+    )
     inputs_number: bpy.props.IntProperty(
         name="Inputs",
         min=2, max=10, default=2,
@@ -44,11 +55,10 @@ class MergeNode(USDNode):
         super().init(context)
 
     def draw_buttons(self, context, layout):
+        layout.prop(self, 'root_prim_name')
         layout.prop(self, 'inputs_number')
 
     def compute(self, **kwargs):
-        from pxr import Usd, UsdGeom
-
         ref_stages = []
         for i in range(self.inputs_number):
             stage = self.get_input_link(i, **kwargs)

--- a/src/hdusd/usd_nodes/nodes/merge.py
+++ b/src/hdusd/usd_nodes/nodes/merge.py
@@ -68,9 +68,9 @@ class MergeNode(USDNode):
         stage.SetDefaultPrim(merge_prim)
 
         for i, ref_stage in enumerate(ref_stages, 1):
-            ref = stage.DefinePrim(f"/merge/ref{i}", 'Xform')
-            default_prim = ref_stage.GetDefaultPrim()
-            override_prim = stage.OverridePrim(str(ref.GetPath()) + '/' + default_prim.GetName())
+            # ref = stage.DefinePrim(f"/merge/ref{i}", 'Xform')
+            # default_prim = ref_stage.GetDefaultPrim()
+            override_prim = stage.OverridePrim(merge_prim.GetPath().AppendChild(f"ref{i}"))
             override_prim.GetReferences().AddReference(ref_stage.GetRootLayer().realPath)
 
         return stage

--- a/src/hdusd/usd_nodes/nodes/merge.py
+++ b/src/hdusd/usd_nodes/nodes/merge.py
@@ -74,12 +74,16 @@ class MergeNode(USDNode):
         stage = self.cached_stage.create()
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-        merge_prim = stage.GetPseudoRoot()
-        stage.SetDefaultPrim(merge_prim)
+
+        if self.root_prim_name:
+            root_prim = stage.DefinePrim(f"/{self.root_prim_name}")
+            stage.SetDefaultPrim(root_prim)
+        else:
+            root_prim = stage.GetPseudoRoot()
 
         for ref_stage in ref_stages:
             for prim in ref_stage.GetPseudoRoot().GetAllChildren():
-                override_prim = stage.OverridePrim(merge_prim.GetPath().AppendChild(prim.GetName()))
+                override_prim = stage.OverridePrim(root_prim.GetPath().AppendChild(prim.GetName()))
                 override_prim.GetReferences().AddReference(ref_stage.GetRootLayer().realPath, prim.GetPath())
 
         return stage

--- a/src/hdusd/usd_nodes/nodes/read_blend_data.py
+++ b/src/hdusd/usd_nodes/nodes/read_blend_data.py
@@ -33,7 +33,7 @@ class ReadBlendDataNode(USDNode):
         depsgraph = bpy.context.evaluated_depsgraph_get()
 
         stage = self.cached_stage()
-        objects_prim = stage.GetPrimAtPath(f"/{depsgraph.scene.name}/objects")
+        objects_prim = stage.GetPseudoRoot()
 
         # removing all children from objects_prim
         for obj_prim in objects_prim.GetAllChildren():
@@ -87,10 +87,12 @@ class ReadBlendDataNode(USDNode):
         UsdGeom.SetStageMetersPerUnit(stage, 1)
         UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
 
-        root_prim = stage.DefinePrim(f"/{sdf_path(depsgraph.scene.name)}")
+        root_prim = stage.GetPseudoRoot()
+        # root_prim = stage.DefinePrim(f"/{sdf_path(depsgraph.scene.name)}")
         stage.SetDefaultPrim(root_prim)
 
-        objects_prim = stage.DefinePrim(f"{root_prim.GetPath()}/objects")
+        objects_prim = root_prim
+
         self._export_depsgraph(objects_prim, depsgraph)
 
         return stage
@@ -101,7 +103,7 @@ class ReadBlendDataNode(USDNode):
             self.final_compute()
             return
 
-        objects_prim = stage.GetPrimAtPath(f"/{depsgraph.scene.name}/objects")
+        objects_prim = stage.GetPseudoRoot()
         if self._update_depsgraph(objects_prim, depsgraph):
             self.hdusd.usd_list.update_items()
 

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -26,9 +26,14 @@ class UsdFileNode(USDNode):
     bl_idname = 'usd.UsdFileNode'
     bl_label = "USD File"
 
-    input_names = ()
+    def update_data(self, context):
+        pass
 
-    filename: bpy.props.StringProperty(name="USD File", subtype='FILE_PATH')
+    filename: bpy.props.StringProperty(
+        name="USD File",
+        subtype='FILE_PATH',
+        update=update_data,
+    )
 
     def draw_buttons(self, context, layout):
         layout.prop(self, 'filename')

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -19,10 +19,10 @@ from .base_node import USDNode
 from . import log
 
 
-class ReadUsdFileNode(USDNode):
+class UsdFileNode(USDNode):
     ''' read USD file '''
-    bl_idname = 'usd.ReadUsdFileNode'
-    bl_label = "Read USD File"
+    bl_idname = 'usd.UsdFileNode'
+    bl_label = "USD File"
 
     input_names = ()
 

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -15,6 +15,8 @@
 import os
 
 import bpy
+from pxr import Usd
+
 from .base_node import USDNode
 from . import log
 
@@ -32,8 +34,6 @@ class UsdFileNode(USDNode):
         layout.prop(self, 'filename')
 
     def compute(self, **kwargs):
-        from pxr import Usd
-
         if not self.filename:
             log.warn("USD file name not set, skipping node", self)
             return None


### PR DESCRIPTION
### PURPOSE
Some of USD nodes like Read Blender Data, Merge, Filter produce additional root prims which isn't useful and complicated. Much better would be to work with objects in the root of stage.

### EFFECT OF CHANGE
USD nodes Blender Data, Merge and Filter produce object prims in the root of stage.

### TECHNICAL STEPS
1. Renamed classes ReadBlendDataNode -> BlenderDataNode, ReadUsdFileNode -> UsdFileNode as more related and simplified.
2. Adjusted Blender Data, Merge and Filter USD nodes to produce object prims in the root of stage.
3. Adjusted engines to produce object prims in the root of stage.
