### PR TITLE
RPRBLND-1827: AI Denoising not activating in Final render menu

### DIFF
--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -102,7 +102,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_denoise_final(HdUSD_Panel):
         self.layout.prop(denoise, "enable")
 
     def draw(self, context):
-        denoise = context.scene.hdusd.viewport.hdrpr.denoise
+        denoise = context.scene.hdusd.final.hdrpr.denoise
 
         layout = self.layout
         layout.use_property_split = True


### PR DESCRIPTION
### PURPOSE
AI Denoising for Final render activates in Viewport render menu, Expexted activate AI Denoiser in Final render settings.

### EFFECT OF CHANGE
Activate AI Denoiser in Final render settings

### TECHNICAL STEPS
Fixed AI Denoiser activation at HDUSD_RENDER_PT_hdrpr_settings_denoise_final
