### PR TITLE
Update scene on MaterialX node graph update

### DIFF
--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -205,8 +205,6 @@ class ViewportEngine(Engine):
 
         self.renderer.SetRendererSetting('renderDevice',
                                          'CPU' if scene.hdusd.rpr_viewport_cpu_device else 'GPU')
-        # self.renderer.SetRendererSetting('renderMode', 'Global Illumination')
-        # self.renderer.SetRendererSetting('renderQuality', 'Northstar')
 
         if self.data_source:
             nodetree = bpy.data.node_groups[self.data_source]

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -254,10 +254,8 @@ class ViewportEngine(Engine):
                 continue
 
             if isinstance(obj, bpy.types.Material):
-                mesh_obj = context.object if context.object and \
-                                             context.object.type == 'MESH' else None
-                materials_prim = self.stage.DefinePrim(f"{root_prim.GetPath()}/materials")
-                material.sync_update(materials_prim, obj, mesh_obj)
+                log.info("sync_update Material", obj)
+                self.update_material_on_scene_objects(root_prim, obj, depsgraph)
                 continue
 
             if isinstance(obj, bpy.types.Object):
@@ -299,6 +297,16 @@ class ViewportEngine(Engine):
             if isinstance(obj, bpy.types.Scene):
                 self.update_render(obj)
                 continue
+
+    def update_material_on_scene_objects(self, root_prim, mat, depsgraph):
+        objects = tuple(obj for obj in depsgraph_objects(depsgraph)
+                        if mat.name in obj.material_slots.keys())
+
+        for obj in objects:
+            object.sync_update(root_prim, obj,
+                               is_updated_geometry=True,
+                               is_updated_transform=False,
+                               is_gl_delegate=self.is_gl_delegate)
 
     def sync_update(self, context, depsgraph):
         """ sync just the updated things """

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -235,7 +235,6 @@ class ViewportEngine(Engine):
         root_prim = self.stage.GetPseudoRoot()
 
         # get supported updates and sort by priorities
-        log.info("sync_update", [update.id for update in depsgraph.updates])
         updates = []
         for obj_type in (
                 bpy.types.Scene, bpy.types.World, bpy.types.Material, bpy.types.Object, bpy.types.Collection,
@@ -248,7 +247,7 @@ class ViewportEngine(Engine):
 
         for update in updates:
             obj = update.id
-            log.info("sync_update", obj)
+            log("sync_update", obj)
             if isinstance(obj, bpy.types.Scene):
                 self.update_render(obj)
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -303,10 +303,7 @@ class ViewportEngine(Engine):
                         if mat.name in obj.material_slots.keys())
 
         for obj in objects:
-            object.sync_update(root_prim, obj,
-                               is_updated_geometry=True,
-                               is_updated_transform=False,
-                               is_gl_delegate=self.is_gl_delegate)
+            object.sync_update_material(root_prim, obj, is_gl_delegate=self.is_gl_delegate)
 
     def sync_update(self, context, depsgraph):
         """ sync just the updated things """

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -31,6 +31,11 @@ from ..utils import logging
 log = logging.Log(tag='viewport_engine')
 
 
+ACCEPTED_BLEND_UPDATE_TYPES = (
+    bpy.types.Scene, bpy.types.World, bpy.types.Material, bpy.types.Object, bpy.types.Collection, MxNodeTree,
+)
+
+
 @dataclass(init=False, eq=True)
 class ViewSettings:
     """
@@ -233,12 +238,8 @@ class ViewportEngine(Engine):
         root_prim = self.stage.GetPseudoRoot()
 
         # get supported updates and sort by priorities
-        updates = []
-        for obj_type in (
-                bpy.types.Scene, bpy.types.World, bpy.types.Material, bpy.types.Object, bpy.types.Collection,
-                MxNodeTree,
-        ):
-            updates.extend(update for update in depsgraph.updates if isinstance(update.id, obj_type))
+        updates = tuple(update for update in depsgraph.updates if
+                        isinstance(update.id, ACCEPTED_BLEND_UPDATE_TYPES))
 
         sync_collection = False
         sync_world = False

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -39,7 +39,7 @@ def sync(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
 
     log("sync", mat, obj)
 
-    if mat.hdusd.mx_node_tree:
+    if mat.hdusd.mx_node_tree and mat.hdusd.mx_node_tree.bl_idname == "hdusd.MxNodeTree":
         return sync_mx(materials_prim, mat.hdusd.mx_node_tree, obj)
 
     return sync_as_mx(materials_prim, mat, obj)

--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -248,16 +248,10 @@ def sync_update(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **
     sync(obj_prim, obj, **kwargs)
 
 
-def sync_update_material(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None):
+def sync_update_material(obj_prim, obj: bpy.types.Object):
     """ Update materials on existing mesh """
-    if not mesh:
-        mesh = obj.data
+    log("sync_update_material", obj_prim, obj)
 
-    log("sync_update_material", obj_prim, mesh, obj)
-
-    # get existing mesh
-    usd_mesh = obj_prim
-
-    if usd_mesh.IsValid():
-        UsdShade.MaterialBindingAPI(usd_mesh).UnbindAllBindings()
-        _assign_materials(obj_prim, obj, usd_mesh)
+    for child_prim in obj_prim.GetAllChildren():
+        UsdShade.MaterialBindingAPI(child_prim).UnbindAllBindings()
+        _assign_materials(obj_prim, obj, child_prim)

--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -246,3 +246,18 @@ def sync_update(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **
         stage.RemovePrim(child_prim.GetPath())
 
     sync(obj_prim, obj, **kwargs)
+
+
+def sync_update_material(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **kwargs):
+    """ Update materials on existing mesh """
+    if not mesh:
+        mesh = obj.data
+
+    log("sync_update_material", obj_prim, mesh, obj)
+
+    # get existing mesh
+    usd_mesh = obj_prim
+
+    if usd_mesh.IsValid():
+        UsdShade.MaterialBindingAPI(usd_mesh).UnbindAllBindings()
+        _assign_materials(obj_prim, obj, usd_mesh)

--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -248,7 +248,7 @@ def sync_update(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **
     sync(obj_prim, obj, **kwargs)
 
 
-def sync_update_material(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None, **kwargs):
+def sync_update_material(obj_prim, obj: bpy.types.Object, mesh: bpy.types.Mesh = None):
     """ Update materials on existing mesh """
     if not mesh:
         mesh = obj.data

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -97,3 +97,7 @@ def sync_update(root_prim, obj: bpy.types.Object, is_updated_geometry, is_update
 
         else:
             log.warn("Not supported object to sync_update", obj, obj.type)
+
+
+def sync_update_material(root_prim, obj: bpy.types.Object, **kwargs):
+    sync_update(root_prim, obj, is_updated_geometry=True, is_updated_transform=False, **kwargs)

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -108,7 +108,7 @@ def sync_update_material(root_prim, obj: bpy.types.Object, **kwargs):
         return
 
     if obj.type in ('MESH', 'CURVE', 'FONT', 'SURFACE', 'META'):
-        mesh.sync_update_material(obj_prim, obj, **kwargs)
+        mesh.sync_update_material(obj_prim, obj)
 
     else:
         log.warn("Unsupported object to sync_update_material", obj, obj.type)

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -96,8 +96,19 @@ def sync_update(root_prim, obj: bpy.types.Object, is_updated_geometry, is_update
             pass
 
         else:
-            log.warn("Not supported object to sync_update", obj, obj.type)
+            log.warn("Unsupported object to sync_update", obj, obj.type)
 
 
 def sync_update_material(root_prim, obj: bpy.types.Object, **kwargs):
-    sync_update(root_prim, obj, is_updated_geometry=True, is_updated_transform=False, **kwargs)
+    log("sync_update_material", obj)
+
+    obj_prim = root_prim.GetChild(sdf_name(obj))
+    if not obj_prim.IsValid():
+        sync(root_prim, obj, **kwargs)
+        return
+
+    if obj.type in ('MESH', 'CURVE', 'FONT', 'SURFACE', 'META'):
+        mesh.sync_update_material(obj_prim, obj, **kwargs)
+
+    else:
+        log.warn("Unsupported object to sync_update_material", obj, obj.type)

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -196,7 +196,7 @@ f"""
 class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
     _file_path = FILE_PATH
     _nodedef_name = '{nodedef.getName()}'
-    _node_name = '{nodedef.getNodeString()}'""")
+    _node_name = '{nodedef.getNodeString()}'
 
     for i, param in enumerate(nodedef.getParameters()):
         if i == 0:

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -196,7 +196,7 @@ f"""
 class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
     _file_path = FILE_PATH
     _nodedef_name = '{nodedef.getName()}'
-    _node_name = '{nodedef.getNodeString()}'
+    _node_name = '{nodedef.getNodeString()}'""")
 
     for i, param in enumerate(nodedef.getParameters()):
         if i == 0:


### PR DESCRIPTION
### PURPOSE
Added scene update on MaterialX nodes edit with active Viewport render.

### EFFECT OF CHANGE
- fixed issue with regular Blender material update in viewport;
- added scene update on MaterialX nodes edit with active Viewport render.

### TECHNICAL STEPS
- ignored non-MaterialX node trees(USD tree could be assigned as one in UI) during material export;
- called for material users re-export to correctly apply updated material;
- added scene update handling for MaterialX node tree update;
- simplified scene updates info filtering.

### NOTES
Calling for viewport scene update on MaterialX node tree structure change would be done as a separate PR.