### PR TITLE
RPRBLND-1723: Call for scene update on USD nodegraph update

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -119,11 +119,16 @@ class HdUSDEngine(bpy.types.RenderEngine):
         log('view_update', self.as_pointer())
 
         try:
-            if self.engine:
+            data_source = depsgraph.scene.hdusd.viewport.data_source
+            if self.engine and self.engine.data_source == data_source:
                 self.engine.sync_update(context, depsgraph)
                 return
 
-            self.engine = viewport_engine.ViewportEngine(self)
+            if data_source:
+                self.engine = viewport_engine.ViewportEngineNodetree(self)
+            else:
+                self.engine = viewport_engine.ViewportEngine(self)
+
             self.engine.sync(context, depsgraph)
 
         except Exception as e:

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -154,20 +154,9 @@ class ViewportEngine(Engine):
     """ Viewport render engine """
 
     TYPE = 'VIEWPORT'
-    _engine_refs = set()
-
-    @classmethod
-    def output_node_computed(cls, nodetree):
-        for engine_ref in cls._engine_refs:
-            engine = engine_ref()
-            output_node = nodetree.get_output_node()
-            engine.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
 
     def __init__(self, rpr_engine):
         super().__init__(rpr_engine)
-
-        # adding current engine to engine refs
-        self._engine_refs.add(weakref.ref(self))
 
         self.view_settings = None
         self.renderer = None
@@ -179,30 +168,12 @@ class ViewportEngine(Engine):
         self.shading_data = None
 
         self.is_gl_delegate = False
-        self.data_source = False
+
+        self.data_source = ""
 
     def __del__(self):
         # explicit renderer deletion
         self.renderer = None
-
-        # removing current engine from engine refs
-        self._engine_refs.remove(weakref.ref(self))
-
-    def nodetree_stage_changed(self, stage):
-        if not stage:
-            return stage
-
-        engine_stage = self.stage
-        root_prim = engine_stage.GetPseudoRoot()
-
-        for prim in engine_stage.GetPseudoRoot().GetAllChildren():
-            engine_stage.RemovePrim(prim.GetPath())
-
-        for prim in stage.GetPseudoRoot().GetAllChildren():
-            override_prim = engine_stage.OverridePrim(
-                root_prim.GetPath().AppendChild(prim.GetName()))
-            override_prim.GetReferences().AddReference(stage.GetRootLayer().realPath,
-                                                       prim.GetPath())
 
     def notify_status(self, info, status, redraw=True):
         """ Display export progress status """
@@ -220,7 +191,6 @@ class ViewportEngine(Engine):
         settings = scene.hdusd.viewport
 
         self.is_gl_delegate = settings.is_gl_delegate
-        self.data_source = settings.data_source
 
         self.space_data = context.space_data
         self.shading_data = ShadingData(context)
@@ -238,29 +208,21 @@ class ViewportEngine(Engine):
         # self.renderer.SetRendererSetting('renderMode', 'Global Illumination')
         # self.renderer.SetRendererSetting('renderQuality', 'Northstar')
 
-        if self.data_source:
-            stage = self.cached_stage.create()
-            UsdGeom.SetStageMetersPerUnit(stage, 1)
-            UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-
-            nodetree = bpy.data.node_groups[self.data_source]
-
-            output_node = nodetree.get_output_node()
-            self.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
-
-        else:
-            stage = self.cached_stage.create()
-            self._export_depsgraph(
-                stage, depsgraph,
-                space_data=self.space_data,
-                use_scene_lights=self.shading_data.use_scene_lights,
-                is_gl_delegate=self.is_gl_delegate,
-            )
+        self._sync(context, depsgraph)
 
         self.is_synced = True
         log('Finish sync')
 
-    def _sync_update_blend(self, context, depsgraph):
+    def _sync(self, context, depsgraph):
+        stage = self.cached_stage.create()
+        self._export_depsgraph(
+            stage, depsgraph,
+            space_data=self.space_data,
+            use_scene_lights=self.shading_data.use_scene_lights,
+            is_gl_delegate=self.is_gl_delegate,
+        )
+
+    def _sync_update(self, context, depsgraph):
         scene = depsgraph.scene
 
         root_prim = self.stage.GetPseudoRoot()
@@ -318,20 +280,6 @@ class ViewportEngine(Engine):
         if sync_collection:
             self.sync_objects_collection(depsgraph)
 
-    def _sync_update_nodegraph(self, context, depsgraph):
-        # get supported updates and sort by priorities
-        updates = []
-        for obj_type in (bpy.types.Scene,):
-            updates.extend(update for update in depsgraph.updates
-                           if isinstance(update.id, obj_type))
-
-        for update in updates:
-            obj = update.id
-            log("sync_update", obj)
-            if isinstance(obj, bpy.types.Scene):
-                self.update_render(obj)
-                continue
-
     def sync_update(self, context, depsgraph):
         """ sync just the updated things """
 
@@ -341,10 +289,7 @@ class ViewportEngine(Engine):
         if self.renderer.IsPauseRendererSupported():
             self.renderer.PauseRenderer()
 
-        if self.data_source:
-            self._sync_update_nodegraph(context, depsgraph)
-        else:
-            self._sync_update_blend(context, depsgraph)
+        self._sync_update(context, depsgraph)
 
         if self.renderer.IsPauseRendererSupported():
             self.renderer.ResumeRenderer()
@@ -414,7 +359,7 @@ class ViewportEngine(Engine):
         self.renderer.SetRendererPlugin(prop.delegate)
 
     def resync_scene_lights(self, scene):
-        if self.data_source or not self.shading_data.use_scene_lights:
+        if self.shading_data.use_scene_lights:
             return
 
         for obj in scene.objects:
@@ -448,3 +393,67 @@ class ViewportEngine(Engine):
                     continue
 
                 object.sync(root_prim, obj)
+
+
+class ViewportEngineNodetree(ViewportEngine):
+    _engine_refs = set()
+
+    @classmethod
+    def output_node_computed(cls, nodetree):
+        for engine_ref in cls._engine_refs:
+            engine = engine_ref()
+            output_node = nodetree.get_output_node()
+            engine.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
+
+    def __init__(self, rpr_engine):
+        super().__init__(rpr_engine)
+
+        # adding current engine to engine refs
+        self._engine_refs.add(weakref.ref(self))
+
+    def __del__(self):
+        super().__del__()
+
+        # removing current engine from engine refs
+        self._engine_refs.remove(weakref.ref(self))
+
+    def _sync(self, context, depsgraph):
+        self.data_source = depsgraph.scene.hdusd.viewport.data_source
+
+        stage = self.cached_stage.create()
+        UsdGeom.SetStageMetersPerUnit(stage, 1)
+        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
+
+        nodetree = bpy.data.node_groups[self.data_source]
+        output_node = nodetree.get_output_node()
+        self.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
+
+    def _sync_update(self, context, depsgraph):
+        # get supported updates and sort by priorities
+        updates = []
+        for obj_type in (bpy.types.Scene,):
+            updates.extend(update for update in depsgraph.updates
+                           if isinstance(update.id, obj_type))
+
+        for update in updates:
+            obj = update.id
+            log("sync_update", obj)
+            if isinstance(obj, bpy.types.Scene):
+                self.update_render(obj)
+                continue
+
+    def nodetree_stage_changed(self, stage):
+        engine_stage = self.stage
+        root_prim = engine_stage.GetPseudoRoot()
+
+        for prim in engine_stage.GetPseudoRoot().GetAllChildren():
+            engine_stage.RemovePrim(prim.GetPath())
+
+        if not stage:
+            return
+
+        for prim in stage.GetPseudoRoot().GetAllChildren():
+            override_prim = engine_stage.OverridePrim(
+                root_prim.GetPath().AppendChild(prim.GetName()))
+            override_prim.GetReferences().AddReference(stage.GetRootLayer().realPath,
+                                                       prim.GetPath())

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -18,6 +18,7 @@ from .nodes.hydra_render import HydraRenderNode
 from .nodes.print_file import PrintFileNode
 from .nodes.write_file import WriteFileNode
 from ..viewport import usd_collection
+from ..engine.viewport_engine import ViewportEngine
 
 
 class USDTree(bpy.types.ShaderNodeTree):
@@ -120,6 +121,8 @@ class USDTree(bpy.types.ShaderNodeTree):
         context = bpy.context
         if context.scene.hdusd.viewport.data_source == self.name:
             usd_collection.update(context)
+
+            ViewportEngine.output_node_computed(self)
 
 
 class RenderTaskTree(bpy.types.ShaderNodeTree):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -18,7 +18,7 @@ from .nodes.hydra_render import HydraRenderNode
 from .nodes.print_file import PrintFileNode
 from .nodes.write_file import WriteFileNode
 from ..viewport import usd_collection
-from ..engine.viewport_engine import ViewportEngine
+from ..engine.viewport_engine import ViewportEngineNodetree
 
 
 class USDTree(bpy.types.ShaderNodeTree):
@@ -122,7 +122,7 @@ class USDTree(bpy.types.ShaderNodeTree):
         if context.scene.hdusd.viewport.data_source == self.name:
             usd_collection.update(context)
 
-            ViewportEngine.output_node_computed(self)
+            ViewportEngineNodetree.output_node_computed(self)
 
 
 class RenderTaskTree(bpy.types.ShaderNodeTree):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -122,7 +122,7 @@ class USDTree(bpy.types.ShaderNodeTree):
         if context.scene.hdusd.viewport.data_source == self.name:
             usd_collection.update(context)
 
-            ViewportEngineNodetree.output_node_computed(self)
+        ViewportEngineNodetree.nodetree_output_node_computed(self)
 
 
 class RenderTaskTree(bpy.types.ShaderNodeTree):

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -14,6 +14,8 @@
 #********************************************************************
 import bpy
 
+from pxr import Sdf
+
 from ..utils import logging
 log = logging.Log(tag='usd_collection')
 
@@ -22,21 +24,54 @@ COLLECTION_NAME = "USD NodeTree"
 
 
 def update(context):
-    clear(context)
-
     usd_tree_name = context.scene.hdusd.viewport.data_source
     if not usd_tree_name:
+        clear(context)
         return
 
     output_node = bpy.data.node_groups[usd_tree_name].get_output_node()
     if not output_node:
+        clear(context)
         return
 
     stage = output_node.cached_stage()
     if not stage:
+        clear(context)
         return
 
-    create(context, stage)
+    collection = bpy.data.collections.get(COLLECTION_NAME)
+    if not collection:
+        collection = bpy.data.collections.new(COLLECTION_NAME)
+        context.scene.collection.children.link(collection)
+        log("Collection created", collection)
+
+    objects = {}
+    for obj in collection.objects:
+        if obj.hdusd.is_usd:
+            objects[obj.hdusd.sdf_path] = obj
+    obj_paths = set(objects.keys())
+
+    prim_paths = set()
+    for prim in stage.TraverseAll():
+        prim_paths.add(str(prim.GetPath()))
+
+    paths_to_remove = obj_paths - prim_paths
+    paths_to_add = prim_paths - obj_paths
+
+    for path in paths_to_remove:
+        obj = objects.pop(path)
+        bpy.data.objects.remove(obj)
+
+    for path in sorted(paths_to_add):
+        parent_path = str(Sdf.Path(path).GetParentPath())
+        parent_obj = None if parent_path == '/' else objects[parent_path]
+
+        prim = stage.GetPrimAtPath(path)
+        obj = bpy.data.objects.new('/', None)
+        obj.hdusd.sync_from_prim(parent_obj, prim)
+        collection.objects.link(obj)
+
+        objects[path] = obj
 
 
 def clear(context):
@@ -49,24 +84,6 @@ def clear(context):
             bpy.data.objects.remove(obj)
 
     bpy.data.collections.remove(collection)
-
-
-def create(context, stage):
-    collection = bpy.data.collections.get(COLLECTION_NAME)
-    if not collection:
-        collection = bpy.data.collections.new(COLLECTION_NAME)
-        context.scene.collection.children.link(collection)
-        log("Collection created", collection)
-
-    def create_objects(root_obj, root_prim):
-        for prim in root_prim.GetAllChildren():
-            obj = bpy.data.objects.new('/', None)
-            obj.hdusd.sync_from_prim(root_obj, prim)
-            collection.objects.link(obj)
-
-            create_objects(obj, prim)
-
-    create_objects(None, stage.GetPseudoRoot())
 
 
 def scene_save_pre():


### PR DESCRIPTION
### PURPOSE
When nodetree data source is selected for viewport, we want to see interactive updates of selected nodetree (node, scene changes) in viewport rendering.

### EFFECT OF CHANGE
Applied viewport render updates on USD node tree update, when nodetree data source is selected for viewport.

### TECHNICAL STEPS
1. Made refactoring: splitted ViewportEngine to 2 classes ViewportEngine and ViewportEngineNodetree for easier maintanance.
2. Implemented notification system from USD nodetree output node stage changes to ViewportEngineNodetree:
    - added set of references of ViewportEngineNodetree instances
    - implemented ViewportEngineNodetree.nodetree_output_node_computed(), ViewportEngineNodetree.nodetree_stage_changed().
3. Improved algorithm of updating blender objects for USD tree in USD collection.
