### PR TITLE
RPRBLND-1798: Fix list of MaterialX node trees in Material 

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -74,7 +74,7 @@ class HdUSDEngine(bpy.types.RenderEngine):
     """
     bl_idname = "HdUSD"
     bl_label = "USD Hydra"
-    bl_use_preview = False #True
+    bl_use_preview = True
     bl_use_shading_nodes = True
     bl_use_shading_nodes_custom = False
     bl_use_gpu_context = False

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -74,7 +74,7 @@ class HdUSDEngine(bpy.types.RenderEngine):
     """
     bl_idname = "HdUSD"
     bl_label = "USD Hydra"
-    bl_use_preview = True
+    bl_use_preview = False #True
     bl_use_shading_nodes = True
     bl_use_shading_nodes_custom = False
     bl_use_gpu_context = False

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -74,7 +74,10 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     material.HDUSD_MATERIAL_PT_context,
     material.HDUSD_MATERIAL_PT_preview,
+    material.HDUSD_MATERIAL_OP_new_mx_node_tree,
     material.HDUSD_MATERIAL_OP_link_mx_node_tree,
+    material.HDUSD_MATERIAL_OP_unlink_mx_node_tree,
+    material.HDUSD_MATERIAL_MT_mx_node_tree,
     material.HDUSD_MATERIAL_PT_material,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
@@ -82,7 +85,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_export_mx_file,
     material.HDUSD_MATERIAL_OP_export_mx_console,
     material.HDUSD_MATERIAL_PT_export_mx,
-    material.HDUSD_MATERIAL_MT_mx_node_tree,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -82,6 +82,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_export_mx_file,
     material.HDUSD_MATERIAL_OP_export_mx_console,
     material.HDUSD_MATERIAL_PT_export_mx,
+    material.HDUSD_MATERIAL_OP_mx_node_tree,
+    material.HDUSD_MATERIAL_MT_mx_node_tree,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -74,7 +74,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
 
     material.HDUSD_MATERIAL_PT_context,
     material.HDUSD_MATERIAL_PT_preview,
-    material.HDUSD_MATERIAL_OP_new_mx_node_tree,
+    material.HDUSD_MATERIAL_OP_link_mx_node_tree,
     material.HDUSD_MATERIAL_PT_material,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
@@ -82,7 +82,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_export_mx_file,
     material.HDUSD_MATERIAL_OP_export_mx_console,
     material.HDUSD_MATERIAL_PT_export_mx,
-    material.HDUSD_MATERIAL_OP_mx_node_tree,
     material.HDUSD_MATERIAL_MT_mx_node_tree,
 
     world.HDUSD_WORLD_PT_surface,

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -99,7 +99,7 @@ class HDUSD_MATERIAL_PT_preview(HdUSD_Panel):
 
 
 class HDUSD_MATERIAL_OP_link_mx_node_tree(bpy.types.Operator):
-    """Create/Link/Unlink MaterialX node tree to selected material"""
+    """Create / Link / Unlink MaterialX node tree to selected material"""
     bl_idname = "hdusd.material_link_mx_node_tree"
     bl_label = ""
 
@@ -179,7 +179,7 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
 
         if mat_hdusd.mx_node_tree:
             row.prop(mat_hdusd.mx_node_tree, 'name', text="")
-            op = row.operator(HDUSD_MATERIAL_OP_link_mx_node_tree.bl_idname, text="", icon='REMOVE')
+            op = row.operator(HDUSD_MATERIAL_OP_link_mx_node_tree.bl_idname, text="", icon='X')
             op.action = 'UNLINK'
 
         else:

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -99,7 +99,7 @@ class HDUSD_MATERIAL_PT_preview(HdUSD_Panel):
 
 
 class HDUSD_MATERIAL_OP_link_mx_node_tree(bpy.types.Operator):
-    """Link new MaterialX node tree for selected material"""
+    """Create/Link/Unlink MaterialX node tree to selected material"""
     bl_idname = "hdusd.material_link_mx_node_tree"
     bl_label = ""
 
@@ -142,12 +142,6 @@ class HDUSD_MATERIAL_MT_mx_node_tree(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
         node_groups = bpy.data.node_groups
-        mat_hdusd = context.material.hdusd
-
-        op = layout.operator(HDUSD_MATERIAL_OP_link_mx_node_tree.bl_idname,
-                             text="Unlink" if mat_hdusd.mx_node_tree else "New",
-                             icon='REMOVE' if mat_hdusd.mx_node_tree else 'ADD')
-        op.action = 'UNLINK' if mat_hdusd.mx_node_tree else 'NEW'
 
         for ng in node_groups:
             if ng.bl_idname != 'hdusd.MxNodeTree':
@@ -178,9 +172,19 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
         col.alignment = 'RIGHT'
         col.label(text="MaterialX")
         col = split.column()
-        col.menu(HDUSD_MATERIAL_MT_mx_node_tree.bl_idname,
-                 text=mat_hdusd.mx_node_tree.name if mat_hdusd.mx_node_tree else "",
-                 icon='MATERIAL')
+        row = col.row(align=True)
+        col1 = row.column()
+        col1.enabled = any(ng.bl_idname == 'hdusd.MxNodeTree' for ng in bpy.data.node_groups)
+        col1.menu(HDUSD_MATERIAL_MT_mx_node_tree.bl_idname, text="", icon='MATERIAL')
+
+        if mat_hdusd.mx_node_tree:
+            row.prop(mat_hdusd.mx_node_tree, 'name', text="")
+            op = row.operator(HDUSD_MATERIAL_OP_link_mx_node_tree.bl_idname, text="", icon='REMOVE')
+            op.action = 'UNLINK'
+
+        else:
+            op = row.operator(HDUSD_MATERIAL_OP_link_mx_node_tree.bl_idname, text="New", icon='ADD')
+            op.action = 'NEW'
 
     def draw_header(self, context):
         layout = self.layout

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -124,6 +124,36 @@ class HDUSD_MATERIAL_OP_new_mx_node_tree(bpy.types.Operator):
         return {"FINISHED"}
 
 
+class HDUSD_MATERIAL_OP_mx_node_tree(bpy.types.Operator):
+    """Select render source"""
+    bl_idname = "hdusd.material_mx_node_tree"
+    bl_label = ""
+
+    mx_node_tree: bpy.props.StringProperty(default="")
+
+    def execute(self, context):
+        print(self.mx_node_tree)
+        return {"FINISHED"}
+
+
+class HDUSD_MATERIAL_MT_mx_node_tree(bpy.types.Menu):
+    bl_idname = "HDUSD_MATERIAL_MT_mx_node_tree"
+    bl_label = "MX Nodetree"
+
+    def draw(self, context):
+        layout = self.layout
+        node_groups = bpy.data.node_groups
+
+        for ng in node_groups:
+            if ng.bl_idname != 'hdusd.MxNodeTree':
+                continue
+
+            row = layout.row()
+            row.enabled = bool(ng.output_node)
+            op = row.operator("hdusd.material_mx_node_tree", text=ng.name)
+            op.mx_node_tree = ng.name
+
+
 class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
     bl_label = ""
     bl_context = "material"
@@ -137,6 +167,9 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
         layout = self.layout
 
         col = layout.column(align=True)
+        col.menu(HDUSD_MATERIAL_MT_mx_node_tree.bl_idname,
+                 text=mat_hdusd.mx_node_tree.name if mat_hdusd.mx_node_tree else "",
+                 icon='MATERIAL')
         col.label(text="MaterialX Node Tree:")
         col.template_ID(mat_hdusd, "mx_node_tree",
                         new=HDUSD_MATERIAL_OP_new_mx_node_tree.bl_idname)


### PR DESCRIPTION
### PURPOSE
MaterialX node trees selection menu in Material panel shows all node trees including USD node trees and grouped node trees.

### EFFECT OF CHANGE
Fixed list of MaterialX node trees in selection menu in Material panel.

### TECHNICAL STEPS
1. Created operators and menu: HDUSD_MATERIAL_OP_link_mx_node_tree, HDUSD_MATERIAL_OP_unlink_mx_node_tree, HDUSD_MATERIAL_MT_mx_node_tree.
2. Added menu and operators to HDUSD_MATERIAL_PT_material panle istead of template_ID.