### PR TITLE
RPRBLND-1851: Export objects with USD Variants depending of render delegate

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -24,6 +24,7 @@ import bgl
 from .engine import Engine
 from ..export import nodegraph
 from ..utils import gl, time_str
+from ..utils import usd as usd_utils
 
 from ..utils import logging
 log = logging.Log(tag='final_engine')
@@ -205,6 +206,8 @@ class FinalEngine(Engine):
                 screen_ratio=screen_ratio,
                 is_gl_delegate=settings.is_gl_delegate,
             )
+
+        usd_utils.set_variant_delegate(stage, settings.is_gl_delegate)
 
         if self.render_engine.test_break():
             log.warn("Syncing stopped by user termination")

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -109,7 +109,6 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
             usd_light.CreateRadiusAttr(light.size)
 
         else:  # shape_type == 'ELLIPSE':
-            # Using Disk light of the approximately similar area instead
             usd_light = UsdLux.DiskLight.Define(stage, light_path)
             usd_light.CreateRadiusAttr(light.size)
 
@@ -117,13 +116,6 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
         raise ValueError("Unsupported light type", light, light.type)
 
     power = get_radiant_power(light)
-
-    # usd_prim = stage.GetPrimAtPath(light_path)
-    #
-    # color_attr = usd_prim.CreateAttribute('color', Sdf.ValueTypeNames.Color3f, False)
-    # color_attr.Set((1.0, 0.0, 0.0))
-    # intensity_attr = usd_prim.CreateAttribute('intensity', Sdf.ValueTypeNames.Float, False)
-    # intensity_attr.Set(1000)
 
     colorAttr = usd_light.CreateColorAttr()
 
@@ -134,6 +126,7 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
         colorAttr.Set(tuple(power))
 
     else:
+        # setting light color through variants for GL and RPR renderers
         vset = obj_prim.GetVariantSets().AddVariantSet('delegate')
         vset.AddVariant('GL')
         vset.AddVariant('RPR')

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -31,13 +31,13 @@ def get_radiant_power(light: bpy.types.Light):
     intensity = color * light.energy
 
     if light.type == 'POINT':
-        return intensity * 4
+        return intensity * 4            # coefficient approximated to follow Cycles results
 
     elif light.type == 'SPOT':
         return intensity
 
     elif light.type == 'SUN':
-        return intensity * 0.000025  # coefficient approximated to follow Cycles results
+        return intensity * 0.000025     # coefficient approximated to follow Cycles results
 
     elif light.type == 'AREA':
         area = 1.0

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -15,7 +15,7 @@
 import math
 import numpy as np
 
-from pxr import UsdLux, Tf
+from pxr import UsdLux, Tf, Sdf
 import bpy
 
 
@@ -118,13 +118,21 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
 
     power = get_radiant_power(light)
 
+    # usd_prim = stage.GetPrimAtPath(light_path)
+    #
+    # color_attr = usd_prim.CreateAttribute('color', Sdf.ValueTypeNames.Color3f, False)
+    # color_attr.Set((1.0, 0.0, 0.0))
+    # intensity_attr = usd_prim.CreateAttribute('intensity', Sdf.ValueTypeNames.Float, False)
+    # intensity_attr.Set(1000)
+
     colorAttr = usd_light.CreateColorAttr()
 
-    # Material Previews are overly bright, that's why
-    # decreasing light intensity for material preview by 10 times
     if is_preview_render:
+        # Material Previews are overly bright, that's why
+        # decreasing light intensity for material preview by 10 times
         power *= 0.1
-        colorAttr.Set(power)
+        colorAttr.Set(tuple(power))
+
     else:
         vset = obj_prim.GetVariantSets().AddVariantSet('delegate')
         vset.AddVariant('GL')

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -60,6 +60,7 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
     """ Creates pyrpr.Light from obj.data: bpy.types.Light """
     light = obj.data
     stage = obj_prim.GetStage()
+    context = bpy.context
     is_preview_render = kwargs.get('is_preview_render', False)
     log("sync", light, obj)
 
@@ -138,6 +139,9 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
         vset.SetVariantSelection('RPR')
         with vset.GetVariantEditContext():
             colorAttr.Set(tuple(power))
+
+        # setting default variant
+        vset.SetVariantSelection('GL' if context.scene.hdusd.viewport.is_gl_delegate else 'RPR')
 
 
 def sync_update(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -91,6 +91,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     usd_list.HDUSD_OP_usd_list_item_expand,
     usd_list.HDUSD_OP_usd_list_item_show_hide,
     usd_list.HDUSD_OP_usd_tree_node_print_stage,
+    usd_list.HDUSD_OP_usd_tree_node_print_root_layer,
     usd_list.HDUSD_UL_usd_list_item,
     usd_list.HDUSD_NODE_PT_usd_list,
     usd_list.HDUSD_OP_usd_nodetree_add_basic_nodes,

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -19,6 +19,9 @@ from pxr import UsdGeom
 from . import HdUSD_Panel, HdUSD_Operator
 from ..usd_nodes.nodes.base_node import USDNode
 
+from ..utils import logging
+log = logging.Log(tag='ui.usd_list')
+
 
 class HDUSD_OP_usd_list_item_expand(bpy.types.Operator):
     """Expand USD item"""
@@ -208,13 +211,13 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
         tree = context.space_data.edit_tree
         node = context.active_node
         if not node:
-            print(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
+            log(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
             return {'CANCELLED'}
 
         # get the USD stage from selected node
         stage = node.cached_stage()
         if not stage:
-            print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
+            log(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
             return {'CANCELLED'}
 
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
@@ -237,13 +240,13 @@ class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
         tree = context.space_data.edit_tree
         node = context.active_node
         if not node:
-            print(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
+            log(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
             return {'CANCELLED'}
 
         # get the USD stage from selected node
         stage = node.cached_stage()
         if not stage:
-            print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
+            log(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
             return {'CANCELLED'}
 
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
@@ -280,7 +283,6 @@ class HDUSD_NODE_PT_usd_nodetree_node_tools(HDUSD_UsdNodeTreePanel):
 
     def draw(self, context):
         col = self.layout.column()
-        op_idname = HDUSD_OP_usd_tree_node_print_stage.bl_idname
 
-        col.operator(op_idname, text="Print node stage to console")
-        col.operator(op_idname, text="Print root layer stage to console")
+        col.operator(HDUSD_OP_usd_tree_node_print_stage.bl_idname)
+        col.operator(HDUSD_OP_usd_tree_node_print_root_layer.bl_idname)

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -212,13 +212,42 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
             return {'CANCELLED'}
 
         # get the USD stage from selected node
-        stage = node._compute_node(node)
+        stage = node.cached_stage()
         if not stage:
             print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
             return {'CANCELLED'}
 
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
         print(stage.ExportToString())
+
+        return {'FINISHED'}
+
+
+class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
+    """ Print selected USD nodetree node stage to console """
+    bl_idname = "hdusd.usd_tree_node_print_root_layer"
+    bl_label = "Print Root Layer To Console"
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.space_data.tree_type == 'hdusd.USDTree' and \
+               context.active_node
+
+    def execute(self, context):
+        tree = context.space_data.edit_tree
+        node = context.active_node
+        if not node:
+            print(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
+            return {'CANCELLED'}
+
+        # get the USD stage from selected node
+        stage = node.cached_stage()
+        if not stage:
+            print(f"Unable to print USD node \"{tree.name}\":\"{node.name}\" stage: could not get the correct stage")
+            return {'CANCELLED'}
+
+        print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
+        print(stage.GetRootLayer().ExportToString())
 
         return {'FINISHED'}
 
@@ -254,3 +283,4 @@ class HDUSD_NODE_PT_usd_nodetree_node_tools(HDUSD_UsdNodeTreePanel):
         op_idname = HDUSD_OP_usd_tree_node_print_stage.bl_idname
 
         col.operator(op_idname, text="Print node stage to console")
+        col.operator(op_idname, text="Print root layer stage to console")

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -215,7 +215,17 @@ class BlenderDataNode(USDNode):
         root_prim = stage.GetPseudoRoot()
 
         for update in depsgraph.updates:
-            if isinstance(update.id, bpy.types.Object):
+            if isinstance(update.id, bpy.types.Scene):
+                scene = update.id
+                for prim in root_prim.GetAllChildren():
+                    vsets = prim.GetVariantSets()
+                    if 'delegate' not in vsets.GetNames():
+                        continue
+
+                    vset = vsets.GetVariantSet('delegate')
+                    vset.SetVariantSelection('GL' if scene.hdusd.viewport.is_gl_delegate else 'RPR')
+
+            elif isinstance(update.id, bpy.types.Object):
                 obj = update.id
                 if obj.hdusd.is_usd:
                     continue

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -19,3 +19,13 @@ import mathutils
 def get_xform_transform(xform):
     transform = mathutils.Matrix(xform.GetLocalTransformation())
     return transform.transposed()
+
+
+def set_variant_delegate(stage, delegate_name):
+    for prim in stage.TraverseAll():
+        vsets = prim.GetVariantSets()
+        if 'delegate' not in vsets.GetNames():
+            continue
+
+        vset = vsets.GetVariantSet('delegate')
+        vset.SetVariantSelection(delegate_name)

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -21,11 +21,12 @@ def get_xform_transform(xform):
     return transform.transposed()
 
 
-def set_variant_delegate(stage, delegate_name):
+def set_variant_delegate(stage, is_gl_delegate):
+    name = 'GL' if is_gl_delegate else 'RPR'
     for prim in stage.TraverseAll():
         vsets = prim.GetVariantSets()
         if 'delegate' not in vsets.GetNames():
             continue
 
         vset = vsets.GetVariantSet('delegate')
-        vset.SetVariantSelection(delegate_name)
+        vset.SetVariantSelection(name)


### PR DESCRIPTION
### PURPOSE
Current light export implementation isn't good, because different we have to use different light intensity depending of render delegate. In viewport we have to resync lights when delegate is changed. Better solution is to use USD Variants where we can store delegate dependent values.

### EFFECT OF CHANGE
Improved light export implementation with using USD Variants.
Added "Print Root Layer To Console" operator to USD Nodes Tools panel.

### TECHNICAL STEPS
1. Improved light export implementation with USD Variants. Improved light intensity calculations.
2. Added utils.usd.set_variant_delegate(), adjusted final and viewport engines to selecting USD variant depending of delegate.
3. Updated BlenderDataNode.depsgraph_update() with selecting default variant delegate.
4. For debug purposes, created operator HDUSD_OP_usd_tree_node_print_root_layer, added it to USD Nodes Tools panel.
