### PR TITLE
RPRBLND-1721: Support RPR MaterialX nodes

### DIFF
--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -282,13 +282,17 @@ class NodeParser:
 
         # getting corresponded NodeParser class
         NodeParser_cls = self.get_node_parser_cls(node.bl_idname)
-        if NodeParser_cls:
-            node_parser = NodeParser_cls(self.id, self.doc, self.material, node, self.object, out_key,
-                                         group_nodes, **self.kwargs)
-            return node_parser.export()
+        if not NodeParser_cls:
+            log.warn("Ignoring unsupported node", node, self.material)
+            return None
 
-        log.warn("Ignoring unsupported node", node, self.material)
-        return None
+        node_parser = NodeParser_cls(self.id, self.doc, self.material, node, self.object, out_key,
+                                     group_nodes, **self.kwargs)
+
+        if self.kwargs.get('rpr', False):
+            return node_parser.export_rpr()
+        else:
+            return node_parser.export()
 
     def _parse_val(self, val):
         """Turn blender socket value into python's value"""
@@ -362,3 +366,7 @@ class NodeParser:
     def export(self) -> [NodeItem, None]:
         """Main export function which should be overridable in child classes"""
         return None
+
+    def export_rpr(self) -> [NodeItem, None]:
+        """Main export with RPR nodes function which could be overridable in child classes"""
+        return self.export()

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -223,65 +223,67 @@ class ShaderNodeBsdfPrincipled(NodeParser):
         tangent = self.get_input_link('Tangent')
 
         # CREATING STANDARD SURFACE
-        result = self.create_node('standard_surface', 'surfaceshader', {
-            'base': 1.0,
-            'base_color': base_color,
-            'diffuse_roughness': roughness,
-            'normal': normal,
-            'tangent': tangent,
-        })
+        result = self.create_node('rpr_uberv2', 'surfaceshader')
 
-        if enabled(metallic):
-            result.set_input('metalness', metallic)
-
-        if enabled(specular):
-            result.set_inputs({
-                'specular': specular,
-                'specular_color': base_color,
-                'specular_roughness': roughness,
-                'specular_IOR': ior,
-                'specular_anisotropy': anisotropic,
-                'specular_rotation': anisotropic_rotation,
-            })
-
-        if enabled(transmission):
-            result.set_inputs({
-                'transmission': transmission,
-                'transmission_color': base_color,
-                'transmission_extra_roughness': transmission_roughness,
-            })
-
-        if enabled(subsurface):
-            result.set_inputs({
-                'subsurface': subsurface,
-                'subsurface_color': subsurface_color,
-                'subsurface_radius': subsurface_radius,
-                'subsurface_anisotropy': anisotropic,
-            })
-
-        if enabled(sheen):
-            result.set_inputs({
-                'sheen': sheen,
-                'sheen_color': base_color,
-                'sheen_roughness': roughness,
-            })
-
-        if enabled(clearcoat):
-            result.set_inputs({
-                'coat': clearcoat,
-                'coat_color': base_color,
-                'coat_roughness': clearcoat_roughness,
-                'coat_IOR': ior,
-                'coat_anisotropy': anisotropic,
-                'coat_rotation': anisotropic_rotation,
-                'coat_normal': clearcoat_normal,
-            })
-
-        if enabled(emission):
-            result.set_inputs({
-                'emission': emission_strength,
-                'emission_color': emission,
-            })
+        # result = self.create_node('rpr_uberv2', 'surfaceshader', {
+        #     'base': 1.0,
+        #     'base_color': base_color,
+        #     'diffuse_roughness': roughness,
+        #     'normal': normal,
+        #     'tangent': tangent,
+        # })
+        #
+        # if enabled(metallic):
+        #     result.set_input('metalness', metallic)
+        #
+        # if enabled(specular):
+        #     result.set_inputs({
+        #         'specular': specular,
+        #         'specular_color': base_color,
+        #         'specular_roughness': roughness,
+        #         'specular_IOR': ior,
+        #         'specular_anisotropy': anisotropic,
+        #         'specular_rotation': anisotropic_rotation,
+        #     })
+        #
+        # if enabled(transmission):
+        #     result.set_inputs({
+        #         'transmission': transmission,
+        #         'transmission_color': base_color,
+        #         'transmission_extra_roughness': transmission_roughness,
+        #     })
+        #
+        # if enabled(subsurface):
+        #     result.set_inputs({
+        #         'subsurface': subsurface,
+        #         'subsurface_color': subsurface_color,
+        #         'subsurface_radius': subsurface_radius,
+        #         'subsurface_anisotropy': anisotropic,
+        #     })
+        #
+        # if enabled(sheen):
+        #     result.set_inputs({
+        #         'sheen': sheen,
+        #         'sheen_color': base_color,
+        #         'sheen_roughness': roughness,
+        #     })
+        #
+        # if enabled(clearcoat):
+        #     result.set_inputs({
+        #         'coat': clearcoat,
+        #         'coat_color': base_color,
+        #         'coat_roughness': clearcoat_roughness,
+        #         'coat_IOR': ior,
+        #         'coat_anisotropy': anisotropic,
+        #         'coat_rotation': anisotropic_rotation,
+        #         'coat_normal': clearcoat_normal,
+        #     })
+        #
+        # if enabled(emission):
+        #     result.set_inputs({
+        #         'emission': emission_strength,
+        #         'emission_color': emission,
+        #     })
 
         return result
 

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -153,6 +153,138 @@ class ShaderNodeBsdfPrincipled(NodeParser):
 
         return result
 
+    def export_rpr(self):
+        def enabled(val):
+            if val is None:
+                return False
+
+            if isinstance(val.data, float) and math.isclose(val.data, 0.0):
+                return False
+
+            if isinstance(val.data, tuple) and \
+               math.isclose(val.data[0], 0.0) and \
+               math.isclose(val.data[1], 0.0) and \
+               math.isclose(val.data[2], 0.0):
+                return False
+
+            return True
+
+        # GETTING REQUIRED INPUTS
+        # Note: if some inputs are not needed they won't be taken
+
+        base_color = self.get_input_value('Base Color')
+
+        subsurface = self.get_input_value('Subsurface')
+        subsurface_radius = None
+        subsurface_color = None
+        if enabled(subsurface):
+            subsurface_radius = self.get_input_value('Subsurface Radius')
+            subsurface_color = self.get_input_value('Subsurface Color')
+
+        metallic = self.get_input_value('Metallic')
+        specular = self.get_input_value('Specular')
+        specular_tint = self.get_input_value('Specular Tint')
+        roughness = self.get_input_value('Roughness')
+
+        anisotropic = None
+        anisotropic_rotation = None
+        if enabled(metallic):
+            # TODO: use Specular Tint input
+            anisotropic = self.get_input_value('Anisotropic')
+            if enabled(anisotropic):
+                anisotropic_rotation = self.get_input_value('Anisotropic Rotation')
+                # anisotropic_rotation = 0.5 - (anisotropic_rotation % 1.0)
+
+        sheen = self.get_input_value('Sheen')
+        sheen_tint = None
+        if enabled(sheen):
+            sheen_tint = self.get_input_value('Sheen Tint')
+
+        clearcoat = self.get_input_value('Clearcoat')
+        clearcoat_roughness = None
+        if enabled(clearcoat):
+            clearcoat_roughness = self.get_input_value('Clearcoat Roughness')
+
+        ior = self.get_input_value('IOR')
+
+        transmission = self.get_input_value('Transmission')
+        transmission_roughness = None
+        if enabled(transmission):
+            transmission_roughness = self.get_input_value('Transmission Roughness')
+
+        emission = self.get_input_value('Emission')
+        emission_strength = self.get_input_value('Emission Strength')
+
+        alpha = self.get_input_value('Alpha')
+        # transparency = 1.0 - alpha
+
+        normal = self.get_input_link('Normal')
+        clearcoat_normal = self.get_input_link('Clearcoat Normal')
+        tangent = self.get_input_link('Tangent')
+
+        # CREATING STANDARD SURFACE
+        result = self.create_node('standard_surface', 'surfaceshader', {
+            'base': 1.0,
+            'base_color': base_color,
+            'diffuse_roughness': roughness,
+            'normal': normal,
+            'tangent': tangent,
+        })
+
+        if enabled(metallic):
+            result.set_input('metalness', metallic)
+
+        if enabled(specular):
+            result.set_inputs({
+                'specular': specular,
+                'specular_color': base_color,
+                'specular_roughness': roughness,
+                'specular_IOR': ior,
+                'specular_anisotropy': anisotropic,
+                'specular_rotation': anisotropic_rotation,
+            })
+
+        if enabled(transmission):
+            result.set_inputs({
+                'transmission': transmission,
+                'transmission_color': base_color,
+                'transmission_extra_roughness': transmission_roughness,
+            })
+
+        if enabled(subsurface):
+            result.set_inputs({
+                'subsurface': subsurface,
+                'subsurface_color': subsurface_color,
+                'subsurface_radius': subsurface_radius,
+                'subsurface_anisotropy': anisotropic,
+            })
+
+        if enabled(sheen):
+            result.set_inputs({
+                'sheen': sheen,
+                'sheen_color': base_color,
+                'sheen_roughness': roughness,
+            })
+
+        if enabled(clearcoat):
+            result.set_inputs({
+                'coat': clearcoat,
+                'coat_color': base_color,
+                'coat_roughness': clearcoat_roughness,
+                'coat_IOR': ior,
+                'coat_anisotropy': anisotropic,
+                'coat_rotation': anisotropic_rotation,
+                'coat_normal': clearcoat_normal,
+            })
+
+        if enabled(emission):
+            result.set_inputs({
+                'emission': emission_strength,
+                'emission_color': emission,
+            })
+
+        return result
+
 
 class ShaderNodeBsdfDiffuse(NodeParser):
     def export(self):

--- a/src/hdusd/engine/preview_engine.py
+++ b/src/hdusd/engine/preview_engine.py
@@ -28,7 +28,7 @@ class PreviewEngine(FinalEngine):
     SAMPLES_NUMBER = 50
 
     def _set_scene_camera(self, renderer, scene):
-        usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, sdf_path('Camera.002'))
+        usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, sdf_path(scene.camera.data.name))
         gf_camera = usd_camera.GetCamera()
         renderer.SetCameraState(gf_camera.frustum.ComputeViewMatrix(),
                                 gf_camera.frustum.ComputeProjectionMatrix())

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -31,30 +31,6 @@ def sdf_name(mat: bpy.types.Material, input_socket_key='Surface'):
     return ret
 
 
-def get_material_output_node(material):
-    """ Finds output node in material tree and exports it """
-    if not material.node_tree:
-        # there could be a situation when node_tree is None
-        return None
-
-    return next((node for node in material.node_tree.nodes
-                 if node.bl_idname == 'ShaderNodeOutputMaterial' and node.is_active_output),
-                None)
-
-
-def get_material_input_node(mat):
-    """ Find the material node attached to output node 'input_socket_key' input """
-    output_node = get_material_output_node(mat)
-    if not output_node:
-        return None
-
-    socket_in = output_node.inputs['Surface']
-    if not socket_in.is_linked or not socket_in.links[0].is_valid:
-        return None
-
-    return socket_in.links[0].from_node
-
-
 def sync(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
     """
     If material exists: returns existing material unless force_update is used
@@ -66,93 +42,7 @@ def sync(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
     if mat.hdusd.mx_node_tree:
         return sync_mx(materials_prim, mat.hdusd.mx_node_tree, obj)
 
-    if mat.hdusd.export_as_mx:
-        return sync_as_mx(materials_prim, mat, obj)
-
-    output_node = get_material_output_node(mat)
-    if not output_node:
-        log("No output node", mat)
-        return None
-
-    node = get_material_input_node(mat)
-    if not node:
-        return None
-
-    stage = materials_prim.GetStage()
-    mat_path = f"{materials_prim.GetPath()}/{sdf_name(mat)}"
-    usd_mat = UsdShade.Material.Define(stage, mat_path)
-
-    # create appropriate USD shader
-    if node.bl_idname == 'ShaderNodeBsdfPrincipled':
-        create_principled_shader(usd_mat, node)
-    elif node.bl_idname == 'ShaderNodeEmission':
-        create_emission_shader(usd_mat, node)
-    elif node.bl_idname == 'ShaderNodeBsdfDiffuse':  # used by Material Preview
-        create_diffuse_shader(usd_mat, node)
-    else:
-        log.warn("Unsupported node", node, mat)
-
-    return usd_mat
-
-
-def get_input_default(node, socket_key):
-    val = node.inputs[socket_key].default_value
-    if isinstance(val, (int, float)):
-        return float(val)
-
-    if len(val) in (3, 4):
-        return tuple(val[:3])
-
-    if isinstance(val, str):
-        return val
-
-    raise TypeError("Unknown value type", val)
-
-
-def create_principled_shader(usd_mat, node):
-    stage = usd_mat.GetPrim().GetStage()
-    shader_key = f"{usd_mat.GetPath()}/PBRShader"
-
-    pbr_shader = UsdShade.Shader.Define(stage, shader_key)
-    pbr_shader.CreateIdAttr("UsdPreviewSurface")
-    pbr_shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Float3).Set(get_input_default(node, 'Base Color',))
-    pbr_shader.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'Roughness'))
-    pbr_shader.CreateInput("metallic", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'Metallic'))
-    pbr_shader.CreateInput("clearcoat", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'Clearcoat'))
-    pbr_shader.CreateInput("clearcoatRoughness", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'Clearcoat Roughness'))
-    pbr_shader.CreateInput("emissiveColor", Sdf.ValueTypeNames.Float3).Set(get_input_default(node, 'Emission'))
-    pbr_shader.CreateInput("ior", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'IOR'))
-    pbr_shader.CreateInput("opacity", Sdf.ValueTypeNames.Float).Set(1.0 - get_input_default(node, 'Transmission'))
-
-    usd_mat.CreateSurfaceOutput().ConnectToSource(pbr_shader, "surface")
-
-
-def create_diffuse_shader(usd_mat, node):
-    stage = usd_mat.GetPrim().GetStage()
-    shader_key = f"{usd_mat.GetPath()}/DiffuseShader"
-
-    pbr_shader = UsdShade.Shader.Define(stage, shader_key)
-    pbr_shader.CreateIdAttr("UsdPreviewSurface")
-    pbr_shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Float3).Set(get_input_default(node, 'Color',))
-    pbr_shader.CreateInput("roughness", Sdf.ValueTypeNames.Float).Set(get_input_default(node, 'Roughness'))
-
-    usd_mat.CreateSurfaceOutput().ConnectToSource(pbr_shader, "surface")
-
-
-def create_emission_shader(usd_mat, node):
-    stage = usd_mat.GetPrim().GetStage()
-    shader_key = f"{usd_mat.GetPath()}/PBREmissionShader"
-
-    pbr_shader = UsdShade.Shader.Define(stage, shader_key)
-    pbr_shader.CreateIdAttr("UsdPreviewSurface")
-    emission_color = get_input_default(node, 'Color')
-    strength = get_input_default(node, 'Strength')
-    emission_color = tuple(e * strength for e in emission_color)
-
-    pbr_shader.CreateInput("diffuseColor", Sdf.ValueTypeNames.Float3).Set(emission_color)
-    pbr_shader.CreateInput("emissiveColor", Sdf.ValueTypeNames.Float3).Set(emission_color)
-
-    usd_mat.CreateSurfaceOutput().ConnectToSource(pbr_shader, "surface")
+    return sync_as_mx(materials_prim, mat, obj)
 
 
 def sync_update(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -124,18 +124,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         self.nodes.clear()
 
         mat_node = self.nodes.new('hdusd.MxNode_STD_surfacematerial')
-        if node_name == 'PBR_standard_surface':
-            node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (mat_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
-                             mat_node.location[1])
-            self.links.new(node.outputs[0], mat_node.inputs[0])
-        else:
-            surface_node = self.nodes.new('hdusd.MxNode_PBR_surface')
-            surface_node.location = (mat_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
-                                     mat_node.location[1])
-            self.links.new(surface_node.outputs[0], mat_node.inputs[0])
-
-            node = self.nodes.new(f'hdusd.MxNode_{node_name}')
-            node.location = (surface_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
-                             surface_node.location[1])
-            self.links.new(node.outputs[0], surface_node.inputs[0])
+        node = self.nodes.new(f'hdusd.MxNode_{node_name}')
+        node.location = (mat_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
+                         mat_node.location[1])
+        self.links.new(node.outputs[0], mat_node.inputs[0])

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -60,8 +60,7 @@ def get_node_def_cls(node_name, nd_type):
     if node_def_cls:
         return node_def_cls
 
-    nd_name = f"ND_{node_name}"
-    node_def_cls = next((cls for cls in mx_nodedef_classes if cls.__name__.endswith(nd_name)), None)
+    node_def_cls = next((cls for cls in mx_nodedef_classes if cls._node_name == node_name), None)
 
     if node_def_cls:
         return node_def_cls

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -12,31 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ********************************************************************
+import importlib
+from pathlib import Path
+
 import bpy
 import nodeitems_utils
 
 from .. import log
 from . import base_node, categories
-from . import (
-    gen_standard_surface,
-    gen_usd_preview_surface,
-    gen_stdlib_defs,
-    gen_pbrlib_defs
-)
 
+gen_modules = [importlib.import_module(f"hdusd.mx_nodes.nodes.{f.name[:-len(f.suffix)]}")
+               for f in Path(__file__).parent.glob("gen_*.py")]
 
-mx_nodedef_classes = [
-    *gen_standard_surface.mx_nodedef_classes,
-    *gen_usd_preview_surface.mx_nodedef_classes,
-    *gen_stdlib_defs.mx_nodedef_classes,
-    *gen_pbrlib_defs.mx_nodedef_classes,
-]
-mx_node_classes = [
-    *gen_standard_surface.mx_node_classes,
-    *gen_usd_preview_surface.mx_node_classes,
-    *gen_stdlib_defs.mx_node_classes,
-    *gen_pbrlib_defs.mx_node_classes,
-]
+mx_nodedef_classes = []
+mx_node_classes = []
+for m in gen_modules:
+    mx_nodedef_classes.extend(m.mx_nodedef_classes)
+    mx_node_classes.extend(m.mx_node_classes)
 
 register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
     base_node.MxNodeInputSocket,

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -70,6 +70,7 @@ class MxNodeOutputSocket(bpy.types.NodeSocket):
 class MxNodeDef(bpy.types.PropertyGroup):
     _file_path: str
     _nodedef_name: str
+    _node_name: str
 
     _nodedef: mx.NodeDef = None
 

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -16,7 +16,7 @@ from collections import defaultdict
 
 from nodeitems_utils import NodeCategory, NodeItem
 
-from ...utils import title_str
+from ...utils import title_str, code_str
 
 
 class MxNodeCategory(NodeCategory):
@@ -35,7 +35,7 @@ def get_node_categories():
     categories = []
     for category, category_classes in d.items():
         categories.append(
-            MxNodeCategory('HdUSD_MX_NG_' + category, title_str(category),
+            MxNodeCategory('HdUSD_MX_NG_' + code_str(category), title_str(category),
                            items=[NodeItem(MxNode_cls.bl_idname)
                                   for MxNode_cls in category_classes]))
 

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -54,3 +54,8 @@ class SceneProperties(HdUSDProperties):
                     "Required for MaterialX testing when GPU isn't supported",
         default=False,
     )
+    use_rpr_mx_nodes: bpy.props.BoolProperty(
+        name="RPR MaterialX Nodes",
+        description="Use RPR MaterialX Nodes as default nodes",
+        default=True,
+    )

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -18,7 +18,6 @@ import bpy
 from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
-from ..export.material import get_material_output_node
 from ..mx_nodes.node_tree import MxNodeTree
 
 
@@ -142,9 +141,6 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
         col.template_ID(mat_hdusd, "mx_node_tree",
                         new=HDUSD_MATERIAL_OP_new_mx_node_tree.bl_idname)
 
-        if not mat_hdusd.mx_node_tree:
-            layout.prop(mat_hdusd, "export_as_mx")
-
     def draw_header(self, context):
         layout = self.layout
         layout.label(text=f"Material: {context.material.name}")
@@ -163,7 +159,7 @@ class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
 
         node_tree = context.material.node_tree
 
-        output_node = get_material_output_node(context.material)
+        output_node = context.material.hdusd.output_node
         if not output_node:
             layout.label(text="No output node")
             return

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -107,7 +107,8 @@ class HDUSD_MATERIAL_OP_new_mx_node_tree(bpy.types.Operator):
     def execute(self, context):
         mat = context.material
         mx_node_tree = bpy.data.node_groups.new(f"MX_{mat.name}", type=MxNodeTree.bl_idname)
-        mx_node_tree.create_basic_nodes()
+        mx_node_tree.create_basic_nodes(
+            'RPR_rpr_uberv2' if context.scene.hdusd.use_rpr_mx_nodes else 'PBR_standard_surface')
         mat.hdusd.mx_node_tree = mx_node_tree
 
         # trying to show MaterialX area with created node tree

--- a/src/hdusd/ui/mx_nodes.py
+++ b/src/hdusd/ui/mx_nodes.py
@@ -107,7 +107,8 @@ class HDUSD_MX_OP_create_basic_nodes(HdUSD_Operator):
 
     def execute(self, context):
         mx_node_tree = context.space_data.edit_tree
-        mx_node_tree.create_basic_nodes()
+        mx_node_tree.create_basic_nodes(
+            'RPR_rpr_uberv2' if context.scene.hdusd.use_rpr_mx_nodes else 'PBR_standard_surface')
         return {"FINISHED"}
 
 

--- a/src/hdusd/ui/render.py
+++ b/src/hdusd/ui/render.py
@@ -117,3 +117,4 @@ class HDUSD_RENDER_PT_debug(HdUSD_Panel):
     def draw(self, context):
         layout = self.layout
         layout.prop(context.scene.hdusd, "rpr_viewport_cpu_device")
+        layout.prop(context.scene.hdusd, "use_rpr_mx_nodes")

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -34,14 +34,14 @@ def set_param_value(mx_param, val, nd_type):
 
 
 def is_value_equal(mx_val, val, nd_type):
-    if nd_type in ('string', 'float', 'integer', 'boolean', 'filename'):
+    if nd_type in ('string', 'float', 'integer', 'boolean', 'filename', 'angle'):
         return mx_val == val
 
     return tuple(mx_val) == tuple(val)
 
 
 def is_shader_type(mx_type):
-    return not (mx_type in ('string', 'float', 'integer', 'boolean', 'filename') or
+    return not (mx_type in ('string', 'float', 'integer', 'boolean', 'filename', 'angle') or
                 mx_type.startswith('color') or
                 mx_type.startswith('vector') or
                 mx_type.endswith('array'))
@@ -52,7 +52,7 @@ def get_attr(mx_param, name, else_val=None):
 
 
 def parse_value(mx_val, mx_type):
-    if mx_type in ('string', 'float', 'integer', 'boolean', 'filename'):
+    if mx_type in ('string', 'float', 'integer', 'boolean', 'filename', 'angle'):
         return mx_val
 
     return tuple(mx_val)
@@ -67,7 +67,7 @@ def parse_value_str(val_str, mx_type, *, first_only=False, is_enum=False):
 
     if mx_type == 'integer':
         return int(val_str)
-    if mx_type == 'float':
+    if mx_type in ('float', 'angle'):
         return float(val_str)
     if mx_type == 'boolean':
         return val_str == "true"

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -195,7 +195,8 @@ def generate_mx_nodedef_class_code(nodedef: mx.NodeDef, prefix: str):
 f"""
 class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
     _file_path = FILE_PATH
-    _nodedef_name = '{nodedef.getName()}'""")
+    _nodedef_name = '{nodedef.getName()}'
+    _node_name = '{nodedef.getNodeString()}'""")
 
     for i, param in enumerate(nodedef.getParameters()):
         if i == 0:

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -45,7 +45,7 @@ def parse_value_str(val_str, mx_type, *, first_only=False, is_enum=False):
 
     if mx_type == 'integer':
         return int(val_str)
-    if mx_type == 'float':
+    if mx_type in ('float', 'angle'):
         return float(val_str)
     if mx_type == 'boolean':
         return val_str == "true"
@@ -89,6 +89,11 @@ def generate_property_code(mx_param):
         if mx_type == 'boolean':
             prop_type = "BoolProperty"
             break
+        if mx_type == 'angle':
+            prop_type = "FloatProperty"
+            prop_attrs['subtype'] = 'ANGLE'
+            break
+
         if mx_type in ('surfaceshader', 'displacementshader', 'volumeshader', 'lightshader',
                        'material', 'BSDF', 'VDF', 'EDF'):
             prop_type = "StringProperty"

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -149,11 +149,11 @@ def get_attr(mx_param, name, else_val=""):
 
 def nodedef_data_type(nodedef):
     # nodedef name consists: ND_{node_name}_{data_type} therefore:
-    res = nodedef.getName()[(4 + len(nodedef.getNodeString())):]
-    if not res:
-        res = nodedef.getOutputs()[0].getType()
+    outputs = nodedef.getOutputs()
+    if len(outputs) == 1:
+        return nodedef.getOutputs()[0].getType()
 
-    return res
+    return "multitypes"
 
 
 def param_prop_name(name):
@@ -217,19 +217,21 @@ class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
     return '\n'.join(code_strings)
 
 
-def generate_mx_node_class_code(nodedefs, prefix):
+def generate_mx_node_class_code(nodedefs, prefix, category):
     nodedef = nodedefs[0]
+    if not category:
+        category = get_attr(nodedef, 'nodegroup', prefix)
 
     class_name = get_mx_node_class_name(nodedef, prefix)
     code_strings = []
     code_strings.append(
 f"""
 class {class_name}(MxNode):
-    bl_label = '{title_str(nodedef.getNodeString())}'
+    bl_label = '{get_attr(nodedef, 'uiname', title_str(nodedef.getNodeString()))}'
     bl_idname = 'hdusd.{class_name}'
     bl_description = "{get_attr(nodedef, 'doc')}"
     
-    category = '{get_attr(nodedef, 'nodegroup', prefix)}'
+    category = '{category}'
     
     _data_types = {tuple(nodedef_data_type(nd) for nd in nodedefs)}
 """)
@@ -275,7 +277,7 @@ class {class_name}(MxNode):
     return '\n'.join(code_strings)
 
 
-def generate_classes_code(file_path, prefix):
+def generate_classes_code(file_path, prefix, category):
     IGNORE_NODEDEF_DATA_TYPE = ('matrix33', 'matrix44', 'matrix33FA', 'matrix44FA')
 
     code_strings = []
@@ -336,7 +338,7 @@ mx_nodedef_classes = [{', '.join(nodedef_class_names)}]
     # creating MxNode types
     mx_node_class_names = []
     for nodedefs_by_node in node_def_classes_by_node.values():
-        code_strings.append(generate_mx_node_class_code(nodedefs_by_node, prefix))
+        code_strings.append(generate_mx_node_class_code(nodedefs_by_node, prefix, category))
         mx_node_class_names.append(get_mx_node_class_name(nodedefs_by_node[0], prefix))
 
     code_strings.append(f"""
@@ -348,20 +350,35 @@ mx_node_classes = [{', '.join(mx_node_class_names)}]
 
 def main():
     mx_libs_dir = libs_dir / "materialx/libraries"
-    mx_node_dir = repo_dir / "src/hdusd/mx_nodes/nodes"
+    gen_code_dir = repo_dir / "src/hdusd/mx_nodes/nodes"
+    hdrpr_mat_dir = libs_dir / "hdrpr/materials"
 
-    for prefix, file_path in (
-                ('PBR', mx_libs_dir / "bxdf/standard_surface.mtlx"),
-                ('USD', mx_libs_dir / "bxdf/usd_preview_surface.mtlx"),
-                ('STD', mx_libs_dir / "stdlib/stdlib_defs.mtlx"),
-                ('PBR', mx_libs_dir / "pbrlib/pbrlib_defs.mtlx"),
-            ):
+    for f in gen_code_dir.glob("gen_*.py"):
+        f.unlink()
+
+    files = [
+        ('PBR', "PBR", mx_libs_dir / "bxdf/standard_surface.mtlx"),
+        ('USD', "USD", mx_libs_dir / "bxdf/usd_preview_surface.mtlx"),
+        ('STD', None, mx_libs_dir / "stdlib/stdlib_defs.mtlx"),
+        ('PBR', "PBR", mx_libs_dir / "pbrlib/pbrlib_defs.mtlx"),
+    ]
+
+    for f in (hdrpr_mat_dir / "Shaders").glob("rpr_*.mtlx"):
+        files.append(('RPR', "RPR Shaders", f))
+
+    for f in (hdrpr_mat_dir / "Utilities").glob("rpr_*.mtlx"):
+        files.append(('RPR', "RPR Utilities", f))
+
+    for f in (hdrpr_mat_dir / "Patterns").glob("rpr_*.mtlx"):
+        files.append(('RPR', "RPR Patterns", f))
+
+    for prefix, category, file_path in files:
 
         module_name = f"gen_{file_path.name[:-len(file_path.suffix)]}"
-        module_file = mx_node_dir / f"{module_name}.py"
+        module_file = gen_code_dir / f"{module_name}.py"
 
         print(f"Generating {module_file} from {file_path}")
-        module_code = generate_classes_code(file_path, prefix)
+        module_code = generate_classes_code(file_path, prefix, category)
         module_file.write_text(module_code)
 
 


### PR DESCRIPTION
### PURPOSE
Standard MaterialX nodes aren't good rendered by HdRPR. While RPR MaterialX nodes are fully supported. Therefore it'll be good to include them into plugin, and temporary set RPR Uber as default, until standard surface will be fully supported by HdRPR and HdStorm.

### EFFECT OF CHANGE
1. Added RPR MaterialX nodes
2. Added debug option "RPR MaterialX Nodes" into Debug panel.
3. Set RPR Uber as default MaterialX node if "RPR MaterialX Nodes" is enabled.
4. Made Principled node to convert into RPR Uber instead Standard surface if "RPR MaterialX Nodes" is enabled.
5. Fixed bug with finding camera in material preview.

### TECHNICAL STEPS
1. Improved generate_mx_classes.py with better node categories and class names:
    - Added RPR MaterialX nodes to generating MX classes process. 
    - Added 'angle' type support.
    -  Added _node_name to MxNodeDef classes for fast searching in get_node_def_cls()
2. Switched HdRPR to latest develop with cyrillic typos fixes.
3. Added NodeParser.export_rpr() method. Implemented ShaderNodeBsdfPrincipled.export_rpr() (implementation was copied from Blender RPR plugin)
4. Removed old unused code from export.material.py.
5. Fixed camera search in PreviewEngine.