### PR TITLE
RPRBLND-1812: Automatic switch to selected mesh MaterialX if selected mesh

### DIFF
--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -37,11 +37,12 @@ def on_load_post(*args):
 def on_depsgraph_update_post(scene, depsgraph):
     from ..properties import object, material
     from ..usd_nodes import node_tree
+    from ..ui import material as material_ui
 
     object.depsgraph_update(depsgraph)
     material.depsgraph_update(depsgraph)
     node_tree.depsgraph_update(depsgraph)
-
+    material_ui.depsgraph_update(depsgraph)
 
 @bpy.app.handlers.persistent
 def on_save_pre(*args):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -288,16 +288,17 @@ def depsgraph_update(depsgraph):
     # trying to show MaterialX area with node tree or Shader area
     screen = context.screen
     if mx_node_tree:
-        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
-        if not area:
-            area = next((a for a in screen.areas if a.ui_type == 'ShaderNodeTree'), None)
+        for area in screen.areas:
+            if area.ui_type not in ('hdusd.MxNodeTree', 'ShaderNodeTree'):
+                continue
 
-        if area:
             area.ui_type = 'hdusd.MxNodeTree'
             space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
             space.node_tree = mx_node_tree
 
     else:
-        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
-        if area:
+        for area in screen.areas:
+            if area.ui_type != 'hdusd.MxNodeTree':
+                continue
+
             area.ui_type = 'ShaderNodeTree'

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -108,19 +108,8 @@ class HDUSD_MATERIAL_OP_new_mx_node_tree(bpy.types.Operator):
         mx_node_tree = bpy.data.node_groups.new(f"MX_{mat.name}", type=MxNodeTree.bl_idname)
         mx_node_tree.create_basic_nodes(
             'RPR_rpr_uberv2' if context.scene.hdusd.use_rpr_mx_nodes else 'PBR_standard_surface')
+
         mat.hdusd.mx_node_tree = mx_node_tree
-
-        # trying to show MaterialX area with created node tree
-        screen = context.screen
-        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
-        if not area:
-            area = next((a for a in screen.areas if a.ui_type == 'ShaderNodeTree'), None)
-
-        if area:
-            area.ui_type = 'hdusd.MxNodeTree'
-            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
-            space.node_tree = mx_node_tree
-
         return {"FINISHED"}
 
 
@@ -288,3 +277,27 @@ class HDUSD_MATERIAL_PT_export_mx(HdUSD_Panel):
 
         layout.operator(HDUSD_MATERIAL_OP_export_mx_file.bl_idname)
         layout.operator(HDUSD_MATERIAL_OP_export_mx_console.bl_idname)
+
+
+def depsgraph_update(depsgraph):
+    context = bpy.context
+    mx_node_tree = None
+    if context.object and context.object.active_material:
+        mx_node_tree = context.object.active_material.hdusd.mx_node_tree
+
+    # trying to show MaterialX area with node tree or Shader area
+    screen = context.screen
+    if mx_node_tree:
+        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
+        if not area:
+            area = next((a for a in screen.areas if a.ui_type == 'ShaderNodeTree'), None)
+
+        if area:
+            area.ui_type = 'hdusd.MxNodeTree'
+            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
+            space.node_tree = mx_node_tree
+
+    else:
+        area = next((a for a in screen.areas if a.ui_type == 'hdusd.MxNodeTree'), None)
+        if area:
+            area.ui_type = 'ShaderNodeTree'


### PR DESCRIPTION
### PURPOSE
Need to add support for workflow: select mesh -> material X editor switch to the material from this mesh

### EFFECT OF CHANGE
Implemented automatic switch to selected MaterialX node tree or Shader editor when selected object or material was changed.

### TECHNICAL STEPS
Implemented ui.material.depsgraph_update() which tries to show correspondent MaterialX area with node tree or Shader area. Removed this code from HDUSD_MATERIAL_OP_new_mx_node_tree operator as not needed.
