### PR TITLE
RPRBLND-1699: Export object properties of the USD empty objects that are edited in the blender scene

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -21,7 +21,7 @@ from pxr import UsdGeom
 
 from ..utils.stage_cache import CachedStage
 from ..utils import depsgraph_objects
-from ..export import sdf_path, object, world
+from ..export import object, world
 
 from ..utils import logging
 log = logging.Log(tag='engine')

--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -38,10 +38,10 @@ def on_load_post(*args):
 
 @bpy.app.handlers.persistent
 def on_depsgraph_update_post(scene, depsgraph):
-    from ..properties import usd_list
+    from ..properties import object
     from ..usd_nodes import node_tree
 
-    usd_list.depsgraph_update(depsgraph)
+    object.depsgraph_update(depsgraph)
     node_tree.depsgraph_update(depsgraph)
 
 

--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -32,9 +32,6 @@ def on_load_post(*args):
     from ..usd_nodes import node_tree
     node_tree.reset()
 
-    from ..properties.usd_list import get_blender_prim_object
-    get_blender_prim_object(bpy.context)
-
 
 @bpy.app.handlers.persistent
 def on_depsgraph_update_post(scene, depsgraph):

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -29,6 +29,10 @@ def get_transform(obj: bpy.types.Object):
     return obj.matrix_world.transposed()
 
 
+def get_transform_local(obj: bpy.types.Object):
+    return obj.matrix_local.transposed()
+
+
 def sync(objects_prim, obj: bpy.types.Object, **kwargs):
     """ sync the object and any data attached """
     log("sync", obj, obj.type)

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -36,43 +36,7 @@ class ObjectProperties(HdUSDProperties):
 
         return stage.GetPrimAtPath(self.sdf_path)
 
-    def sync_from_prim(self, prim, context):
-        prim_obj = self.id_data
-
-        if not prim or str(prim.GetTypeName()) != 'Xform':
-            self.cached_stage.clear()
-            prim_obj.name = self.sdf_path = "/"
-            prim_obj.matrix_world = mathutils.Matrix.Identity(4)
-
-            # hiding, deactivating and deselecting prim object
-            prim_obj.hide_viewport = True
-            prim_obj.select_set(False)
-            if context.view_layer.objects.active == prim_obj:
-                context.view_layer.objects.active = None
-            return
-
-        self.cached_stage.assign(prim.GetStage())
-        prim_obj.name = self.sdf_path = str(prim.GetPath())
-        prim_obj.matrix_world = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
-
-        # showing, activating and selecting prim object
-        prim_obj.hide_viewport = False
-        context.view_layer.objects.active = prim_obj
-        if len(context.selected_objects) < 2:
-            if context.selected_objects:
-                context.selected_objects[0].select_set(False)
-            prim_obj.select_set(True)
-
-    def sync_to_prim(self):
-        prim = self.get_prim()
-        if not prim:
-            return
-
-        obj = self.id_data
-        xform = UsdGeom.Xform(prim)
-        xform.MakeMatrixXform().Set(Gf.Matrix4d(get_transform_local(obj)))
-
-    def sync_from_prim_collection(self, root_obj, prim):
+    def sync_from_prim(self, root_obj, prim):
         prim_obj = self.id_data
 
         self.is_usd = True
@@ -82,6 +46,15 @@ class ObjectProperties(HdUSDProperties):
         prim_obj.name = prim.GetName()
         prim_obj.parent = root_obj
         prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
+
+    def sync_to_prim(self):
+        prim = self.get_prim()
+        if not prim:
+            return
+
+        obj = self.id_data
+        xform = UsdGeom.Xform(prim)
+        xform.MakeMatrixXform().Set(Gf.Matrix4d(get_transform_local(obj)))
 
 
 def depsgraph_update(depsgraph):

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -13,13 +13,15 @@
 # limitations under the License.
 #********************************************************************
 import bpy
-import mathutils
 
 from pxr import UsdGeom, Gf
 
 from . import HdUSDProperties, CachedStageProp
 from ..export.object import get_transform_local
 from ..utils import usd as usd_utils
+
+
+GEOM_TYPES = ('Xform', 'SkelRoot')
 
 
 class ObjectProperties(HdUSDProperties):
@@ -46,6 +48,7 @@ class ObjectProperties(HdUSDProperties):
         prim_obj.name = prim.GetName()
         prim_obj.parent = root_obj
         prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
+        prim_obj.hide_viewport = prim.GetTypeName() not in GEOM_TYPES
 
     def sync_to_prim(self):
         prim = self.get_prim()

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -82,3 +82,15 @@ class ObjectProperties(HdUSDProperties):
         prim_obj.name = prim.GetName()
         prim_obj.parent = root_obj
         prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
+
+
+def depsgraph_update(depsgraph):
+    if not depsgraph.updates:
+        return
+
+    upd = depsgraph.updates[0]
+    obj = upd.id
+    if not isinstance(obj, bpy.types.Object) or not obj.hdusd.is_usd:
+        return
+
+    obj.hdusd.sync_to_prim()

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -125,7 +125,7 @@ def get_blender_prim_object(context):
 
 
 def depsgraph_update(depsgraph):
-    if len(depsgraph.updates) != 1:
+    if not depsgraph.updates:
         return
 
     upd = depsgraph.updates[0]

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -122,15 +122,3 @@ def get_blender_prim_object(context):
         log("Object created", obj)
 
     return collection.objects[0]
-
-
-def depsgraph_update(depsgraph):
-    if not depsgraph.updates:
-        return
-
-    upd = depsgraph.updates[0]
-    obj = upd.id
-    if not isinstance(obj, bpy.types.Object) or not obj.hdusd.is_usd:
-        return
-
-    obj.hdusd.sync_to_prim()

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -27,9 +27,6 @@ from . import CachedStageProp
 from . import log
 
 
-COLLECTION_NAME = "HDUSD"
-
-
 class PrimPropertyItem(PropertyGroup):
     def value_float_update(self, context):
         if not self.name:
@@ -69,16 +66,12 @@ class UsdListItem(PropertyGroup):
 
 class UsdList(PropertyGroup):
     def item_index_update(self, context):
-        prim_obj = get_blender_prim_object(context)
-        
         self.prim_properties.clear()
         if self.item_index == -1:
-            prim_obj.hdusd.sync_from_prim(None, context)
             return
 
         item = self.items[self.item_index]
         prim = self.get_prim(item)
-        prim_obj.hdusd.sync_from_prim(prim, context)
 
         def add_prop(name, value):
             prop = self.prim_properties.add()
@@ -107,18 +100,3 @@ class UsdList(PropertyGroup):
     def get_prim(self, item):
         stage = self.cached_stage()
         return stage.GetPrimAtPath(item.sdf_path) if stage else None
-
-
-def get_blender_prim_object(context):
-    collection = bpy.data.collections.get(COLLECTION_NAME)
-    if not collection:
-        collection = bpy.data.collections.new(COLLECTION_NAME)
-        context.scene.collection.children.link(collection)
-        log("Collection created", collection)
-
-        obj = bpy.data.objects.new("/", None)
-        obj.hdusd.is_usd = True
-        collection.objects.link(obj)
-        log("Object created", obj)
-
-    return collection.objects[0]

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -91,6 +91,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     mx_nodes.HDUSD_MX_MATERIAL_PT_import_export,
 
     object.HDUSD_OBJECT_PT_usd_settings,
+    object.HDUSD_OP_usd_object_show_hide,
 ])
 
 

--- a/src/hdusd/ui/object.py
+++ b/src/hdusd/ui/object.py
@@ -12,11 +12,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+import bpy
+
+from pxr import UsdGeom
+
 from . import HdUSD_Panel
+from ..properties.object import GEOM_TYPES
+
+
+class HDUSD_OP_usd_object_show_hide(bpy.types.Operator):
+    """Show/Hide USD object"""
+    bl_idname = "hdusd.usd_object_show_hide"
+    bl_label = "Show/Hide"
+
+    def execute(self, context):
+        obj = context.object
+        prim = obj.hdusd.get_prim()
+        im = UsdGeom.Imageable(prim)
+        if im.ComputeVisibility() == 'invisible':
+            im.MakeVisible()
+        else:
+            im.MakeInvisible()
+
+        return {'FINISHED'}
 
 
 class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
-    bl_label = "USD Prim Settings"
+    bl_label = "USD Settings"
     bl_context = 'object'
 
     @classmethod
@@ -46,3 +68,13 @@ class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
 
         col1.label(text="Type")
         col2.label(text=prim.GetTypeName())
+
+        if prim.GetTypeName() in GEOM_TYPES:
+            visible = UsdGeom.Imageable(prim).ComputeVisibility() != 'invisible'
+            icon = 'HIDE_OFF' if visible else 'HIDE_ON'
+
+            col1.label(text="Visibility")
+            col2.operator(HDUSD_OP_usd_object_show_hide.bl_idname,
+                          text="Hide" if visible else 'Show',
+                          icon='HIDE_OFF' if visible else 'HIDE_ON',
+                          emboss=True, depress=False)

--- a/src/hdusd/ui/object.py
+++ b/src/hdusd/ui/object.py
@@ -16,7 +16,7 @@ from . import HdUSD_Panel
 
 
 class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
-    bl_label = "USD Settings"
+    bl_label = "USD Prim Settings"
     bl_context = 'object'
 
     @classmethod
@@ -24,10 +24,25 @@ class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
         return super().poll(context) and context.object and context.object.hdusd.is_usd
 
     def draw(self, context):
-        self.layout.use_property_split = True
-        self.layout.use_property_decorate = False
-
         obj = context.object
-        col = self.layout.column()
-        col.enabled = False
-        col.prop(obj.hdusd, 'sdf_path', text="USD Path")
+        prim = obj.hdusd.get_prim()
+        if not prim:
+            return
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        split = layout.row(align=True).split(factor=0.4)
+        col1 = split.column()
+        col1.alignment = 'RIGHT'
+        col2 = split.column()
+
+        col1.label(text="Name")
+        col2.label(text=prim.GetName())
+
+        col1.label(text="Path")
+        col2.label(text=str(prim.GetPath()))
+
+        col1.label(text="Type")
+        col2.label(text=prim.GetTypeName())

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -35,7 +35,7 @@ class USDTree(bpy.types.ShaderNodeTree):
     COMPAT_ENGINES = {'HdUSD'}
 
     _is_updating = False
-    _is_node_safe_call = False
+    _is_safe_call = False
 
     @classmethod
     def poll(cls, context):
@@ -70,7 +70,7 @@ class USDTree(bpy.types.ShaderNodeTree):
 
     # this is called from Blender
     def update(self):
-        if self._is_node_safe_call:
+        if self._is_safe_call:
             return
 
         self._reset_nodes(self.nodes, False)
@@ -87,15 +87,14 @@ class USDTree(bpy.types.ShaderNodeTree):
 
     def safe_call(self, op, *args, **kwargs):
         """This function prevents call of self.update() during calling our function"""
-        if self._is_node_safe_call:
-            op(*args, **kwargs)
-            return
+        if self._is_safe_call:
+            return op(*args, **kwargs)
 
-        self._is_node_safe_call = True
+        self._is_safe_call = True
         try:
-            op(*args, **kwargs)
+            return op(*args, **kwargs)
         finally:
-            self._is_node_safe_call = False
+            self._is_safe_call = False
 
     def add_basic_nodes(self, source='SCENE'):
         """ Reset basic node tree structure using scene or USD file as an input """

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -63,14 +63,9 @@ def create(context, stage):
 
     def create_objects(root_obj, root_prim):
         for prim in root_prim.GetAllChildren():
-            if prim.GetTypeName() not in ('Xform', 'SkelRoot'):
-                create_objects(root_obj, prim)
-                continue
-
             obj = bpy.data.objects.new('/', None)
             obj.hdusd.sync_from_prim_collection(root_obj, prim)
             collection.objects.link(obj)
-            log("Object created", obj)
 
             create_objects(obj, prim)
 

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -64,7 +64,7 @@ def create(context, stage):
     def create_objects(root_obj, root_prim):
         for prim in root_prim.GetAllChildren():
             obj = bpy.data.objects.new('/', None)
-            obj.hdusd.sync_from_prim_collection(root_obj, prim)
+            obj.hdusd.sync_from_prim(root_obj, prim)
             collection.objects.link(obj)
 
             create_objects(obj, prim)

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -34,9 +34,6 @@ def update(context):
 
     stage = output_node.cached_stage()
     if not stage:
-        stage = output_node.final_compute('Input')
-
-    if not stage:
         return
 
     create(context, stage)


### PR DESCRIPTION
### PURPOSE
Export object properties of the USD empty objects that are edited in the blender scene
For example position, visibility, etc should be exported for each “empty object” in the USD collection as an edit layer on top of the USD node tree data.

### EFFECT OF CHANGE
USD empty objects now can change USD stage: like changing transform and showed more info about USD prim.

### TECHNICAL STEPS
1. Adjusted ObjectProperties class to work with USD prim
2. Improved Object UI panel for showing USD Settings: name, path, change visibility. dded Show/Hide operator. Prepared to show more info.
3. Removed usage of UsdList item object as not needed.
4. Made some code improvements, renamings.
