### PR TITLE
Updated HdRPR with standard surface crash fix.

### DIFF
--- a/src/hdusd/__init__.py
+++ b/src/hdusd/__init__.py
@@ -17,7 +17,7 @@ bl_info = {
     "name": "USD Hydra",
     "author": "AMD",
     "version": (1, 0, 0),
-    "blender": (2, 90, 1),
+    "blender": (2, 93, 0),
     "location": "Info header, render engine menu",
     "description": "USD Hydra rendering plugin for Blender",
     "warning": "",


### PR DESCRIPTION
### PURPOSE
When standard surface MaterialX node is used HdRPR is very unstable and crashes randomly.

### EFFECT OF CHANGE
Fixed crashes when MaterialX standard surface node is used.
Updated min Blender version to 2.93 for this plugin.

### TECHNICAL STEPS
Updated HdRPR submodule.
Set min Blender version 2.93.0 in bl_info
