### PR TITLE
RPRBLND-1839: Blender crashes after switching material of object.

### DIFF
--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -54,7 +54,8 @@ class MaterialProperties(HdUSDProperties):
 
         node_parser = ShaderNodeOutputMaterial(doc, material, output_node, obj,
                                                rpr=bpy.context.scene.hdusd.use_rpr_mx_nodes)
-        node_parser.export()
+        if not node_parser.export():
+            return None
 
         return doc
 


### PR DESCRIPTION
### PURPOSE
There was unhandled exceptions during node parsing.

### EFFECT OF CHANGE
Fixed unhandled exceptions if parser returns None.

### TECHNICAL STEPS
Return None if node_parser.export() returns None