### PR TITLE
RPRBLND-1813: World support

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -62,7 +62,7 @@ class Engine:
             except Exception as e:
                 log.error(e, 'EXCEPTION:', traceback.format_exc())
 
-        world.sync(root_prim, depsgraph.scene.world, **kwargs)
+        world.sync(root_prim, depsgraph.scene.world)
 
 
 from . import final_engine, viewport_engine, preview_engine

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -401,7 +401,8 @@ class ViewportEngineScene(ViewportEngine):
                                          self.shading_data.use_scene_lights)
 
         depsgraph_keys = set(object.sdf_name(obj) for obj in dg_objects())
-        usd_object_keys = set(prim.GetName() for prim in root_prim.GetAllChildren())
+        usd_object_keys = set(prim.GetName() for prim in root_prim.GetAllChildren()
+                              if prim.GetName() != world.PRIM_NAME)
         keys_to_remove = usd_object_keys - depsgraph_keys
         keys_to_add = depsgraph_keys - usd_object_keys
 

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -106,10 +106,8 @@ class WorldData:
         return data
 
 
-def sync(root_prim, world: bpy.types.World, **kwargs):
-    # get the World IBL image
+def sync(root_prim, world: bpy.types.World):
     data = WorldData.init_from_world(world)
-    print(data)
 
     stage = root_prim.GetStage()
 
@@ -136,3 +134,14 @@ def sync(root_prim, world: bpy.types.World, **kwargs):
     # transform[:3, :3] = euler.to_matrix()
     #
     # usd_light.AddTransformOp().Set(Gf.Matrix4d(transform))
+
+
+def sync_update(root_prim, world: bpy.types.World):
+    stage = root_prim.GetStage()
+
+    usd_light = UsdLux.DomeLight.Define(stage,
+        Sdf.Path('/World').AppendChild(Tf.MakeValidIdentifier(world.name)))
+    usd_light.CreateColorAttr().Clear()
+    usd_light.CreateTextureFileAttr().Clear()
+
+    sync(root_prim, world)

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -13,9 +13,7 @@
 # limitations under the License.
 #********************************************************************
 from dataclasses import dataclass
-
 import numpy as np
-
 from pathlib import Path
 
 import bpy
@@ -23,130 +21,118 @@ import mathutils
 
 from pxr import Gf, Sdf, UsdGeom, UsdLux, Tf
 
+from ...utils.image import cache_image_file
+from ...utils import BLENDER_DATA_DIR
+
 from ...utils import logging
 log = logging.Log(tag='export.world')
-
-
-WARNING_IMAGE_NOT_DEFINED_COLOR = (1.0, 0.0, 1.0)
-STUDIO_LIGHT_DEFAULT_COLOR = (0.051, 0.051, 0.051)  # Blender's default background color in viewport
 
 
 @dataclass(init=False, eq=True, repr=True)
 class WorldData:
     """ Comparable dataclass which holds all environment settings """
 
-    @dataclass(eq=True)
-    class IblData:
-        color: tuple = (0, 0, 0)
-        image: str = None
-        studio_light: str = None
-        rotation: tuple = (0, 0, 0)
-
-        @staticmethod
-        def init_from_cycles(world: bpy.types.World):
-            data = WorldData.IblData()
-
-            data.color = world.color[:3]
-
-            if not world.use_nodes:
-                return data
-
-            # Parse the simplest environment IBL image nodes config:
-            # Mapping -> Environment Image -> Background -> World Output
-            output = world.node_tree.get_output_node('ALL')
-            if not output:
-                output = world.node_tree.get_output_node('CYCLES')
-
-            if not output or not output.inputs['Surface'].is_linked:
-                return data
-
-            # Background node
-            background_node = output.inputs['Surface'].links[0].from_node
-            if background_node.type != 'BACKGROUND':
-                return data
-
-            data.color = background_node.inputs['Color'].default_value[:3]
-
-            # Environment Image node => image file info
-            if not background_node.inputs['Color'].is_linked:
-                return data
-            environment_node = background_node.inputs['Color'].links[0].from_node
-            if environment_node.type != 'TEX_ENVIRONMENT':
-                return data
-            if not environment_node.image or not environment_node.image.filepath:
-                return data
-            img_path = environment_node.image.filepath_from_user()
-
-            # TODO extract studio lights and packed images
-            if not Path(img_path).is_file():
-                return data
-            data.image = str(img_path)
-
-            # Mapping node => rotation info
-            if not environment_node.inputs['Vector'].is_linked:
-                return data
-            mapping_node = environment_node.inputs['Vector'].links[0].from_node
-            if mapping_node.type != 'MAPPING':
-                return data
-            data.rotation = tuple(mapping_node.inputs[2].default_value)
-
-            return data
-
-        @staticmethod
-        def init_from_shading(shading):
-            data = WorldData.IblData()
-            data.studio_light = shading.studio_light
-            return data
-
-    cycles_ibl: IblData = None
-    # TODO support studio light settings
-    # TODO support RPR Environment settings as an option
+    color: tuple = (0, 0, 0)
+    image: str = None
+    intensity: float = 1.0
+    rotation: tuple = (0, 0, 0)
 
     @staticmethod
     def init_from_world(world: bpy.types.World):
         """ Returns WorldData from bpy.types.World """
         data = WorldData()
 
-        data.cycles_ibl = WorldData.IblData.init_from_cycles(world)
+        if not world.use_nodes:
+            data.color = tuple(world.color)
+            return data
 
+        output_node = next((node for node in world.node_tree.nodes
+                           if node.bl_idname == 'ShaderNodeOutputWorld' and node.is_active_output),
+                           None)
+        if not output_node:
+            return data
+
+        from .nodes import ShaderNodeOutputWorld
+
+        node_parser = ShaderNodeOutputWorld(world, output_node)
+        node_item = node_parser.export()
+        if not node_item:
+            return data
+
+        d = node_item.data
+        print(d)
+
+        if isinstance(d, float):
+            data.color = (d, d, d)
+        if isinstance(d, tuple):
+            data.color = d[:3]
+        else:   # dict
+            intensity = d.get('intensity', 1.0)
+            if isinstance(intensity, tuple):
+                intensity = intensity[0]
+
+            data.intensity = intensity
+
+            color = d.get('color')
+            if color:
+                if isinstance(color, float):
+                    data.color = (color, color, color)
+                if isinstance(color, tuple):
+                    data.color = color[:3]
+                else:   # dict
+                    image = color.get('image')
+                    if image:
+                        data.image = cache_image_file(image)
+            else:
+                image = d.get('image')
+                if image:
+                    data.image = cache_image_file(image)
+
+        return data
+
+    @staticmethod
+    def init_from_shading(shading):
+        data = WorldData()
+        data.intensity = shading.studio_light_intensity
+        data.rotation = (0.0, 0.0, shading.studio_light_rotate_z)
+        data.image = str(BLENDER_DATA_DIR / "studiolights/world" / shading.studio_light)
         return data
 
 
 def sync(root_prim, world: bpy.types.World, **kwargs):
-    is_gl_mode = kwargs.get('is_gl_delegate', False)
-
-    if is_gl_mode:
-        # TODO export correct Dome light with texture for GL mode
-        return
 
     # get the World IBL image
     data = WorldData.init_from_world(world)
+    print(data)
 
-    stage = root_prim.GetStage()
-
-    if not data.cycles_ibl.image:
-        # TODO create image from environment color data if no image used
-        return
-
-    # create Dome light
-    xform = UsdGeom.Xform.Define(stage, root_prim.GetPath().AppendChild("_world"))
-    obj_prim = xform.GetPrim()
-
-    usd_light = UsdLux.DomeLight.Define(stage, obj_prim.GetPath().AppendChild(Tf.MakeValidIdentifier(world.name)))
-    usd_light.ClearXformOpOrder()
-    usd_light.OrientToStageUpAxis()
-
-    p = Sdf.AssetPath(data.cycles_ibl.image)
-    usd_light.CreateTextureFileAttr(p)
-
-    # set correct Dome light rotation
-    matrix = np.identity(4)
-    rotation = data.cycles_ibl.rotation
-    euler = mathutils.Euler((-rotation[0], -rotation[1] + np.pi, -rotation[2] - np.pi / 2))
-
-    rotation_matrix = np.array(euler.to_matrix(), dtype=np.float32)
-
-    matrix[:3, :3] = rotation_matrix[:, :]
-
-    xform.ClearXformOpOrder()
-    xform.AddTransformOp().Set(Gf.Matrix4d(matrix))
+    #
+    #
+    #
+    # stage = root_prim.GetStage()
+    #
+    # if not data.cycles_ibl.image:
+    #     # TODO create image from environment color data if no image used
+    #     return
+    #
+    # # create Dome light
+    # xform = UsdGeom.Xform.Define(stage, root_prim.GetPath().AppendChild("_world"))
+    # obj_prim = xform.GetPrim()
+    #
+    # usd_light = UsdLux.DomeLight.Define(stage, obj_prim.GetPath().AppendChild(Tf.MakeValidIdentifier(world.name)))
+    # usd_light.ClearXformOpOrder()
+    # usd_light.OrientToStageUpAxis()
+    #
+    # p = Sdf.AssetPath(data.cycles_ibl.image)
+    # usd_light.CreateTextureFileAttr(p)
+    #
+    # # set correct Dome light rotation
+    # matrix = np.identity(4)
+    # rotation = data.cycles_ibl.rotation
+    # euler = mathutils.Euler((-rotation[0], -rotation[1] + np.pi, -rotation[2] - np.pi / 2))
+    #
+    # rotation_matrix = np.array(euler.to_matrix(), dtype=np.float32)
+    #
+    # matrix[:3, :3] = rotation_matrix[:, :]
+    #
+    # xform.ClearXformOpOrder()
+    # xform.AddTransformOp().Set(Gf.Matrix4d(matrix))

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -3,9 +3,9 @@
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
-# 
+#
 #     http://www.apache.org/licenses/LICENSE-2.0
-# 
+#
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
@@ -23,7 +23,7 @@ import mathutils
 
 from pxr import Gf, Sdf, UsdGeom, UsdLux, Tf
 
-from ..utils import logging
+from ...utils import logging
 log = logging.Log(tag='export.world')
 
 

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -111,11 +111,9 @@ def sync(root_prim, world: bpy.types.World):
 
     stage = root_prim.GetStage()
 
-    # create Dome light
     obj_prim = stage.DefinePrim(root_prim.GetPath().AppendChild("World"))
     usd_light = UsdLux.DomeLight.Define(stage,
         obj_prim.GetPath().AppendChild(Tf.MakeValidIdentifier(world.name)))
-    usd_light.ClearXformOpOrder()
     usd_light.OrientToStageUpAxis()
 
     if data.image:
@@ -126,14 +124,9 @@ def sync(root_prim, world: bpy.types.World):
     usd_light.CreateIntensityAttr(data.intensity)
 
     # # set correct Dome light rotation
-    # rot = data.rotation
-    # # euler = mathutils.Euler((-rot[0], -rot[1] + np.pi, -rot[2] - np.pi / 2))
-    # euler = mathutils.Euler((rot[0] + np.pi, rot[1], rot[2] - np.pi))
-    #
-    # transform = np.identity(4)
-    # transform[:3, :3] = euler.to_matrix()
-    #
-    # usd_light.AddTransformOp().Set(Gf.Matrix4d(transform))
+    usd_light.AddRotateXOp().Set(180.0)
+    usd_light.AddRotateYOp().Set(-90.0)
+    # TODO: enable rotation angles
 
 
 def sync_update(root_prim, world: bpy.types.World):
@@ -141,7 +134,10 @@ def sync_update(root_prim, world: bpy.types.World):
 
     usd_light = UsdLux.DomeLight.Define(stage,
         Sdf.Path('/World').AppendChild(Tf.MakeValidIdentifier(world.name)))
+
+    # removing prev settings
     usd_light.CreateColorAttr().Clear()
     usd_light.CreateTextureFileAttr().Clear()
+    usd_light.ClearXformOpOrder()
 
     sync(root_prim, world)

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -187,9 +187,9 @@ class NodeParser:
     Subclasses should override only export() function.
     """
 
-    def __init__(self, material: bpy.types.Material,
+    def __init__(self, world: bpy.types.World,
                  node: bpy.types.Node, out_key, **kwargs):
-        self.material = material
+        self.world = world
         self.node = node
         self.out_key = out_key
         self.kwargs = kwargs
@@ -205,10 +205,10 @@ class NodeParser:
         # getting corresponded NodeParser class
         NodeParser_cls = self.get_node_parser_cls(node.bl_idname)
         if not NodeParser_cls:
-            log.warn("Ignoring unsupported node", node, self.material)
+            log.warn("Ignoring unsupported node", node, self.world)
             return None
 
-        node_parser = NodeParser_cls(self.material, node, out_key, **self.kwargs)
+        node_parser = NodeParser_cls(self.world, node, out_key, **self.kwargs)
         return node_parser.export()
 
     def _parse_val(self, val):
@@ -256,7 +256,7 @@ class NodeParser:
 
         # # check if linked is correct
         if not link.is_valid:
-            log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
+            log.warn("Invalid link ignored", link, socket_in, self.node, self.world)
             return None
 
         return self._export_node(link.from_node, link.from_socket.identifier)
@@ -273,7 +273,7 @@ class NodeParser:
     def get_input_scalar(self, socket_key):
         """ Parse link, accept only RPR core material nodes """
         val = self.get_input_link(socket_key)
-        if val is not None and isinstance(val, (float, tuple)):
+        if val is not None and isinstance(val.data, (float, tuple)):
             return val
 
         return self.get_input_default(socket_key)

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -1,0 +1,280 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import math
+
+import bpy
+
+from . import log
+
+
+class NodeItem:
+    """This class is a wrapper used for doing operations on MaterialX nodes, floats, and tuples"""
+
+    def __init__(self, data: [tuple, float, str]):
+        self.data = data
+
+    def node_item(self, value):
+        if isinstance(value, NodeItem):
+            return value
+
+        return NodeItem(value)
+
+    # MATH OPERATIONS
+    def _arithmetic_helper(self, other, func):
+        if other is None:
+            if isinstance(self.data, float):
+                result_data = func(self.data)
+            elif isinstance(self.data, tuple):
+                result_data = tuple(map(func, self.data))
+            else:
+                result_data = self.data
+
+        else:
+            other_data = other.data if isinstance(other, NodeItem) else other
+            if isinstance(self.data, (float, tuple)) and isinstance(other_data, (float, tuple)):
+                if isinstance(self.data, float) and isinstance(other_data, float):
+                    result_data = func(self.data, other_data)
+                else:
+                    data = self.data
+
+                    # converting data or other_data to have equal length
+                    if isinstance(data, float):
+                        data = (data,) * len(other_data)
+                    elif isinstance(other_data, float):
+                        other_data = (other_data,) * len(data)
+                    elif len(data) < len(other_data):
+                        data = (*data, 1.0)
+                    elif len(other_data) < len(data):
+                        other_data = (*other_data, 1.0)
+
+                    result_data = tuple(map(func, data, other_data))
+
+            else:
+                result_data = self.data if isinstance(self.data, str) else other_data
+
+        return self.node_item(result_data)
+
+    def __add__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a + b)
+
+    def __sub__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a - b)
+
+    def __mul__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a * b)
+
+    def __truediv__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a / b if not math.isclose(b, 0.0) else 0.0)
+
+    def __mod__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a % b)
+
+    def __pow__(self, other):
+        return self._arithmetic_helper(other, lambda a, b: a ** b)
+
+    def __neg__(self):
+        return 0.0 - self
+
+    def __abs__(self):
+        return self._arithmetic_helper(None, lambda a: abs(a))
+
+    def floor(self):
+        return self._arithmetic_helper(None, lambda a: float(math.floor(a)))
+
+    def ceil(self):
+        return self._arithmetic_helper(None, lambda a: float(math.ceil(a)))
+
+    # right hand methods for doing something like 1.0 - Node
+    def __radd__(self, other):
+        return self + other
+
+    def __rsub__(self, other):
+        return self.node_item(other) - self
+
+    def __rmul__(self, other):
+        return self * other
+
+    def __rtruediv__(self, other):
+        return self.node_item(other) / self
+
+    def __rmod__(self, other):
+        return self.node_item(other) % self
+
+    def __rpow__(self, other):
+        return self.node_item(other) ** self
+
+    def dot(self, other):
+        dot = self._arithmetic_helper(other, lambda a, b: a * b)
+        if isinstance(dot.data, tuple):
+            dot.data = sum(dot.data)
+
+        return dot
+
+    def if_else(self, cond: str, other, if_value, else_value):
+        if cond == '>':
+            res = self._arithmetic_helper(other, lambda a, b: float(a > b))
+        elif cond == '>=':
+            res = self._arithmetic_helper(other, lambda a, b: float(a >= b))
+        elif cond == '==':
+            res = self._arithmetic_helper(other, lambda a, b: float(a == b))
+        elif cond == '<':
+            return self.node_item(other).if_else('>', self, else_value, if_value)
+        elif cond == '<=':
+            return self.node_item(other).if_else('>=', self, else_value, if_value)
+        elif cond == '!=':
+            return self.if_else('==', other, else_value, if_value)
+        else:
+            raise ValueError("Incorrect condition:", cond)
+
+        if isinstance(res.data, float):
+            return if_value if res.data == 1.0 else else_value
+        elif isinstance(res.data, tuple):
+            return if_value if res.data[0] == 1.0 else else_value
+        else:
+            return res
+
+    def min(self, other):
+        return self._arithmetic_helper(other, lambda a, b: min(a, b))
+
+    def max(self, other):
+        return self._arithmetic_helper(other, lambda a, b: max(a, b))
+
+    def clamp(self, min_val=0.0, max_val=1.0):
+        """ clamp data to min/max """
+        return self.min(max_val).max(min_val)
+
+    def sin(self):
+        return self._arithmetic_helper(None, lambda a: math.sin(a))
+
+    def cos(self):
+        return self._arithmetic_helper(None, lambda a: math.cos(a))
+
+    def tan(self):
+        return self._arithmetic_helper(None, lambda a: math.tan(a))
+
+    def asin(self):
+        return self._arithmetic_helper(None, lambda a: math.asin(a))
+
+    def acos(self):
+        return self._arithmetic_helper(None, lambda a: math.acos(a))
+
+    def atan(self):
+        return self._arithmetic_helper(None, lambda a: math.atan(a))
+
+    def log(self):
+        return self._arithmetic_helper(None, lambda a: math.log(a))
+
+
+class NodeParser:
+    """
+    This is the base class that parses a blender node.
+    Subclasses should override only export() function.
+    """
+
+    def __init__(self, material: bpy.types.Material,
+                 node: bpy.types.Node, out_key, **kwargs):
+        self.material = material
+        self.node = node
+        self.out_key = out_key
+        self.kwargs = kwargs
+
+    @staticmethod
+    def get_node_parser_cls(bl_idname):
+        """ Returns NodeParser class for node_idname or None if not found """
+        from . import nodes
+        return getattr(nodes, bl_idname, None)
+
+    # INTERNAL FUNCTIONS
+    def _export_node(self, node, out_key, group_node=None):
+        # getting corresponded NodeParser class
+        NodeParser_cls = self.get_node_parser_cls(node.bl_idname)
+        if not NodeParser_cls:
+            log.warn("Ignoring unsupported node", node, self.material)
+            return None
+
+        node_parser = NodeParser_cls(self.material, node, out_key, **self.kwargs)
+        return node_parser.export()
+
+    def _parse_val(self, val):
+        """Turn blender socket value into python's value"""
+
+        if isinstance(val, (int, float)):
+            return float(val)
+
+        if len(val) in (3, 4):
+            return tuple(val)
+
+        if isinstance(val, str):
+            return val
+
+        raise TypeError("Unknown value type to pass to rpr", val)
+
+    def node_item(self, value):
+        if isinstance(value, NodeItem):
+            return value
+
+        return NodeItem(value)
+
+    # HELPER FUNCTIONS
+    # Child classes should use them to do their export
+    def get_output_default(self):
+        """ Returns default value of output socket """
+        socket_out = self.node.outputs[self.out_key]
+
+        return self.node_item(self._parse_val(socket_out.default_value))
+
+    def get_input_default(self, in_key):
+        """ Returns default value of input socket """
+
+        socket_in = self.node.inputs[in_key]
+        return self.node_item(self._parse_val(socket_in.default_value))
+
+    def get_input_link(self, in_key: [str, int]):
+        """Returns linked parsed node or None if nothing is linked or not link is not valid"""
+
+        socket_in = self.node.inputs[in_key]
+        if not socket_in.is_linked:
+            return None
+
+        link = socket_in.links[0]
+
+        # # check if linked is correct
+        if not link.is_valid:
+            log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
+            return None
+
+        return self._export_node(link.from_node, link.from_socket.identifier)
+
+    def get_input_value(self, in_key):
+        """ Returns linked node or default socket value """
+
+        val = self.get_input_link(in_key)
+        if val is not None:
+            return val
+
+        return self.get_input_default(in_key)
+
+    def get_input_scalar(self, socket_key):
+        """ Parse link, accept only RPR core material nodes """
+        val = self.get_input_link(socket_key)
+        if val is not None and isinstance(val, (float, tuple)):
+            return val
+
+        return self.get_input_default(socket_key)
+
+    # EXPORT FUNCTION
+    def export(self) -> [NodeItem, None]:
+        """Main export function which should be overridable in child classes"""
+        return None

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -22,7 +22,7 @@ from . import log
 class NodeItem:
     """This class is a wrapper used for doing operations on MaterialX nodes, floats, and tuples"""
 
-    def __init__(self, data: [tuple, float, str]):
+    def __init__(self, data: [tuple, float, dict]):
         self.data = data
 
     def node_item(self, value):
@@ -62,7 +62,7 @@ class NodeItem:
                     result_data = tuple(map(func, data, other_data))
 
             else:
-                result_data = self.data if isinstance(self.data, str) else other_data
+                result_data = other_data if isinstance(self.data, (float, tuple)) else self.data
 
         return self.node_item(result_data)
 
@@ -175,6 +175,10 @@ class NodeItem:
 
     def log(self):
         return self._arithmetic_helper(None, lambda a: math.log(a))
+
+    def blend(self, value1, value2):
+        """ Line interpolate value between value1(0.0) and value2(1.0) by self.data as factor """
+        return self * value2 + (1.0 - self) * value1
 
 
 class NodeParser:

--- a/src/hdusd/export/world/nodes.py
+++ b/src/hdusd/export/world/nodes.py
@@ -16,6 +16,9 @@ from .node_parser import NodeParser
 
 
 class ShaderNodeOutputWorld(NodeParser):
+    def __init__(self, world, node, **kwargs):
+        super().__init__(world, node, None, **kwargs)
+
     def export(self):
         return self.get_input_link('Surface')
 
@@ -24,12 +27,6 @@ class ShaderNodeBackground(NodeParser):
     def export(self):
         color = self.get_input_value('Color').data
         strength = self.get_input_scalar('Strength').data
-
-        if isinstance(color, float):
-            color = (color, color, color)
-
-        if isinstance(strength, tuple):
-            strength = strength[0]
 
         return self.node_item({
             'color': color,

--- a/src/hdusd/export/world/nodes.py
+++ b/src/hdusd/export/world/nodes.py
@@ -17,14 +17,53 @@ from .node_parser import NodeParser
 
 class ShaderNodeOutputWorld(NodeParser):
     def export(self):
-        color = self.get_input_value('Color')
-        roughness = self.get_input_value('Roughness')
-        normal = self.get_input_link('Normal')
+        return self.get_input_link('Surface')
 
-        result = self.create_node('diffuse_brdf', 'BSDF', {
+
+class ShaderNodeBackground(NodeParser):
+    def export(self):
+        color = self.get_input_value('Color').data
+        strength = self.get_input_scalar('Strength').data
+
+        if isinstance(color, float):
+            color = (color, color, color)
+
+        if isinstance(strength, tuple):
+            strength = strength[0]
+
+        return self.node_item({
             'color': color,
-            'roughness': roughness,
-            'normal': normal,
+            'intensity': strength
         })
 
-        return result
+
+class ShaderNodeTexEnvironment(NodeParser):
+    def export(self):
+        return self.node_item({
+            'image': self.node.image
+        })
+
+
+class ShaderNodeTexImage(NodeParser):
+    def export(self):
+        return self.node_item({
+            'image': self.node.image
+        })
+
+
+class ShaderNodeRGB(NodeParser):
+    def export(self):
+        return self.get_output_default()
+
+
+class ShaderNodeValue(NodeParser):
+    def export(self):
+        return self.get_output_default()
+
+
+class ShaderNodeInvert(NodeParser):
+    def export(self):
+        fac = self.get_input_scalar('Fac')
+        color = self.get_input_scalar('Color')
+
+        return fac.blend(color, 1.0 - color)

--- a/src/hdusd/export/world/nodes.py
+++ b/src/hdusd/export/world/nodes.py
@@ -1,0 +1,14 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************

--- a/src/hdusd/export/world/nodes.py
+++ b/src/hdusd/export/world/nodes.py
@@ -12,3 +12,19 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+from .node_parser import NodeParser
+
+
+class ShaderNodeOutputWorld(NodeParser):
+    def export(self):
+        color = self.get_input_value('Color')
+        roughness = self.get_input_value('Roughness')
+        normal = self.get_input_link('Normal')
+
+        result = self.create_node('diffuse_brdf', 'BSDF', {
+            'color': color,
+            'roughness': roughness,
+            'normal': normal,
+        })
+
+        return result

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -1,0 +1,28 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from pathlib import Path
+
+import bpy
+
+from . import get_temp_file
+
+
+def cache_image_file(image: bpy.types.Image):
+    if image.source == 'FILE':
+        return Path(image.filepath_from_user())
+
+    temp_path = get_temp_file(".png")
+    image.save_render(str(temp_path))
+    return temp_path


### PR DESCRIPTION
### PURPOSE
World export implementation is outdated and was working in draft mode. We need more complex support of world nodes, make it work in USD nodes and in viewport.

### EFFECT OF CHANGE
Improved worlds export system with better world nodes support, make it work in USD nodes and available to change in viewport.

### TECHNICAL STEPS
1. Created module export/world:
    - added node_parser.py with NodeItem and NodeParser classes, which parses nodes in world node_tree
    - reimplemented WorldData class, adjusted sync(), implemented sync_update() in export/world/\_\_init__.py
    - implemented parsing of useful nodes used in world node_tree.
    - removed export/world.py
2. Added world syncing to BlenderDataNode USD node, made code improvements.
3. Added world syncing to ViewportEngineScene, made code improvements
4. Added utils/image.py with cache_image_file()

### NOTES FOR REVIEWERS
Viewport shading world doesn't implemented here, plan to do it in separate task.