### PR TITLE
Fixed PySide2 import bug during loading HdRPR

### DIFF
--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -111,6 +111,11 @@ def main(bin_dir):
 
         subprocess.check_call(patchelf_args)
 
+    # Clear hdrpr/lib/python/rpr/RprUsd/__init__.py
+    rpr_usd_init_py = libs_dir / "hdrpr/lib/python/rpr/RprUsd/__init__.py"
+    print(f"Clearing {rpr_usd_init_py}")
+    rpr_usd_init_py.write_text("")
+
     print("Done.")
 
 


### PR DESCRIPTION
### PURPOSE
After https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/496 we have import bug:
```
Warning (secondary thread): in Tf_PyLoadScriptModule at line 122 of D:\amd-gpuopen\BlenderUSDHydraAddon\deps\USD\pxr\base\tf\pyUtils.cpp -- Import failed for module 'rpr.RprUsd'!
Traceback (most recent call last):
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\hdrpr\lib\python\rpr\RprUsd\devicesConfiguration.py", line 17, in <module>
    from hutil.Qt import QtCore, QtGui, QtWidgets
ModuleNotFoundError: No module named 'hutil'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\hdrpr\lib\python\rpr\RprUsd\__init__.py", line 13, in <module>
    from . import devicesConfiguration
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\hdrpr\lib\python\rpr\RprUsd\devicesConfiguration.py", line 19, in <module>
    from pxr.Usdviewq.qt import QtCore, QtGui, QtWidgets
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\usd\python\pxr\Usdviewq\__init__.py", line 32, in <module>
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\usd\python\pxr\Usdviewq\qt.py", line 42, in <module>
    PySideModule = GetPySideModule()
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\usd\python\pxr\Usdviewq\qt.py", line 31, in GetPySideModule
    from . import attributeValueEditorUI
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\libs\usd\python\pxr\Usdviewq\attributeValueEditorUI.py", line 11, in <module>
    from PySide2.QtCore import *
ModuleNotFoundError: No module named 'PySide2'
```

### EFFECT OF CHANGE
Fixed PySide2 import bug during loading HdRPR.

### TECHNICAL STEPS
Fixed by clearing hdrpr/lib/python/rpr/RprUsd/\_\_init__.py, as it is not used in plugin, during creating libs process