### PR TITLE
RPRBLND-1756: Support MaterialX <nodegraph>

### DIFF
--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -82,7 +82,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         def import_node(mx_node, layer):
             mx_nodegraph = mx_node.getParent()
-            node_name = mx_utils.get_node_name(mx_node)
+            node_name = mx_utils.get_full_node_name(mx_node)
             file_prefix = mx_utils.get_file_prefix(mx_node, file_path)
 
             if node_name in self.nodes:

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -82,17 +82,17 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         def import_node(mx_node, layer):
             mx_nodegraph = mx_node.getParent()
-            node_name = mx_utils.get_full_node_name(mx_node)
+            node_path = mx_node.getNamePath()
             file_prefix = mx_utils.get_file_prefix(mx_node, file_path)
 
-            if node_name in self.nodes:
-                layers[node_name] = max(layers[node_name], layer)
-                return self.nodes[node_name]
+            if node_path in self.nodes:
+                layers[node_path] = max(layers[node_path], layer)
+                return self.nodes[node_path]
 
             MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
             node = self.nodes.new(MxNode_cls.bl_idname)
-            node.name = node_name
-            layers[node_name] = layer
+            node.name = node_path
+            layers[node_path] = layer
 
             node.data_type = mx_node.getType()
             for mx_param in mx_node.getParameters():

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -82,18 +82,8 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
 
         def import_node(mx_node, layer):
             mx_nodegraph = mx_node.getParent()
-
-            # getting node_name and file_prefix including parent nodegraphs
-            node_name = mx_node.getName()
-            file_prefix = file_path.parent
-            n = mx_node
-            while True:
-                n = n.getParent()
-                file_prefix /= n.getFilePrefix()
-                if isinstance(n, mx.Document):
-                    break
-
-                node_name = f"{n.getName()}:{node_name}"
+            node_name = mx_utils.get_node_name(mx_node)
+            file_prefix = mx_utils.get_file_prefix(mx_node, file_path)
 
             if node_name in self.nodes:
                 layers[node_name] = max(layers[node_name], layer)

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -77,77 +77,81 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         return doc
 
     def import_(self, doc: mx.Document, file_path):
-        self.nodes.clear()
-        layers = {}
+        def do_import():
+            self.nodes.clear()
+            layers = {}
 
-        def import_node(mx_node, layer):
-            mx_nodegraph = mx_node.getParent()
-            node_path = mx_node.getNamePath()
-            file_prefix = mx_utils.get_file_prefix(mx_node, file_path)
+            def import_node(mx_node, layer):
+                mx_nodegraph = mx_node.getParent()
+                node_path = mx_node.getNamePath()
+                file_prefix = mx_utils.get_file_prefix(mx_node, file_path)
 
-            if node_path in self.nodes:
-                layers[node_path] = max(layers[node_path], layer)
-                return self.nodes[node_path]
+                if node_path in self.nodes:
+                    layers[node_path] = max(layers[node_path], layer)
+                    return self.nodes[node_path]
 
-            MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
-            node = self.nodes.new(MxNode_cls.bl_idname)
-            node.name = node_path
-            layers[node_path] = layer
+                MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
+                node = self.nodes.new(MxNode_cls.bl_idname)
+                node.name = node_path
+                layers[node_path] = layer
 
-            node.data_type = mx_node.getType()
-            for mx_param in mx_node.getParameters():
-                node.set_param_value(
-                    mx_param.getName(),
-                    mx_utils.parse_value(mx_param.getValue(), mx_param.getType(), file_prefix))
+                node.data_type = mx_node.getType()
+                for mx_param in mx_node.getParameters():
+                    node.set_param_value(
+                        mx_param.getName(),
+                        mx_utils.parse_value(mx_param.getValue(), mx_param.getType(), file_prefix))
 
-            for mx_input in mx_node.getInputs():
-                input_name = mx_input.getName()
-                val = mx_input.getValue()
-                if val is not None:
-                    node.set_input_default(
-                        input_name,
-                        mx_utils.parse_value(val, mx_input.getType(), file_prefix))
-                    continue
+                for mx_input in mx_node.getInputs():
+                    input_name = mx_input.getName()
+                    val = mx_input.getValue()
+                    if val is not None:
+                        node.set_input_default(
+                            input_name,
+                            mx_utils.parse_value(val, mx_input.getType(), file_prefix))
+                        continue
 
-                node_name = mx_input.getNodeName()
-                if node_name:
-                    new_mx_node = mx_nodegraph.getNode(node_name)
-                    new_node = import_node(new_mx_node, layer + 1)
-                    self.links.new(new_node.outputs[0], node.inputs[input_name])
-                    continue
+                    node_name = mx_input.getNodeName()
+                    if node_name:
+                        new_mx_node = mx_nodegraph.getNode(node_name)
+                        new_node = import_node(new_mx_node, layer + 1)
+                        self.links.new(new_node.outputs[0], node.inputs[input_name])
+                        continue
 
-                new_nodegraph_name = mx_input.getAttribute('nodegraph')
-                if new_nodegraph_name:
-                    output_name = mx_input.getAttribute('output')
-                    new_mx_nodegraph = mx_nodegraph.getNodeGraph(new_nodegraph_name)
-                    mx_output = new_mx_nodegraph.getOutput(output_name)
-                    node_name = mx_output.getNodeName()
-                    new_mx_node = new_mx_nodegraph.getNode(node_name)
-                    new_node = import_node(new_mx_node, layer + 1)
-                    self.links.new(new_node.outputs[0], node.inputs[input_name])
-                    continue
+                    new_nodegraph_name = mx_input.getAttribute('nodegraph')
+                    if new_nodegraph_name:
+                        output_name = mx_input.getAttribute('output')
+                        new_mx_nodegraph = mx_nodegraph.getNodeGraph(new_nodegraph_name)
+                        mx_output = new_mx_nodegraph.getOutput(output_name)
+                        node_name = mx_output.getNodeName()
+                        new_mx_node = new_mx_nodegraph.getNode(node_name)
+                        new_node = import_node(new_mx_node, layer + 1)
+                        self.links.new(new_node.outputs[0], node.inputs[input_name])
+                        continue
 
-            node.ui_folders_check()
-            return node
+                node.ui_folders_check()
+                return node
 
-        mx_node = next(n for n in doc.getNodes() if n.getCategory() == 'surfacematerial')
-        import_node(mx_node, 0)
+            mx_node = next(n for n in doc.getNodes() if n.getCategory() == 'surfacematerial')
+            import_node(mx_node, 0)
 
-        # placing nodes by layers
-        node_layers = [[] for _ in range(max(layers.values()) + 1)]
-        for node in self.nodes:
-            node_layers[layers[node.name]].append(node.name)
+            # placing nodes by layers
+            node_layers = [[] for _ in range(max(layers.values()) + 1)]
+            for node in self.nodes:
+                node_layers[layers[node.name]].append(node.name)
 
-        loc_x = 0
-        for i, node_names in enumerate(node_layers):
-            loc_y = 0
-            for name in node_names:
-                node = self.nodes[name]
-                node.location = (loc_x, loc_y)
-                loc_y -= NODE_LAYER_SHIFT_Y
-                loc_x -= NODE_LAYER_SHIFT_X
+            loc_x = 0
+            for i, node_names in enumerate(node_layers):
+                loc_y = 0
+                for name in node_names:
+                    node = self.nodes[name]
+                    node.location = (loc_x, loc_y)
+                    loc_y -= NODE_LAYER_SHIFT_Y
+                    loc_x -= NODE_LAYER_SHIFT_X
 
-            loc_x -= NODE_LAYER_SEPARATION_WIDTH
+                loc_x -= NODE_LAYER_SEPARATION_WIDTH
+
+        self.no_update_call(do_import)
+        self.update_()
 
     def create_basic_nodes(self, node_name='PBR_standard_surface'):
         """ Reset basic node tree structure using scene or USD file as an input """

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -201,8 +201,8 @@ class MxNode(bpy.types.ShaderNode):
         for in_key in range(len(self.inputs)):
             values.append(self.get_input_value(in_key, **kwargs))
 
-        mx_nodegraph = mx_utils.get_nodegraph_by_full_node_name(doc, self.name, True)
-        node_name = mx_utils.get_node_name(self.name)
+        mx_nodegraph = mx_utils.get_nodegraph_by_node_path(doc, self.name, True)
+        node_name = mx_utils.get_node_name_by_node_path(self.name)
         mx_node = mx_nodegraph.addNode(nodedef.getNodeString(), node_name, nd_output.getType())
         for in_key, val in enumerate(values):
             nd_input = self.get_nodedef_input(in_key)
@@ -240,9 +240,9 @@ class MxNode(bpy.types.ShaderNode):
 
     def _compute_node(self, node, out_key, **kwargs):
         doc = kwargs['doc']
-        mx_nodegraph = mx_utils.get_nodegraph_by_full_node_name(doc, node.name)
+        mx_nodegraph = mx_utils.get_nodegraph_by_node_path(doc, node.name)
         if mx_nodegraph:
-            node_name = mx_utils.get_node_name(node.name)
+            node_name = mx_utils.get_node_name_by_node_path(node.name)
             mx_node = mx_nodegraph.getNode(node_name)
             if mx_node:
                 return mx_node

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -35,15 +35,20 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
         nd_input = nd.getInput(self.name)
         nd_type = nd_input.getType()
 
+        uiname = mx_utils.get_attr(nd_input, 'uiname', title_str(nd_input.getName()))
+        if nd.getName() == "ND_rpr_uber_surfaceshader":
+            # special case for ND_rpr_uber_surfaceshader
+            uifolder = mx_utils.get_attr(nd_input, 'uifolder')
+            uiname = f"{uifolder} {uiname}"
+
         if self.is_linked or mx_utils.is_shader_type(nd_type) or nd_input.getValue() is None:
-            uiname = mx_utils.get_attr(nd_input, 'uiname', title_str(nd_input.getName()))
             uitype = title_str(nd_type)
             if uiname.lower() == uitype.lower():
                 layout.label(text=uitype)
             else:
                 layout.label(text=f"{uiname}: {uitype}")
         else:
-            layout.prop(node.prop, MxNodeDef._input_prop_name(self.name))
+            layout.prop(node.prop, MxNodeDef._input_prop_name(self.name), text=uiname)
 
     def draw_color(self, context, node):
         return self.get_color(node.prop.nodedef().getInput(self.name).getType())

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -201,7 +201,9 @@ class MxNode(bpy.types.ShaderNode):
         for in_key in range(len(self.inputs)):
             values.append(self.get_input_value(in_key, **kwargs))
 
-        node = doc.addNode(nodedef.getNodeString(), code_str(self.name), nd_output.getType())
+        mx_nodegraph = mx_utils.get_nodegraph_by_full_node_name(doc, self.name, True)
+        node_name = mx_utils.get_node_name(self.name)
+        mx_node = mx_nodegraph.addNode(nodedef.getNodeString(), node_name, nd_output.getType())
         for in_key, val in enumerate(values):
             nd_input = self.get_nodedef_input(in_key)
             nd_type = nd_input.getType()
@@ -213,8 +215,8 @@ class MxNode(bpy.types.ShaderNode):
                 if nd_val is None or mx_utils.is_value_equal(nd_val, val, nd_type):
                     continue
 
-            input = node.addInput(nd_input.getName(), nd_type)
-            mx_utils.set_param_value(input, val, nd_type)
+            mx_input = mx_node.addInput(nd_input.getName(), nd_type)
+            mx_utils.set_param_value(mx_input, val, nd_type)
 
         for nd_input in mx_utils.get_nodedef_inputs(nodedef, True):
             val = self.get_input_param_value(nd_input.getName())
@@ -222,8 +224,8 @@ class MxNode(bpy.types.ShaderNode):
             if mx_utils.is_value_equal(nd_input.getValue(), val, nd_type):
                 continue
 
-            input = node.addInput(nd_input.getName(), nd_type)
-            mx_utils.set_param_value(input, val, nd_type)
+            mx_input = mx_node.addInput(nd_input.getName(), nd_type)
+            mx_utils.set_param_value(mx_input, val, nd_type)
 
         for nd_param in nodedef.getParameters():
             val = self.get_param_value(nd_param.getName())
@@ -231,16 +233,19 @@ class MxNode(bpy.types.ShaderNode):
             if mx_utils.is_value_equal(nd_param.getValue(), val, nd_type):
                 continue
 
-            param = node.addParameter(nd_param.getName(), nd_type)
-            mx_utils.set_param_value(param, val, nd_type)
+            mx_param = mx_node.addParameter(nd_param.getName(), nd_type)
+            mx_utils.set_param_value(mx_param, val, nd_type)
 
-        return node
+        return mx_node
 
     def _compute_node(self, node, out_key, **kwargs):
         doc = kwargs['doc']
-        mx_node = doc.getNode(code_str(node.name))
-        if mx_node:
-            return mx_node
+        mx_nodegraph = mx_utils.get_nodegraph_by_full_node_name(doc, node.name)
+        if mx_nodegraph:
+            node_name = mx_utils.get_node_name(node.name)
+            mx_node = mx_nodegraph.getNode(node_name)
+            if mx_node:
+                return mx_node
 
         return node.compute(out_key, **kwargs)
 

--- a/src/hdusd/ui/mx_nodes.py
+++ b/src/hdusd/ui/mx_nodes.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+from pathlib import Path
 import MaterialX as mx
 
 import bpy
@@ -47,7 +48,7 @@ class HDUSD_MX_OP_import_file(HdUSD_Operator, ImportHelper):
             return {'CANCELLED'}
 
         mx_node_tree = context.space_data.edit_tree
-        mx_node_tree.import_(doc)
+        mx_node_tree.import_(doc, Path(self.filepath))
 
         return {'FINISHED'}
 

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -14,7 +14,7 @@
 #********************************************************************
 import MaterialX as mx
 
-from . import title_str
+from . import title_str, code_str
 
 from . import logging
 log = logging.Log(tag='utils.mx')
@@ -97,11 +97,11 @@ def get_nodedef_inputs(nodedef, uniform=None):
                 yield input
 
 
-def get_node_name(mx_node):
+def get_full_node_name(mx_node):
     name = mx_node.getName()
     n = mx_node.getParent()
     while not isinstance(n, mx.Document):
-        name = f"{n.getName()}:{name}"
+        name = f"{n.getName()}/{name}"
         n = n.getParent()
 
     return name
@@ -117,3 +117,23 @@ def get_file_prefix(mx_node, file_path):
             break
 
     return file_prefix.resolve()
+
+
+def get_nodegraph_by_full_node_name(doc, full_node_name, do_create=False):
+    nodegraph_names = code_str(full_node_name).split('/')[:-1]
+    mx_nodegraph = doc
+    for nodegraph_name in nodegraph_names:
+        next_mx_nodegraph = mx_nodegraph.getNodeGraph(nodegraph_name)
+        if not next_mx_nodegraph:
+            if do_create:
+                next_mx_nodegraph = mx_nodegraph.addNodeGraph(nodegraph_name)
+            else:
+                return None
+
+        mx_nodegraph = next_mx_nodegraph
+
+    return mx_nodegraph
+
+
+def get_node_name(full_node_name):
+    return code_str(full_node_name.split('/')[-1])

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -28,6 +28,15 @@ def set_param_value(mx_param, val, nd_type):
         if val_nodegraph == param_nodegraph:
             mx_param.setNodeName(node_name)
         else:
+            # checking nodegraph paths
+            val_ng_path = val_nodegraph.getNamePath()
+            param_ng_path = param_nodegraph.getNamePath()
+            ind = val_ng_path.rfind('/')
+            ind = ind if ind >= 0 else 0
+            if param_ng_path != val_ng_path[:ind]:
+                raise ValueError(f"Inconsistent nodegraphs. Cannot connect input "
+                                 f"{mx_param.getNamePath()} to {val.getNamePath()}")
+
             mx_output = val_nodegraph.getOutput(f"out_{node_name}")
             if not mx_output:
                 mx_output = val_nodegraph.addOutput(f"out_{node_name}", val.getType())
@@ -38,6 +47,7 @@ def set_param_value(mx_param, val, nd_type):
 
     elif nd_type == 'filename':
         mx_param.setValueString(val)
+
     else:
         mx_type = getattr(mx, title_str(nd_type), None)
         if mx_type:

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -95,3 +95,25 @@ def get_nodedef_inputs(nodedef, uniform=None):
         else:
             if not uniform:
                 yield input
+
+
+def get_node_name(mx_node):
+    name = mx_node.getName()
+    n = mx_node.getParent()
+    while not isinstance(n, mx.Document):
+        name = f"{n.getName()}:{name}"
+        n = n.getParent()
+
+    return name
+
+
+def get_file_prefix(mx_node, file_path):
+    file_prefix = file_path.parent
+    n = mx_node
+    while True:
+        n = n.getParent()
+        file_prefix /= n.getFilePrefix()
+        if isinstance(n, mx.Document):
+            break
+
+    return file_prefix.resolve()

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -22,8 +22,20 @@ log = logging.Log(tag='utils.mx')
 
 def set_param_value(mx_param, val, nd_type):
     if isinstance(val, mx.Node):
+        param_nodegraph = mx_param.getParent().getParent()
+        val_nodegraph = val.getParent()
+        node_name = val.getName()
+        if val_nodegraph == param_nodegraph:
+            mx_param.setNodeName(node_name)
+        else:
+            mx_output = val_nodegraph.getOutput(f"out_{node_name}")
+            if not mx_output:
+                mx_output = val_nodegraph.addOutput(f"out_{node_name}", val.getType())
+                mx_output.setNodeName(node_name)
 
-        mx_param.setNodeName(val.getName())
+            mx_param.setAttribute('nodegraph', val_nodegraph.getName())
+            mx_param.setAttribute('output', mx_output.getName())
+
     elif nd_type == 'filename':
         mx_param.setValueString(val)
     else:

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -51,8 +51,11 @@ def get_attr(mx_param, name, else_val=None):
     return mx_param.getAttribute(name) if mx_param.hasAttribute(name) else else_val
 
 
-def parse_value(mx_val, mx_type):
+def parse_value(mx_val, mx_type, file_prefix=None):
     if mx_type in ('string', 'float', 'integer', 'boolean', 'filename', 'angle'):
+        if file_prefix and mx_type == 'filename':
+            mx_val = str((file_prefix / mx_val).resolve())
+
         return mx_val
 
     return tuple(mx_val)

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -22,6 +22,7 @@ log = logging.Log(tag='utils.mx')
 
 def set_param_value(mx_param, val, nd_type):
     if isinstance(val, mx.Node):
+
         mx_param.setNodeName(val.getName())
     elif nd_type == 'filename':
         mx_param.setValueString(val)
@@ -97,16 +98,6 @@ def get_nodedef_inputs(nodedef, uniform=None):
                 yield input
 
 
-def get_full_node_name(mx_node):
-    name = mx_node.getName()
-    n = mx_node.getParent()
-    while not isinstance(n, mx.Document):
-        name = f"{n.getName()}/{name}"
-        n = n.getParent()
-
-    return name
-
-
 def get_file_prefix(mx_node, file_path):
     file_prefix = file_path.parent
     n = mx_node
@@ -119,8 +110,8 @@ def get_file_prefix(mx_node, file_path):
     return file_prefix.resolve()
 
 
-def get_nodegraph_by_full_node_name(doc, full_node_name, do_create=False):
-    nodegraph_names = code_str(full_node_name).split('/')[:-1]
+def get_nodegraph_by_node_path(doc, node_path, do_create=False):
+    nodegraph_names = code_str(node_path).split('/')[:-1]
     mx_nodegraph = doc
     for nodegraph_name in nodegraph_names:
         next_mx_nodegraph = mx_nodegraph.getNodeGraph(nodegraph_name)
@@ -135,5 +126,5 @@ def get_nodegraph_by_full_node_name(doc, full_node_name, do_create=False):
     return mx_nodegraph
 
 
-def get_node_name(full_node_name):
-    return code_str(full_node_name.split('/')[-1])
+def get_node_name_by_node_path(node_path):
+    return code_str(node_path.split('/')[-1])


### PR DESCRIPTION
### PURPOSE
MaterialX <nodegraph> statement is not supported, therefore we cannot import mtlx files which have it and we cannot export MX node tree using this statement.

### EFFECT OF CHANGE
Implemented support of MaterialX <nodegraph> statement.

### TECHNICAL STEPS
1. Adjusted MX import process to support <nodegraph>:
   - adjusted MxNodeTree.import_() function
   - added some functions to utils/mx.py
2. Adjusted MX export process to support <nodegraph>.
   - adjusted MxNode.compute() function
   - added/updated some functions in utils/mx.py

### NOTES FOR REVIEWERS
Currently MX <nodegraph> isn't implemented using blender node groups, because it is not available in MxNodeTree. I didn't find how to enable it, but spent significant time for this. Therefore import of nodes which are in nodegraph is placed inside MX node tree with name like: \<nodegraph name>/\<node name>.