### PR TITLE
RPRBLND-1367: USD render settings

### DIFF
--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.cpp
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.cpp
@@ -225,7 +225,7 @@ void UsdImagingLiteEngine::SetRendererSetting(TfToken const& id, VtValue const& 
     _renderIndex->GetRenderDelegate()->SetRenderSetting(id, value);
 }
 
-void UsdImagingLiteEngine::Render(UsdPrim root)
+void UsdImagingLiteEngine::Render(UsdPrim root, const UsdImagingLiteRenderParams &params)
 {
     _delegate->Populate(root);
 

--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.cpp
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.cpp
@@ -118,168 +118,6 @@ _ComputeCameraToFrameStage(const UsdStageRefPtr& stage, UsdTimeCode timeCode,
     return gfCamera;
 }
 
-// Prman linear to display
-static float DspyLinearTosRGB(float u) {
-    return u < 0.0031308f ? 12.92f * u : 1.055f * powf(u, 0.4167f) - 0.055f;
-}
-
-int render_old(UsdPrim root, const UsdImagingLiteRenderParams &params) {
-    HdEngine engine;
-    auto renderDelegate = GetRenderDelegate(params.renderPluginId);
-    auto renderIndex = HdRenderIndex::New(renderDelegate, {});
-    auto sceneDelegateId = SdfPath::AbsoluteRootPath().AppendElementString("usdImagingDelegate");
-    auto sceneDelegate = new UsdImagingDelegate(renderIndex, sceneDelegateId);
-    sceneDelegate->Populate(root);
-
-    renderDelegate->SetRenderSetting(TfToken("maxSamples"), VtValue(params.samples));
-
-    auto taskDataDelegate = new HdRenderDataDelegate(renderIndex, SdfPath::AbsoluteRootPath().AppendElementString("taskDataDelegate"));
-    auto taskDataDelegateId = taskDataDelegate->GetDelegateID();
-
-    auto freeCameraId = taskDataDelegateId.AppendElementString("freeCamera");
-    renderIndex->InsertSprim(HdPrimTypeTokens->camera, taskDataDelegate, freeCameraId);
-    taskDataDelegate->SetParameter(freeCameraId, HdCameraTokens->windowPolicy, VtValue(CameraUtilFit));
-    taskDataDelegate->SetParameter(freeCameraId, HdCameraTokens->worldToViewMatrix, VtValue(params.viewMatrix));
-    taskDataDelegate->SetParameter(freeCameraId, HdCameraTokens->projectionMatrix, VtValue(params.projMatrix));
-    taskDataDelegate->SetParameter(freeCameraId, HdCameraTokens->clipPlanes, VtValue(std::vector<GfVec4d>()));
-
-    GfVec4d viewport(0, 0, params.renderResolution[0], params.renderResolution[1]);
-    auto aovDimensions = GfVec3i(params.renderResolution[0], params.renderResolution[1], 1);
-
-    HdRenderPassAovBindingVector aovBindings;
-    if (TF_VERIFY(renderIndex->IsBprimTypeSupported(HdPrimTypeTokens->renderBuffer))) {
-        for (auto& aov : params.aovs) {
-            auto aovDesc = renderDelegate->GetDefaultAovDescriptor(aov);
-            if (aovDesc.format != HdFormatInvalid) {
-                auto renderBufferId = taskDataDelegateId.AppendElementString("aov_" + aov.GetString());
-                renderIndex->InsertBprim(HdPrimTypeTokens->renderBuffer, taskDataDelegate, renderBufferId);
-
-                HdRenderBufferDescriptor desc;
-                desc.dimensions = aovDimensions;
-                desc.format = aovDesc.format;
-                desc.multiSampled = aovDesc.multiSampled;
-                taskDataDelegate->SetParameter(renderBufferId, _tokens->renderBufferDescriptor, desc);
-                renderIndex->GetChangeTracker().MarkBprimDirty(renderBufferId, HdRenderBuffer::DirtyDescription);
-
-                HdRenderPassAovBinding binding;
-                binding.aovName = aov;
-                binding.renderBufferId = renderBufferId;
-                binding.aovSettings = aovDesc.aovSettings;
-                aovBindings.push_back(binding);
-            }
-            else {
-                TF_RUNTIME_ERROR("Could not set \"%s\" AOV: unsupported by render delegate\n", aov.GetText());
-            }
-        }
-    }
-
-    auto renderTaskId = taskDataDelegateId.AppendElementString("renderTask");
-    renderIndex->InsertTask<HdRenderTask>(taskDataDelegate, renderTaskId);
-
-    HdRenderTaskParams renderTaskParams;
-    renderTaskParams.viewport = viewport;
-    renderTaskParams.camera = freeCameraId;
-    renderTaskParams.aovBindings = aovBindings;
-    taskDataDelegate->SetParameter(renderTaskId, HdTokens->params, renderTaskParams);
-    renderIndex->GetChangeTracker().MarkTaskDirty(renderTaskId, HdChangeTracker::DirtyParams);
-
-    auto reprSelector = HdReprSelector(HdReprTokens->smoothHull);
-    HdRprimCollection rprimCollection(HdTokens->geometry, reprSelector, false, TfToken());
-    rprimCollection.SetRootPath(SdfPath::AbsoluteRootPath());
-    taskDataDelegate->SetParameter(renderTaskId, HdTokens->collection, rprimCollection);
-    renderIndex->GetChangeTracker().MarkTaskDirty(renderTaskId, HdChangeTracker::DirtyCollection);
-
-    TfTokenVector renderTags{ HdRenderTagTokens->geometry };
-    taskDataDelegate->SetParameter(renderTaskId, HdTokens->renderTags, renderTags);
-    renderIndex->GetChangeTracker().MarkTaskDirty(renderTaskId, HdChangeTracker::DirtyRenderTags);
-
-    printf("rendering...\n");
-    {
-        auto renderTask = std::static_pointer_cast<HdRenderTask>(renderIndex->GetTask(renderTaskId));
-        HdTaskSharedPtrVector tasks = { renderTask };
-
-        engine.Execute(renderIndex, &tasks);
-        while (!renderTask->IsConverged()) {
-            printf(".");
-            std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-        }
-    }
-    printf("\nrendering finished\n");
-
-    for (auto i = 0; i != params.aovBuffers.size(); i++) {
-        void *buf = reinterpret_cast<void *>(params.aovBuffers[i]);
-        if (buf == nullptr)
-            continue;
-
-        
-        HdRenderBuffer *rBuf = static_cast<HdRenderBuffer*>(renderIndex->GetBprim(HdPrimTypeTokens->renderBuffer, aovBindings[i].renderBufferId));
-        aovBindings[i].renderBuffer = rBuf;
-        void *data = rBuf->Map();
-        memcpy(buf, data, rBuf->GetWidth() * rBuf->GetHeight() * HdDataSizeOfFormat(rBuf->GetFormat()));
-        rBuf->Unmap();
-    }
-    printf("results archieved\n");
-
-    delete taskDataDelegate;
-    delete sceneDelegate;
-    delete renderIndex;
-    delete renderDelegate;
-
-    return 0;
-}
-
-int render(UsdPrim root, const UsdImagingLiteRenderParams &params) {
-    HdEngine engine;
-    auto renderDelegate = GetRenderDelegate(params.renderPluginId);
-    auto renderIndex = HdRenderIndex::New(renderDelegate, {});
-
-    HdxTaskController *taskController = new HdxTaskController(renderIndex,
-        SdfPath::AbsoluteRootPath().AppendElementString("taskController"));
-
-    auto delegate = new UsdImagingDelegate(renderIndex,
-        SdfPath::AbsoluteRootPath().AppendElementString("usdImagingDelegate"));
-
-    taskController->SetFreeCameraMatrices(params.viewMatrix, params.projMatrix);
-    taskController->SetRenderViewport(GfVec4d(0, 0, params.renderResolution[0], params.renderResolution[1]));
-    taskController->SetRenderOutputs(params.aovs);
-
-
-    delegate->Populate(root);
-    delegate->SetTime(params.frame);
-
-    HdTaskSharedPtrVector tasks = taskController->GetRenderingTasks();
-
-    printf("rendering...\n");
-    engine.Execute(renderIndex, &tasks);
-    while (!taskController->IsConverged()) {
-        printf(".");
-        std::this_thread::sleep_for(std::chrono::milliseconds(1000));
-    }
-    printf("\nrendering finished\n");
-
-
-
-    for (auto i = 0; i != params.aovBuffers.size(); i++) {
-        void *buf = reinterpret_cast<void *>(params.aovBuffers[i]);
-        if (buf == nullptr)
-            continue;
-
-        HdRenderBuffer *rBuf = taskController->GetRenderOutput(params.aovs[i]);
-        void *data = rBuf->Map();
-        memcpy(buf, data, rBuf->GetWidth() * rBuf->GetHeight() * HdDataSizeOfFormat(rBuf->GetFormat()));
-        rBuf->Unmap();
-    }
-    printf("results archieved\n");
-
-
-    delete taskController;
-    delete delegate;
-    delete renderIndex;
-    delete renderDelegate;
-
-    return 0;
-}
-
 UsdImagingLiteEngine::UsdImagingLiteEngine()
     : _renderIndex(nullptr)
     , _delegate(nullptr)
@@ -335,11 +173,61 @@ bool UsdImagingLiteEngine::GetRendererAov(TfToken const &id, void *buf)
     return true;
 }
 
-void UsdImagingLiteEngine::Render(UsdPrim root, const UsdImagingLiteRenderParams & params)
+UsdImagingGLRendererSettingsList UsdImagingLiteEngine::GetRendererSettingsList() const
+{
+    HdRenderDelegate *_renderDelegate = _renderIndex->GetRenderDelegate();
+
+    const HdRenderSettingDescriptorList descriptors =
+        _renderDelegate->GetRenderSettingDescriptors();
+    UsdImagingGLRendererSettingsList ret;
+
+    for (auto const& desc : descriptors) {
+        UsdImagingGLRendererSetting r;
+        r.key = desc.key;
+        r.name = desc.name;
+        r.defValue = desc.defaultValue;
+
+        // Use the type of the default value to tell us what kind of
+        // widget to create...
+        if (r.defValue.IsHolding<bool>()) {
+            r.type = UsdImagingGLRendererSetting::TYPE_FLAG;
+        }
+        else if (r.defValue.IsHolding<int>() ||
+            r.defValue.IsHolding<unsigned int>()) {
+            r.type = UsdImagingGLRendererSetting::TYPE_INT;
+        }
+        else if (r.defValue.IsHolding<float>()) {
+            r.type = UsdImagingGLRendererSetting::TYPE_FLOAT;
+        }
+        else if (r.defValue.IsHolding<std::string>()) {
+            r.type = UsdImagingGLRendererSetting::TYPE_STRING;
+        }
+        else {
+            TF_WARN("Setting '%s' with type '%s' doesn't have a UI"
+                " implementation...",
+                r.name.c_str(),
+                r.defValue.GetTypeName().c_str());
+            continue;
+        }
+        ret.push_back(r);
+    }
+
+    return ret;
+}
+
+VtValue UsdImagingLiteEngine::GetRendererSetting(TfToken const& id) const
+{
+    return _renderIndex->GetRenderDelegate()->GetRenderSetting(id);
+}
+
+void UsdImagingLiteEngine::SetRendererSetting(TfToken const& id, VtValue const& value)
+{
+    _renderIndex->GetRenderDelegate()->SetRenderSetting(id, value);
+}
+
+void UsdImagingLiteEngine::Render(UsdPrim root)
 {
     _delegate->Populate(root);
-
-    _renderIndex->GetRenderDelegate()->SetRenderSetting(TfToken("maxSamples"), VtValue(params.samples));
 
     SdfPath renderTaskId = _taskDataDelegate->GetDelegateID().AppendElementString("renderTask");
     _renderIndex->InsertTask<HdRenderTask>(_taskDataDelegate, renderTaskId);

--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
@@ -31,6 +31,7 @@
 #include "pxr/imaging/hd/rendererPlugin.h"
 #include "pxr/imaging/hdx/taskController.h"
 #include "pxr/usdImaging/usdImaging/delegate.h"
+#include "pxr/usdImaging/usdImagingGL/rendererSettings.h"
 
 #include "api.h"
 #include "renderParams.h"
@@ -38,10 +39,6 @@
 #include "renderTask.h"
 
 PXR_NAMESPACE_OPEN_SCOPE
-
-USDIMAGINGLITE_API
-int render(UsdPrim root, const UsdImagingLiteRenderParams &params);
-
 
 /// \class UsdImagingLiteEngine
 ///
@@ -75,7 +72,7 @@ public:
 
     /// Entry point for kicking off a render
     USDIMAGINGLITE_API
-    void Render(UsdPrim root, const UsdImagingLiteRenderParams &params);
+    void Render(UsdPrim root);
 
     USDIMAGINGLITE_API
     void InvalidateBuffers();
@@ -91,6 +88,18 @@ public:
     USDIMAGINGLITE_API
     bool GetRendererAov(TfToken const &id, void *buf);
     /// @}
+
+    /// Returns the list of renderer settings.
+    USDIMAGINGLITE_API
+    UsdImagingGLRendererSettingsList GetRendererSettingsList() const;
+
+    /// Gets a renderer setting's current value.
+    USDIMAGINGLITE_API
+    VtValue GetRendererSetting(TfToken const& id) const;
+
+    /// Sets a renderer setting's value.
+    USDIMAGINGLITE_API
+    void SetRendererSetting(TfToken const& id, VtValue const& value);
 
     // ---------------------------------------------------------------------
     /// \name Camera State

--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
@@ -72,7 +72,7 @@ public:
 
     /// Entry point for kicking off a render
     USDIMAGINGLITE_API
-    void Render(UsdPrim root);
+    void Render(UsdPrim root, const UsdImagingLiteRenderParams &params);
 
     USDIMAGINGLITE_API
     void InvalidateBuffers();

--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/wrapEngine.cpp
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/wrapEngine.cpp
@@ -51,11 +51,6 @@ public:
 void
 wrapEngine()
 {
-    def(
-        "Render",
-        render,
-        (args("root", "params")));
-
     {
         using Cls = UsdImagingLiteEngine_wrap;
 
@@ -66,6 +61,11 @@ wrapEngine()
             .def("SetRenderViewport", &Cls::SetRenderViewport)
             .def("SetRendererAov", &Cls::SetRendererAov)
             .def("GetRendererAov", &Cls::GetRendererAov_wrap)
+            .def("GetRendererSettingsList",
+                &Cls::GetRendererSettingsList,
+                return_value_policy< TfPySequenceToList >())
+            .def("GetRendererSetting", &Cls::GetRendererSetting)
+            .def("SetRendererSetting", &Cls::SetRendererSetting)
             .def("SetCameraPath", &Cls::SetCameraPath)
             .def("SetCameraState", &Cls::SetCameraState)
             .def("IsConverged", &Cls::IsConverged)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -33,7 +33,6 @@ class FinalEngine(Engine):
     """ Final render engine """
 
     TYPE = 'FINAL'
-    SAMPLES_NUMBER = 200
 
     def __init__(self, render_engine):
         super().__init__(render_engine)
@@ -64,8 +63,7 @@ class FinalEngine(Engine):
 
         # creating renderer
         renderer = UsdImagingGL.Engine()
-        log("Hydra render:", scene.hdusd.final.delegate)
-        renderer.SetRendererPlugin(scene.hdusd.final.delegate)
+        self._sync_render_settings(renderer, scene)
 
         # setting camera
         self._set_scene_camera(renderer, scene)
@@ -103,20 +101,19 @@ class FinalEngine(Engine):
     def _render(self, scene):
         # creating renderer
         renderer = UsdImagingLite.Engine()
-        renderer.SetRendererPlugin(scene.hdusd.final.delegate)
+        self._sync_render_settings(renderer, scene)
+
         renderer.SetRenderViewport((0, 0, self.width, self.height))
         renderer.SetRendererAov('color')
 
         # setting camera
         self._set_scene_camera(renderer, scene)
 
-        params = UsdImagingLite.RenderParams()
-        params.samples = self.SAMPLES_NUMBER
         render_images = {
             'Combined': np.empty((self.width, self.height, 4), dtype=np.float32)
         }
 
-        renderer.Render(self.stage.GetPseudoRoot(), params)
+        renderer.Render(self.stage.GetPseudoRoot())
 
         time_begin = time.perf_counter()
         while True:
@@ -237,3 +234,41 @@ class FinalEngine(Engine):
         # efficient way to copy all AOV images
         render_passes.foreach_set('rect', np.concatenate(images))
         self.render_engine.end_result(result)
+
+    def _sync_render_settings(self, renderer, scene):
+        settings = scene.hdusd.final
+
+        renderer.SetRendererPlugin(settings.delegate)
+        if settings.delegate == 'HdRprPlugin':
+            hdrpr = settings.hdrpr
+            quality = hdrpr.quality
+            denoise = hdrpr.denoise
+
+            renderer.SetRendererSetting('renderMode', 'batch')
+            renderer.SetRendererSetting('progressive', True)
+            renderer.SetRendererSetting('enableAlpha', False)
+
+            renderer.SetRendererSetting('renderDevice', hdrpr.device)
+            renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
+            renderer.SetRendererSetting('coreRenderMode', hdrpr.render_mode)
+
+            renderer.SetRendererSetting('aoRadius', hdrpr.ao_radius)
+
+            renderer.SetRendererSetting('maxSamples', hdrpr.max_samples)
+            renderer.SetRendererSetting('minAdaptiveSamples', hdrpr.min_adaptive_samples)
+            renderer.SetRendererSetting('varianceThreshold', hdrpr.variance_threshold)
+
+            renderer.SetRendererSetting('maxRayDepth', quality.max_ray_depth)
+            renderer.SetRendererSetting('maxRayDepthDiffuse', quality.max_ray_depth_diffuse)
+            renderer.SetRendererSetting('maxRayDepthGlossy', quality.max_ray_depth_glossy)
+            renderer.SetRendererSetting('maxRayDepthRefraction', quality.max_ray_depth_refraction)
+            renderer.SetRendererSetting('maxRayDepthGlossyRefraction',
+                                        quality.max_ray_depth_glossy_refraction)
+            renderer.SetRendererSetting('maxRayDepthShadow', quality.max_ray_depth_shadow)
+            renderer.SetRendererSetting('raycastEpsilon', quality.raycast_epsilon)
+            renderer.SetRendererSetting('enableRadianceClamping', quality.enable_radiance_clamping)
+            renderer.SetRendererSetting('radianceClamping', quality.radiance_clamping)
+
+            renderer.SetRendererSetting('enableDenoising', denoise.enable)
+            renderer.SetRendererSetting('denoiseMinIter', denoise.min_iter)
+            renderer.SetRendererSetting('denoiseIterStep', denoise.iter_step)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -109,11 +109,12 @@ class FinalEngine(Engine):
         # setting camera
         self._set_scene_camera(renderer, scene)
 
+        params = UsdImagingLite.RenderParams()
         render_images = {
             'Combined': np.empty((self.width, self.height, 4), dtype=np.float32)
         }
 
-        renderer.Render(self.stage.GetPseudoRoot())
+        renderer.Render(self.stage.GetPseudoRoot(), params)
 
         time_begin = time.perf_counter()
         while True:

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -313,8 +313,8 @@ class ViewportEngine(Engine):
             denoise = hdrpr.denoise
 
             self.renderer.SetRendererSetting('renderMode', 'interactive')
-            self.renderer.SetRendererSetting('progressive', True)
-            self.renderer.SetRendererSetting('enableAlpha', True)
+            # self.renderer.SetRendererSetting('rpr:interactive', True)
+            self.renderer.SetRendererSetting('enableAlpha', False)
 
             self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
             self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -314,6 +314,7 @@ class ViewportEngine(Engine):
 
             self.renderer.SetRendererSetting('renderMode', 'interactive')
             self.renderer.SetRendererSetting('progressive', True)
+            self.renderer.SetRendererSetting('enableAlpha', True)
 
             self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
             self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
@@ -332,7 +333,6 @@ class ViewportEngine(Engine):
             self.renderer.SetRendererSetting('enableDenoising', denoise.enable)
             self.renderer.SetRendererSetting('denoiseMinIter', denoise.min_iter)
             self.renderer.SetRendererSetting('denoiseIterStep', denoise.iter_step)
-
 
 
 class ViewportEngineScene(ViewportEngine):

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -309,9 +309,18 @@ class ViewportEngine(Engine):
         self.renderer.SetRendererPlugin(settings.delegate)
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
+
+            self.renderer.SetRendererSetting('renderMode', 'interactive')
+            self.renderer.SetRendererSetting('progressive', True)
+
             self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
             self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
-            self.renderer.SetRendererSetting('renderMode', hdrpr.render_mode)
+            self.renderer.SetRendererSetting('coreRenderMode', hdrpr.render_mode)
+
+            self.renderer.SetRendererSetting('aoRadius', hdrpr.ao_radius)
+
+
+
 
 
 class ViewportEngineScene(ViewportEngine):

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -213,28 +213,15 @@ class ViewportEngine(Engine):
         self.shading_data = ShadingData(context)
 
         self.render_params = UsdImagingGL.RenderParams()
-        self.render_params.samples = 200
         self.render_params.frame = Usd.TimeCode.Default()
         self.render_params.clearColor = (0, 0, 0, 0)
 
         self.renderer = UsdImagingGL.Engine()
-        self.renderer.SetRendererPlugin(settings.delegate)
-
-        self.renderer.SetRendererSetting('renderDevice',
-                                         'CPU' if scene.hdusd.rpr_viewport_cpu_device else 'GPU')
-        # self.renderer.SetRendererSetting('renderMode', 'Global Illumination')
-        # self.renderer.SetRendererSetting('renderQuality', 'Northstar')
 
         self._sync(context, depsgraph)
 
         self.is_synced = True
         log('Finish sync')
-
-    def _sync(self, context, depsgraph):
-        pass
-
-    def _sync_update(self, context, depsgraph):
-        pass
 
     def sync_update(self, context, depsgraph):
         """ sync just the updated things """
@@ -251,6 +238,17 @@ class ViewportEngine(Engine):
             self.renderer.ResumeRenderer()
 
         self.render_engine.tag_redraw()
+
+    def _sync(self, context, depsgraph):
+        self._sync_render_settings(depsgraph.scene)
+
+    def _sync_update(self, context, depsgraph):
+        scene = next((update.id for update in depsgraph.updates
+                      if isinstance(update.id, bpy.types.Scene)), None)
+        if not scene:
+            return
+
+        self._sync_render_settings(scene)
 
     def draw(self, context):
         log("Draw")
@@ -304,6 +302,17 @@ class ViewportEngine(Engine):
         else:
             self.notify_status("Rendering Done", "", False)
 
+    def _sync_render_settings(self, scene):
+        settings = scene.hdusd.viewport
+
+        self.is_gl_delegate = settings.is_gl_delegate
+        self.renderer.SetRendererPlugin(settings.delegate)
+        if settings.delegate == 'HdRprPlugin':
+            hdrpr = settings.hdrpr
+            self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
+            self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
+            self.renderer.SetRendererSetting('renderMode', hdrpr.render_mode)
+
 
 class ViewportEngineScene(ViewportEngine):
     """Viewport engine for rendering Blender current scene"""
@@ -319,6 +328,8 @@ class ViewportEngineScene(ViewportEngine):
         self.render_engine.tag_redraw()
 
     def _sync(self, context, depsgraph):
+        super()._sync(context, depsgraph)
+
         stage = self.cached_stage.create()
         self._export_depsgraph(
             stage, depsgraph,
@@ -328,38 +339,28 @@ class ViewportEngineScene(ViewportEngine):
         )
 
     def _sync_update(self, context, depsgraph):
-        scene = depsgraph.scene
-
-        root_prim = self.stage.GetPseudoRoot()
+        super()._sync_update(context, depsgraph)
 
         # get supported updates and sort by priorities
         updates = []
-        for obj_type in (bpy.types.Scene, bpy.types.World, bpy.types.Material, bpy.types.Object, bpy.types.Collection):
+        for obj_type in (bpy.types.Scene, bpy.types.Object, bpy.types.Collection):
             updates.extend(update for update in depsgraph.updates if isinstance(update.id, obj_type))
 
-        sync_collection = False
-        sync_world = False
+        if not updates:
+            return
+
+        root_prim = self.stage.GetPseudoRoot()
 
         for update in updates:
             obj = update.id
             log("sync_update", obj)
-            if isinstance(obj, bpy.types.Scene):
-                prop = scene.hdusd.viewport
-                if self.is_gl_delegate != prop.is_gl_delegate:
-                    self.is_gl_delegate = prop.is_gl_delegate
 
-                    # update all scene lights since on renderer change
-                    self.resync_scene_lights(scene)
-
-                self.renderer.SetRendererPlugin(prop.delegate)
-
-                # Outliner object visibility change will provide us only bpy.types.Scene update
-                # That's why we need to sync objects collection in the end
-                sync_collection = True
-
+            if isinstance(obj, (bpy.types.Collection, bpy.types.Scene)):
+                self._sync_objects_collection(depsgraph)
                 continue
 
             if isinstance(obj, bpy.types.Object):
+
                 if obj.type == 'CAMERA':
                     continue
 
@@ -372,30 +373,18 @@ class ViewportEngineScene(ViewportEngine):
                                    is_gl_delegate=self.is_gl_delegate)
                 continue
 
-            if isinstance(obj, bpy.types.World):
-                sync_world = True
+    def _sync_render_settings(self, scene):
+        resync_lights = self.is_gl_delegate != scene.hdusd.viewport.is_gl_delegate
+        super()._sync_render_settings(scene)
 
-            if isinstance(obj, bpy.types.Collection):
-                sync_collection = True
-                continue
+        if resync_lights and self.shading_data.use_scene_lights:
+            for obj in scene.objects:
+                if obj.type == 'LIGHT':
+                    objects_prim = self.stage.GetPseudoRoot()
+                    object.sync_update(objects_prim, obj, True, False,
+                                       is_gl_delegate=self.is_gl_delegate)
 
-        if sync_world:
-            pass
-
-        if sync_collection:
-            self.sync_objects_collection(depsgraph)
-
-    def resync_scene_lights(self, scene):
-        if self.shading_data.use_scene_lights:
-            return
-
-        for obj in scene.objects:
-            if obj.type == 'LIGHT':
-                objects_prim = self.stage.GetPseudoRoot()
-                object.sync_update(objects_prim, obj, True, False,
-                                   is_gl_delegate=self.is_gl_delegate)
-
-    def sync_objects_collection(self, depsgraph):
+    def _sync_objects_collection(self, depsgraph):
         root_prim = self.stage.GetPseudoRoot()
 
         def dg_objects():
@@ -435,6 +424,8 @@ class ViewportEngineNodetree(ViewportEngine):
             engine.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
 
     def _sync(self, context, depsgraph):
+        super()._sync(context, depsgraph)
+
         self.data_source = depsgraph.scene.hdusd.viewport.data_source
 
         stage = self.cached_stage.create()
@@ -444,21 +435,6 @@ class ViewportEngineNodetree(ViewportEngine):
         nodetree = bpy.data.node_groups[self.data_source]
         output_node = nodetree.get_output_node()
         self.nodetree_stage_changed(output_node.cached_stage() if output_node else None)
-
-    def _sync_update(self, context, depsgraph):
-        # get supported updates and sort by priorities
-        updates = []
-        for obj_type in (bpy.types.Scene,):
-            updates.extend(update for update in depsgraph.updates
-                           if isinstance(update.id, obj_type))
-
-        for update in updates:
-            obj = update.id
-            log("sync_update", obj)
-            if isinstance(obj, bpy.types.Scene):
-                scene = obj
-                self.renderer.SetRendererPlugin(scene.hdusd.viewport.delegate)
-                continue
 
     def nodetree_stage_changed(self, stage):
         engine_stage = self.stage

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -309,6 +309,8 @@ class ViewportEngine(Engine):
         self.renderer.SetRendererPlugin(settings.delegate)
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
+            quality = hdrpr.interactive_quality
+            denoise = hdrpr.denoise
 
             self.renderer.SetRendererSetting('renderMode', 'interactive')
             self.renderer.SetRendererSetting('progressive', True)
@@ -319,7 +321,17 @@ class ViewportEngine(Engine):
 
             self.renderer.SetRendererSetting('aoRadius', hdrpr.ao_radius)
 
+            self.renderer.SetRendererSetting('maxSamples', hdrpr.max_samples)
+            self.renderer.SetRendererSetting('minAdaptiveSamples', hdrpr.min_adaptive_samples)
+            self.renderer.SetRendererSetting('varianceThreshold', hdrpr.variance_threshold)
 
+            self.renderer.SetRendererSetting('interactiveMaxRayDepth', quality.max_ray_depth)
+            self.renderer.SetRendererSetting('interactiveEnableDownscale', quality.enable_downscale)
+            self.renderer.SetRendererSetting('interactiveResolutionDownscale', quality.resolution_downscale)
+
+            self.renderer.SetRendererSetting('enableDenoising', denoise.enable)
+            self.renderer.SetRendererSetting('denoiseMinIter', denoise.min_iter)
+            self.renderer.SetRendererSetting('denoiseIterStep', denoise.iter_step)
 
 
 

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -48,7 +48,10 @@ from . import scene, object, node, usd_list, material, hdrpr_render
 register, unregister = bpy.utils.register_classes_factory((
     CachedStageProp,
 
+    hdrpr_render.QualitySettings,
+    hdrpr_render.InteractiveQualitySettings,
     hdrpr_render.ContourSettings,
+    hdrpr_render.DenoiseSettings,
     hdrpr_render.RenderSettings,
 
     usd_list.PrimPropertyItem,

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -44,9 +44,12 @@ class CachedStageProp(bpy.types.PropertyGroup, stage_cache.CachedStage):
         pass
 
 
-from . import scene, object, node, usd_list, material
+from . import scene, object, node, usd_list, material, hdrpr_render
 register, unregister = bpy.utils.register_classes_factory((
     CachedStageProp,
+
+    hdrpr_render.ContourSettings,
+    hdrpr_render.RenderSettings,
 
     usd_list.PrimPropertyItem,
     usd_list.UsdListItem,

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -174,7 +174,7 @@ Colors legend:
 
 class DenoiseSettings(bpy.types.PropertyGroup):
     enable: BoolProperty(
-        name="Enable AI Denoising",
+        name="AI Denoising",
         description="Enable AI Denoising",
         default=False,
     )

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -1,0 +1,122 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import math
+
+import bpy
+from bpy.types import (
+    PointerProperty,
+    EnumProperty,
+    FloatProperty,
+    BoolProperty,
+)
+
+
+class ContourSettings(bpy.types.PropertyGroup):
+    antialiasing: FloatProperty(
+        name="Antialiasing",
+        description="Contour Antialising",
+        min=0.0, max=1.0,
+        default=1.0,
+    )
+    use_normal: BoolProperty(
+        name="Use Normal",
+        description="Whether to use geometry normals for edge detection or not",
+        default=True,
+    )
+    line_width_normal: FloatProperty(
+        name="Line Width Normal",
+        description="Line width of edges detected via normals",
+        min=1.0, max=100.0,
+        default=1.0,
+    )
+    normal_threshold: FloatProperty(
+        name="Normal Threshold",
+        description="Threshold for normals, in degrees",
+        subtype='ANGLE',
+        min=0.0, max=math.radians(180.0),
+        default=math.radians(45.0),
+    )
+    use_prim_id: BoolProperty(
+        name="Use Primitive ID",
+        description="Whether to use primitive Id for edge detection or not",
+        default=True,
+    )
+    line_width_prim_id: FloatProperty(
+        name="Line Primitive Id",
+        description="Line width of edges detected via primitive Id",
+        min=0.0, max=100.0,
+        default=1.0,
+    )
+    use_material_id: BoolProperty(
+        name="Use Material Id",
+        description="Whether to use material Id for edge detection or not",
+        default=True,
+    )
+    line_width_material_id: FloatProperty(
+        name="Line Width Material Id",
+        description="Line width of edges detected via material Id",
+        min=0.0, max=100.0,
+        default=1.0,
+    )
+    debug: BoolProperty(
+        name="Debug",
+        description="""Whether to show colored outlines according to used features or not.
+Colors legend:
+ * red - primitive Id
+ * green - material Id
+ * blue - normal
+ * yellow - primitive Id + material Id
+ * magenta - primitive Id + normal
+ * cyan - material Id + normal
+ * black - all""",
+        default=True,
+    )
+
+
+class RenderSettings(bpy.types.PropertyGroup):
+    render_quality: EnumProperty(
+        name="Renderer Quality",
+        description="",
+        items=(('Northstar', "Full", "Full render quality"),
+               ('Full', "Legacy", "Legacy render quality"),
+               ('High', "High", "High render quality"),
+               ('Medium', "Medium", "Medium render quality"),
+               ('Low', "Low", "Low render quality")),
+        default='Northstar',
+    )
+    render_mode: EnumProperty(
+        name="Render Mode",
+        description="Override render mode",
+        items=(
+            ('Global Illumination', "Global Illumination", "Global illumination render mode"),
+            ('Direct Illumination', "Direct Illumination", "Direct illumination render mode"),
+            ('Wireframe', "Wireframe", "Wireframe render mode"),
+            ('Material Index', "Material Index", "Material index render mode"),
+            ('Position', "Position", "World position render mode"),
+            ('Normal', "Normal", "Shading normal render mode"),
+            ('Texcoord', "Texture Coordinate", "Texture coordinate render mode"),
+            ('Ambient Occlusion', "Ambient Occlusion", "Ambient occlusion render mode"),
+            ('Diffuse', "Diffuse", "Diffuse render mode"),
+            ('Contour', "Contour", "Contour render mode"),
+        ),
+        default='Global Illumination',
+    )
+    ao_radius: FloatProperty(
+        name="AO Radius",
+        description="Ambient Occlusion Radius",
+        min=0.0, max=100.0,
+        default=1.0,
+    )
+    contour: PointerProperty(type=ContourSettings)

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -179,13 +179,13 @@ class DenoiseSettings(bpy.types.PropertyGroup):
         default=False,
     )
     min_iter: IntProperty(
-        name="Denoise Min Iteration",
+        name="Min Iteration",
         description="The first iteration on which denoising should be applied",
         min=1, max=2 ** 16,
         default=4,
     )
     iter_step: IntProperty(
-        name="Denoise Iteration Step",
+        name="Iteration Step",
         description="Denoise use frequency. To denoise on each iteration, set to 1",
         min=1, max=2 ** 16,
         default=32,

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -192,7 +192,6 @@ class DenoiseSettings(bpy.types.PropertyGroup):
     )
 
 
-
 class RenderSettings(bpy.types.PropertyGroup):
     device: EnumProperty(
         name="Render Device",

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -15,9 +15,8 @@
 import bpy
 from pxr import UsdImagingGL
 
-from ..usd_nodes.node_tree import get_usd_nodetree
 from ..viewport import usd_collection
-from . import HdUSDProperties, log
+from . import HdUSDProperties, hdrpr_render, log
 
 
 _render_delegates = {name: UsdImagingGL.Engine.GetRendererDisplayName(name)
@@ -32,6 +31,8 @@ class RenderSettings(bpy.types.PropertyGroup):
     @property
     def is_gl_delegate(self):
         return self.delegate == 'HdStormRendererPlugin'
+
+    hdrpr: bpy.props.PointerProperty(type=hdrpr_render.RenderSettings)
 
 
 class FinalRenderSettings(RenderSettings):

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -70,12 +70,6 @@ class SceneProperties(HdUSDProperties):
     final: bpy.props.PointerProperty(type=FinalRenderSettings)
     viewport: bpy.props.PointerProperty(type=ViewportRenderSettings)
 
-    rpr_viewport_cpu_device: bpy.props.BoolProperty(
-        name="CPU Viewport Render Device",
-        description="Use CPU device for viewport render in RPR.\n"
-                    "Required for MaterialX testing when GPU isn't supported",
-        default=False,
-    )
     use_rpr_mx_nodes: bpy.props.BoolProperty(
         name="RPR MaterialX Nodes",
         description="Use RPR MaterialX Nodes as default nodes",

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -63,6 +63,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_final,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_viewport,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_viewport,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_viewport,
 
     light.HDUSD_LIGHT_PT_light,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -62,6 +62,9 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     render.HDUSD_RENDER_PT_debug,
 
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_final,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_final,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_final,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_denoise_final,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_viewport,

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -43,6 +43,7 @@ class HdUSD_ChildPanel(bpy.types.Panel):
 from . import (
     panels,
     render,
+    hdrpr_render,
     light,
     material,
     world,
@@ -59,6 +60,9 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     render.HDUSD_RENDER_PT_render_settings_final,
     render.HDUSD_RENDER_PT_render_settings_viewport,
     render.HDUSD_RENDER_PT_debug,
+
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_final,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_viewport,
 
     light.HDUSD_LIGHT_PT_light,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -65,6 +65,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_viewport,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport,
 
     light.HDUSD_LIGHT_PT_light,
 

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -173,8 +173,8 @@ class HDUSD_RENDER_PT_hdrpr_settings_quality_viewport(HdUSD_Panel):
 
         layout.prop(hdrpr, "render_quality")
         layout.prop(quality, "max_ray_depth")
-        layout.prop(quality, "enable_downscale")
-        layout.prop(quality, "resolution_downscale")
+        # layout.prop(quality, "enable_downscale")
+        # layout.prop(quality, "resolution_downscale")
 
 
 class HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport(HdUSD_Panel):

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -51,7 +51,42 @@ class HDUSD_RENDER_PT_hdrpr_settings_viewport(HdUSD_Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        col = layout.column()
-        col.prop(hdrpr, "device")
-        col.prop(hdrpr, "render_quality")
-        col.prop(hdrpr, "render_mode")
+        layout = layout.column()
+        layout.prop(hdrpr, "device")
+        layout.prop(hdrpr, "render_mode")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_samples_viewport(HdUSD_Panel):
+    bl_label = "Samples"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_viewport'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.final.hdrpr
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.prop(hdrpr, "min_adaptive_samples")
+        layout.prop(hdrpr, "max_samples")
+        layout.prop(hdrpr, "variance_threshold")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_quality_viewport(HdUSD_Panel):
+    bl_label = "Quality"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_viewport'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.final.hdrpr
+        quality = hdrpr.interactive_quality
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.prop(hdrpr, "render_quality")
+        layout.prop(quality, "max_ray_depth")
+        layout.prop(quality, "enable_downscale")
+        layout.prop(quality, "resolution_downscale")

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -1,0 +1,57 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from . import HdUSD_Panel
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
+    bl_label = "RPR Render Settings"
+    bl_parent_id = 'HDUSD_RENDER_PT_render_settings_final'
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.scene.hdusd.final.delegate == 'HdRprPlugin'
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.final.hdrpr
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        col = layout.column()
+        col.prop(hdrpr, "device")
+        col.prop(hdrpr, "render_quality")
+        col.prop(hdrpr, "render_mode")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_viewport(HdUSD_Panel):
+    bl_label = "RPR Render Settings"
+    bl_parent_id = 'HDUSD_RENDER_PT_render_settings_viewport'
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.scene.hdusd.viewport.delegate == 'HdRprPlugin'
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.viewport.hdrpr
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        col = layout.column()
+        col.prop(hdrpr, "device")
+        col.prop(hdrpr, "render_quality")
+        col.prop(hdrpr, "render_mode")

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -16,7 +16,7 @@ from . import HdUSD_Panel
 
 
 class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
-    bl_label = "RPR Render Settings"
+    bl_label = "RPR Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_final'
 
     @classmethod
@@ -37,7 +37,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
 
 
 class HDUSD_RENDER_PT_hdrpr_settings_viewport(HdUSD_Panel):
-    bl_label = "RPR Render Settings"
+    bl_label = "RPR Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_viewport'
 
     @classmethod

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -15,6 +15,9 @@
 from . import HdUSD_Panel
 
 
+#
+# FINAL RENDER SETTINGS
+#
 class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
     bl_label = "RPR Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_final'
@@ -36,6 +39,83 @@ class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
         col.prop(hdrpr, "render_mode")
 
 
+class HDUSD_RENDER_PT_hdrpr_settings_samples_final(HdUSD_Panel):
+    bl_label = "Samples"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_final'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.final.hdrpr
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.prop(hdrpr, "max_samples")
+
+        col = layout.column(align=True)
+        col.prop(hdrpr, "variance_threshold")
+        row = col.row()
+        row.enabled = hdrpr.variance_threshold > 0.0
+        row.prop(hdrpr, "min_adaptive_samples")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_quality_final(HdUSD_Panel):
+    bl_label = "Quality"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_final'
+    bl_space_type = 'PROPERTIES'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdrpr = context.scene.hdusd.final.hdrpr
+        quality = hdrpr.quality
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.prop(hdrpr, "render_quality")
+
+        col = layout.column(align=True)
+        col.prop(quality, "max_ray_depth")
+        col.prop(quality, "max_ray_depth_diffuse")
+        col.prop(quality, "max_ray_depth_glossy")
+        col.prop(quality, "max_ray_depth_refraction")
+        col.prop(quality, "max_ray_depth_glossy_refraction")
+
+        layout.prop(quality, "raycast_epsilon")
+
+        col = layout.column(align=True)
+        col.prop(quality, "enable_radiance_clamping")
+        row = col.row()
+        row.enabled = quality.enable_radiance_clamping
+        row.prop(quality, "radiance_clamping")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_denoise_final(HdUSD_Panel):
+    bl_label = ""
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_final'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw_header(self, context):
+        denoise = context.scene.hdusd.final.hdrpr.denoise
+        self.layout.prop(denoise, "enable")
+
+    def draw(self, context):
+        denoise = context.scene.hdusd.viewport.hdrpr.denoise
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.enabled = denoise.enable
+        layout.prop(denoise, "min_iter")
+        layout.prop(denoise, "iter_step")
+
+
+#
+# VIEWPORT RENDER SETTINGS
+#
 class HDUSD_RENDER_PT_hdrpr_settings_viewport(HdUSD_Panel):
     bl_label = "RPR Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_viewport'
@@ -68,9 +148,13 @@ class HDUSD_RENDER_PT_hdrpr_settings_samples_viewport(HdUSD_Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        layout.prop(hdrpr, "min_adaptive_samples")
         layout.prop(hdrpr, "max_samples")
-        layout.prop(hdrpr, "variance_threshold")
+
+        col = layout.column(align=True)
+        col.prop(hdrpr, "variance_threshold")
+        row = col.row()
+        row.enabled = hdrpr.variance_threshold > 0.0
+        row.prop(hdrpr, "min_adaptive_samples")
 
 
 class HDUSD_RENDER_PT_hdrpr_settings_quality_viewport(HdUSD_Panel):
@@ -100,7 +184,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport(HdUSD_Panel):
 
     def draw_header(self, context):
         denoise = context.scene.hdusd.viewport.hdrpr.denoise
-        self.layout.prop(denoise, 'enable')
+        self.layout.prop(denoise, "enable")
 
     def draw(self, context):
         denoise = context.scene.hdusd.viewport.hdrpr.denoise
@@ -109,5 +193,6 @@ class HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport(HdUSD_Panel):
         layout.use_property_split = True
         layout.use_property_decorate = False
 
-        layout.prop(denoise, 'min_iter')
-        layout.prop(denoise, 'iter_step')
+        layout.enabled = denoise.enable
+        layout.prop(denoise, "min_iter")
+        layout.prop(denoise, "iter_step")

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -62,7 +62,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_samples_viewport(HdUSD_Panel):
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        hdrpr = context.scene.hdusd.final.hdrpr
+        hdrpr = context.scene.hdusd.viewport.hdrpr
 
         layout = self.layout
         layout.use_property_split = True
@@ -76,10 +76,11 @@ class HDUSD_RENDER_PT_hdrpr_settings_samples_viewport(HdUSD_Panel):
 class HDUSD_RENDER_PT_hdrpr_settings_quality_viewport(HdUSD_Panel):
     bl_label = "Quality"
     bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_viewport'
+    bl_space_type = 'PROPERTIES'
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):
-        hdrpr = context.scene.hdusd.final.hdrpr
+        hdrpr = context.scene.hdusd.viewport.hdrpr
         quality = hdrpr.interactive_quality
 
         layout = self.layout
@@ -90,3 +91,23 @@ class HDUSD_RENDER_PT_hdrpr_settings_quality_viewport(HdUSD_Panel):
         layout.prop(quality, "max_ray_depth")
         layout.prop(quality, "enable_downscale")
         layout.prop(quality, "resolution_downscale")
+
+
+class HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport(HdUSD_Panel):
+    bl_label = ""
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_viewport'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw_header(self, context):
+        denoise = context.scene.hdusd.viewport.hdrpr.denoise
+        self.layout.prop(denoise, 'enable')
+
+    def draw(self, context):
+        denoise = context.scene.hdusd.viewport.hdrpr.denoise
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        layout.prop(denoise, 'min_iter')
+        layout.prop(denoise, 'iter_step')

--- a/src/hdusd/ui/render.py
+++ b/src/hdusd/ui/render.py
@@ -116,5 +116,4 @@ class HDUSD_RENDER_PT_debug(HdUSD_Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.prop(context.scene.hdusd, "rpr_viewport_cpu_device")
         layout.prop(context.scene.hdusd, "use_rpr_mx_nodes")


### PR DESCRIPTION
### PURPOSE
We need more render settings for final and viewport renderers. Also every renderer could have its own render settings.

### EFFECT OF CHANGE
Implemented render settings for HdRPR render delegate. Added devices, samples, quality, denosing UI panels for final and viewport renderers.

### TECHNICAL STEPS
1. Added render settings property classes for HdRPR in properties/hdrpr_render.py
2. Added render setting UI panel classes for HdRPR in ui/hdrpr_render.py
3. Implemented _sync_render_settings() in FinalEngine and ViewportEngine. Adjusted code.
4. Implemented methods UsdImagingLiteEngine::SetRendererSetting() and additional GetRendererSetting(), GetRendererSettingsList().
5. Removed unused code usdImagingLite/engine.cpp: render(), render_old()

### NOTES FOR REVIEWERS
In this PR I decided not to do dynamically created render settings and UI panels from json like settings. Such implementation could take more time. I propose to implement this in future when we'll have more render delegates.