### PR TITLE
RPRBLND-1804: add "Sun" (directional light) light source support for USD

### DIFF
--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -88,17 +88,17 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
 
     elif light.type == 'SPOT':
         usd_light = UsdLux.SphereLight.Define(stage, light_path)
-        a = stage.GetPrimAtPath(light_path)
+        usd_prim = stage.GetPrimAtPath(light_path)
 
         usd_light.CreateTreatAsPointAttr(1)
 
         spot_size = math.degrees(light.spot_size)
 
-        usd_shaping = UsdLux.ShapingAPI(a)
+        usd_shaping = UsdLux.ShapingAPI(usd_prim)
         usd_shaping.CreateShapingConeAngleAttr(spot_size / 2)
         usd_shaping.CreateShapingConeSoftnessAttr(light.spot_blend)
 
-        usd_shaping.Apply(a)
+        usd_shaping.Apply(usd_prim)
 
     elif light.type == 'AREA':
         shape_type = light.shape


### PR DESCRIPTION
### PURPOSE
Sun light is not supported now.

### EFFECT OF CHANGE
1. Added sun light support
2. Also added Spot light support

### TECHNICAL STEPS
1. Fixed getting light transform in HdRPR https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/500
2. Implemented DistantLight for sun light.
3. Spotlight emulated via ShapingAPI.

### NOTES FOR REVIEWERS
Full quality doesn't support Spotlight fully (spot blend doesn't work).