### PR TITLE
RPRBLND-1698: Add the entire USD stage, not just selected item to the USD collection as empty objects

### DIFF
--- a/src/hdusd/engine/__init__.py
+++ b/src/hdusd/engine/__init__.py
@@ -46,6 +46,8 @@ def register():
     bpy.app.handlers.load_pre.append(handlers.on_load_pre)
     bpy.app.handlers.load_post.append(handlers.on_load_post)
     bpy.app.handlers.depsgraph_update_post.append(handlers.on_depsgraph_update_post)
+    bpy.app.handlers.save_pre.append(handlers.on_save_pre)
+    bpy.app.handlers.save_post.append(handlers.on_save_post)
 
 
 def unregister():
@@ -54,3 +56,5 @@ def unregister():
     bpy.app.handlers.load_pre.remove(handlers.on_load_pre)
     bpy.app.handlers.load_post.remove(handlers.on_load_post)
     bpy.app.handlers.depsgraph_update_post.remove(handlers.on_depsgraph_update_post)
+    bpy.app.handlers.save_pre.remove(handlers.on_save_pre)
+    bpy.app.handlers.save_post.remove(handlers.on_save_post)

--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -43,3 +43,17 @@ def on_depsgraph_update_post(scene, depsgraph):
 
     usd_list.depsgraph_update(depsgraph)
     node_tree.depsgraph_update(depsgraph)
+
+
+@bpy.app.handlers.persistent
+def on_save_pre(*args):
+    log("on_save_pre", args)
+    from ..viewport import usd_collection
+    usd_collection.scene_save_pre()
+
+
+@bpy.app.handlers.persistent
+def on_save_post(*args):
+    log("on_save_post", args)
+    from ..viewport import usd_collection
+    usd_collection.scene_save_post()

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -55,6 +55,7 @@ register, unregister = bpy.utils.register_classes_factory((
     node.NodeProperties,
 
     scene.RenderSettings,
+    scene.ViewportRenderSettings,
     scene.SceneProperties,
 
     object.ObjectProperties,

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -54,7 +54,7 @@ register, unregister = bpy.utils.register_classes_factory((
 
     node.NodeProperties,
 
-    scene.RenderSettings,
+    scene.FinalRenderSettings,
     scene.ViewportRenderSettings,
     scene.SceneProperties,
 

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -19,7 +19,7 @@ from pxr import UsdGeom, Gf
 
 from . import HdUSDProperties, CachedStageProp
 from ..export.object import get_transform
-from ..mx_nodes.node_tree import MxNodeTree
+from ..utils import usd as usd_utils
 
 
 class ObjectProperties(HdUSDProperties):
@@ -46,12 +46,7 @@ class ObjectProperties(HdUSDProperties):
 
         self.cached_stage.assign(prim.GetStage())
         prim_obj.name = self.sdf_path = str(prim.GetPath())
-        xform = UsdGeom.Xform(prim)
-        ops = xform.GetOrderedXformOps()
-        if ops:
-            prim_obj.matrix_world = mathutils.Matrix(ops[0].Get()).transposed()
-        else:
-            prim_obj.matrix_world = mathutils.Matrix.Identity(4)
+        prim_obj.matrix_world = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
 
         # showing, activating and selecting prim object
         prim_obj.hide_viewport = False
@@ -71,3 +66,16 @@ class ObjectProperties(HdUSDProperties):
 
         xform = UsdGeom.Xform(prim)
         xform.MakeMatrixXform().Set(Gf.Matrix4d(get_transform(obj)))
+
+    def sync_from_prim_collection(self, root_obj, prim):
+        prim_obj = self.id_data
+
+        sdf_path = str(prim.GetPath())
+        obj_name = f"{'.' * sdf_path.count('/')}{prim.GetName()}"
+
+        self.is_usd = True
+        self.sdf_path = sdf_path
+        self.cached_stage.assign(prim.GetStage())
+        prim_obj.name = obj_name
+        prim_obj.parent = root_obj
+        prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -71,7 +71,8 @@ class ObjectProperties(HdUSDProperties):
         prim_obj = self.id_data
 
         sdf_path = str(prim.GetPath())
-        obj_name = f"{'.' * sdf_path.count('/')}{prim.GetName()}"
+        # obj_name = f"{'.' * sdf_path.count('/')}{prim.GetName()}"
+        obj_name = f"{prim.GetName()}"
 
         self.is_usd = True
         self.sdf_path = sdf_path
@@ -79,3 +80,4 @@ class ObjectProperties(HdUSDProperties):
         prim_obj.name = obj_name
         prim_obj.parent = root_obj
         prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
+        prim_obj.hide_viewport = True

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -16,6 +16,7 @@ import bpy
 from pxr import UsdImagingGL
 
 from ..usd_nodes.node_tree import get_usd_nodetree
+from ..viewport import usd_collection
 from . import HdUSDProperties, log
 
 
@@ -25,13 +26,20 @@ log("Render Delegates", _render_delegates)
 
 
 class RenderSettings(bpy.types.PropertyGroup):
+    def data_source_update(self, context):
+        usd_collection.update(self.data_source)
+
     delegate: bpy.props.EnumProperty(
         name="Renderer",
         items=((name, display_name, f"Hydra render delegate: {display_name}")
                for name, display_name in _render_delegates.items()),
         default='HdRprPlugin',
     )
-    data_source: bpy.props.StringProperty(name="Data Source", default="")
+    data_source: bpy.props.StringProperty(
+        name="Data Source",
+        default="",
+        update=data_source_update
+    )
 
     @property
     def is_gl_delegate(self):

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -26,9 +26,6 @@ log("Render Delegates", _render_delegates)
 
 
 class RenderSettings(bpy.types.PropertyGroup):
-    def data_source_update(self, context):
-        usd_collection.update(context, self.data_source)
-
     delegate: bpy.props.EnumProperty(
         name="Renderer",
         items=((name, display_name, f"Hydra render delegate: {display_name}")
@@ -37,8 +34,7 @@ class RenderSettings(bpy.types.PropertyGroup):
     )
     data_source: bpy.props.StringProperty(
         name="Data Source",
-        default="",
-        update=data_source_update
+        default=""
     )
 
     @property
@@ -50,11 +46,22 @@ class RenderSettings(bpy.types.PropertyGroup):
         return self.use_usd_nodegraph and get_usd_nodetree() is not None
 
 
+class ViewportRenderSettings(bpy.types.PropertyGroup):
+    def data_source_update(self, context):
+        usd_collection.update(context, self.data_source)
+
+    data_source: bpy.props.StringProperty(
+        name="Data Source",
+        default="",
+        update=data_source_update
+    )
+
+
 class SceneProperties(HdUSDProperties):
     bl_type = bpy.types.Scene
 
     final: bpy.props.PointerProperty(type=RenderSettings)
-    viewport: bpy.props.PointerProperty(type=RenderSettings)
+    viewport: bpy.props.PointerProperty(type=ViewportRenderSettings)
 
     rpr_viewport_cpu_device: bpy.props.BoolProperty(
         name="CPU Viewport Render Device",

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -27,7 +27,7 @@ log("Render Delegates", _render_delegates)
 
 class RenderSettings(bpy.types.PropertyGroup):
     def data_source_update(self, context):
-        usd_collection.update(self.data_source)
+        usd_collection.update(context, self.data_source)
 
     delegate: bpy.props.EnumProperty(
         name="Renderer",

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -27,6 +27,9 @@ from . import CachedStageProp
 from . import log
 
 
+BLENDER_COLLECTION_NAME = "HDUSD"
+
+
 class PrimPropertyItem(PropertyGroup):
     def value_float_update(self, context):
         if not self.name:
@@ -107,9 +110,9 @@ class UsdList(PropertyGroup):
 
 
 def get_blender_prim_object(context):
-    collection = bpy.data.collections.get("HDUSD")
+    collection = bpy.data.collections.get(BLENDER_COLLECTION_NAME)
     if not collection:
-        collection = bpy.data.collections.new("HDUSD")
+        collection = bpy.data.collections.new(BLENDER_COLLECTION_NAME)
         context.scene.collection.children.link(collection)
         log("Collection created", collection)
 

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -27,7 +27,7 @@ from . import CachedStageProp
 from . import log
 
 
-BLENDER_COLLECTION_NAME = "HDUSD"
+COLLECTION_NAME = "HDUSD"
 
 
 class PrimPropertyItem(PropertyGroup):
@@ -110,10 +110,10 @@ class UsdList(PropertyGroup):
 
 
 def get_blender_prim_object(context):
-    collection = bpy.data.collections.get(BLENDER_COLLECTION_NAME)
+    collection = bpy.data.collections.get(COLLECTION_NAME)
     if not collection:
-        collection = bpy.data.collections.new(BLENDER_COLLECTION_NAME)
-        context.scene.collection.children.link(collection)
+        collection = bpy.data.collections.new(COLLECTION_NAME)
+        # context.scene.collection.children.link(collection)
         log("Collection created", collection)
 
         obj = bpy.data.objects.new("/", None)

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -113,7 +113,7 @@ def get_blender_prim_object(context):
     collection = bpy.data.collections.get(COLLECTION_NAME)
     if not collection:
         collection = bpy.data.collections.new(COLLECTION_NAME)
-        # context.scene.collection.children.link(collection)
+        context.scene.collection.children.link(collection)
         log("Collection created", collection)
 
         obj = bpy.data.objects.new("/", None)

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -48,6 +48,7 @@ from . import (
     world,
     usd_list,
     mx_nodes,
+    object,
 )
 
 
@@ -88,6 +89,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     mx_nodes.HDUSD_MX_OP_export_console,
     mx_nodes.HDUSD_MX_OP_create_basic_nodes,
     mx_nodes.HDUSD_MX_MATERIAL_PT_import_export,
+
+    object.HDUSD_OBJECT_PT_usd_settings,
 ])
 
 

--- a/src/hdusd/ui/object.py
+++ b/src/hdusd/ui/object.py
@@ -1,0 +1,33 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from . import HdUSD_Panel
+
+
+class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
+    bl_label = "USD Settings"
+    bl_context = 'object'
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.object and context.object.hdusd.is_usd
+
+    def draw(self, context):
+        self.layout.use_property_split = True
+        self.layout.use_property_decorate = False
+
+        obj = context.object
+        col = self.layout.column()
+        col.enabled = False
+        col.prop(obj.hdusd, 'sdf_path', text="USD Path")

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -217,9 +217,8 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
             print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
             return {'CANCELLED'}
 
-        flatten_stage = stage.Flatten()
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
-        print(flatten_stage.ExportToString())
+        print(stage.ExportToString())
 
         return {'FINISHED'}
 

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -217,8 +217,9 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
             print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
             return {'CANCELLED'}
 
+        flatten_stage = stage.Flatten()
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
-        print(stage.ExportToString())
+        print(flatten_stage.ExportToString())
 
         return {'FINISHED'}
 

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -120,7 +120,7 @@ class USDTree(bpy.types.ShaderNodeTree):
     def output_node_computed(self):
         context = bpy.context
         if context.scene.hdusd.viewport.data_source == self.name:
-            usd_collection.update(context, self.name)
+            usd_collection.update(context)
 
 
 class RenderTaskTree(bpy.types.ShaderNodeTree):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -17,6 +17,7 @@ import bpy
 from .nodes.hydra_render import HydraRenderNode
 from .nodes.print_file import PrintFileNode
 from .nodes.write_file import WriteFileNode
+from ..viewport import usd_collection
 
 
 class USDTree(bpy.types.ShaderNodeTree):
@@ -115,6 +116,11 @@ class USDTree(bpy.types.ShaderNodeTree):
 
         self.safe_call(create_nodes)
         self.reset()
+
+    def output_node_computed(self):
+        context = bpy.context
+        if context.scene.hdusd.viewport.data_source == self.name:
+            usd_collection.update(context, self.name)
 
 
 class RenderTaskTree(bpy.types.ShaderNodeTree):

--- a/src/hdusd/usd_nodes/nodes/base_node.py
+++ b/src/hdusd/usd_nodes/nodes/base_node.py
@@ -61,6 +61,7 @@ class USDNode(bpy.types.Node):
             stage = self.compute(group_nodes=group_nodes, **kwargs)
             self.cached_stage.assign(stage)
             self.hdusd.usd_list.update_items()
+            self.node_computed()
 
         return stage
 
@@ -85,6 +86,10 @@ class USDNode(bpy.types.Node):
 
         # getting corresponded NodeParser class
         return node.final_compute(group_nodes, **kwargs)
+
+    def node_computed(self):
+        """Notifier that stage for this node has been already computed"""
+        pass
 
     # HELPER FUNCTIONS
     # Child classes should use them to do their compute

--- a/src/hdusd/usd_nodes/nodes/hydra_render.py
+++ b/src/hdusd/usd_nodes/nodes/hydra_render.py
@@ -37,3 +37,9 @@ class HydraRenderNode(USDNode):
     def compute(self, **kwargs):
         stage = self.get_input_link('Input', **kwargs)
         return stage
+
+    def node_computed(self):
+        # notify USD nodetree that Output node was computed
+        nodetree = self.id_data
+        if self.name == nodetree.get_output_node().name:
+            nodetree.output_node_computed()

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -17,9 +17,9 @@ import mathutils
 
 
 def get_xform_transform(xform):
-    transform = mathutils.Matrix.Identity(4)
-    ops = xform.GetOrderedXformOps()
-    for op in ops:
-        transform = mathutils.Matrix(op.GetOpTransform(0)) @ transform
+    transform = mathutils.Matrix(xform.GetLocalTransformation())
+    #ops = xform.GetOrderedXformOps()
+    #for op in ops:
+    #    transform = mathutils.Matrix(op.GetOpTransform(0)) @ transform
 
     return transform.transposed()

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -1,0 +1,25 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from pxr import UsdGeom
+import mathutils
+
+
+def get_xform_transform(xform):
+    transform = mathutils.Matrix.Identity(4)
+    ops = xform.GetOrderedXformOps()
+    for op in ops:
+        transform = mathutils.Matrix(op.GetOpTransform(0)) @ transform
+
+    return transform.transposed()

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -18,8 +18,4 @@ import mathutils
 
 def get_xform_transform(xform):
     transform = mathutils.Matrix(xform.GetLocalTransformation())
-    #ops = xform.GetOrderedXformOps()
-    #for op in ops:
-    #    transform = mathutils.Matrix(op.GetOpTransform(0)) @ transform
-
     return transform.transposed()

--- a/src/hdusd/viewport/__init__.py
+++ b/src/hdusd/viewport/__init__.py
@@ -1,0 +1,14 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -1,0 +1,45 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import bpy
+
+
+def update(usd_tree_name):
+    clear()
+
+    if not usd_tree_name:
+        return
+
+    output_node = bpy.data.node_groups[usd_tree_name].get_output_node()
+    if not output_node:
+        return
+
+    stage = output_node.cached_stage()
+    if not stage:
+        stage = output_node.final_compute('Input')
+
+    if not stage:
+        return
+
+    create(stage)
+
+
+def clear():
+    print("clear")
+    pass
+
+
+def create(stage):
+    print(stage)
+    pass

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -60,19 +60,17 @@ def create(context, stage):
         context.scene.collection.children.link(collection)
         log("Collection created", collection)
 
-    def create_objects(root_prim):
-        root_obj = None if root_prim.IsPseudoRoot() else \
-            bpy.data.objects.get(str(root_prim.GetPath()))
+    def create_objects(root_obj, root_prim):
         for prim in root_prim.GetAllChildren():
             if prim.GetTypeName() not in ('Xform', 'SkelRoot'):
+                create_objects(root_obj, prim)
                 continue
 
-            obj = bpy.data.objects.new(str(prim.GetPath()), None)
-            obj.hdusd.is_usd = True
+            obj = bpy.data.objects.new('/', None)
+            obj.hdusd.sync_from_prim_collection(root_obj, prim)
             collection.objects.link(obj)
-            obj.parent = root_obj
             log("Object created", obj)
 
-            create_objects(prim)
+            create_objects(obj, prim)
 
-    create_objects(stage.GetPseudoRoot())
+    create_objects(None, stage.GetPseudoRoot())

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -21,9 +21,10 @@ log = logging.Log(tag='usd_collection')
 COLLECTION_NAME = "USD NodeTree"
 
 
-def update(context, usd_tree_name):
+def update(context):
     clear(context)
 
+    usd_tree_name = context.scene.hdusd.viewport.data_source
     if not usd_tree_name:
         return
 
@@ -74,3 +75,13 @@ def create(context, stage):
             create_objects(obj, prim)
 
     create_objects(None, stage.GetPseudoRoot())
+
+
+def scene_save_pre():
+    context = bpy.context
+    clear(context)
+
+
+def scene_save_post():
+    context = bpy.context
+    update(context)


### PR DESCRIPTION
### PURPOSE
We want export entire USD stage from selected USD node tree to be exported as empty objects into scene collection.

### EFFECT OF CHANGE
1. USD stage from selected viewport USD node tree is exported as empty objects into scene collection (called "USD NodeTree"). Created empty objects duplicate tree structure of USD stage. 
2. Added basic UI panel with USD object settings into Object tab.
3. Changes in USD node tree affect to USD NodeTree objects collection.
4. Made USD NodeTree objects collection to be not saved in .blend file.

### TECHNICAL STEPS
1. Added vieport/usd_collection.py module, which works with USD NodeTree scene collection with empty objects: create, update, clear.
2. Added USDNode.node_computed() handler. Implemented HydraRenderNode.node_computed() to notify USD node tree output_node_computed() and update objects collection.
3. Added on_save_pre(), on_save_post() handlers
4. Created HDUSD_OBJECT_PT_usd_settings UI panel with basic USD info.

### NOTES FOR REVIEWERS
Updating of USD NodeTree scene collection after USD stage changes isn't optimized, it is recreated after each changes. Optimization will be done sooner in separate another task.