### PR TITLE
RPRBLND-1833: Collection render no working correct

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -49,10 +49,8 @@ class Engine:
 
         root_prim = stage.GetPseudoRoot()
 
-        use_scene_cameras = self.TYPE!='FINAL'
-
         objects_len = len(depsgraph.objects)
-        for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights, use_scene_cameras)):
+        for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights, False)):
             if test_break and test_break():
                 return None
 
@@ -61,13 +59,6 @@ class Engine:
 
             try:
                 object.sync(root_prim, obj, **kwargs)
-            except Exception as e:
-                log.error(e, 'EXCEPTION:', traceback.format_exc())
-
-        # sync a scene camera separately for final render
-        if not use_scene_cameras:
-            try:
-                object.sync(root_prim, depsgraph.scene.camera, **kwargs)
             except Exception as e:
                 log.error(e, 'EXCEPTION:', traceback.format_exc())
 

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -49,8 +49,10 @@ class Engine:
 
         root_prim = stage.GetPseudoRoot()
 
+        use_scene_cameras = self.TYPE!='FINAL'
+
         objects_len = len(depsgraph.objects)
-        for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights)):
+        for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights, use_scene_cameras)):
             if test_break and test_break():
                 return None
 
@@ -59,6 +61,13 @@ class Engine:
 
             try:
                 object.sync(root_prim, obj, **kwargs)
+            except Exception as e:
+                log.error(e, 'EXCEPTION:', traceback.format_exc())
+
+        # sync a scene camera separately for final render
+        if not use_scene_cameras:
+            try:
+                object.sync(root_prim, depsgraph.scene.camera, **kwargs)
             except Exception as e:
                 log.error(e, 'EXCEPTION:', traceback.format_exc())
 

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -22,6 +22,7 @@ import bpy
 import bgl
 
 from .engine import Engine
+from ..export import object
 from ..utils import gl, time_str
 from ..utils import usd as usd_utils
 
@@ -97,6 +98,18 @@ class FinalEngine(Engine):
         # it's important to clear data explicitly
         draw_target = None
         renderer = None
+
+    def _export_depsgraph(self, stage, depsgraph, sync_callback=None, test_break=None,
+                          space_data=None, use_scene_lights=True, **kwargs):
+
+        super()._export_depsgraph(stage, depsgraph, sync_callback=sync_callback, test_break=test_break,
+                          space_data=space_data, use_scene_lights=use_scene_lights, **kwargs)
+
+        # add scene camera to a stage
+        try:
+            object.sync(stage.GetPseudoRoot(), depsgraph.scene.camera, **kwargs)
+        except Exception as e:
+            log.error(e, 'EXCEPTION:', traceback.format_exc())
 
     def _render(self, scene):
         # creating renderer

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -108,13 +108,16 @@ def time_str(val):
     return f"{math.floor(val / 60):02}:{math.floor(val % 60):02}.{math.floor((val % 1) * 100):02}"
 
 
-def depsgraph_objects(depsgraph, space_data=None, use_scene_lights=True):
+def depsgraph_objects(depsgraph, space_data=None, use_scene_lights=True, use_scene_cameras=True):
     for obj in depsgraph.objects:
         if obj.type not in ('MESH', 'LIGHT', 'CURVE', 'FONT',
                             'SURFACE', 'META', 'VOLUME', 'CAMERA'):
             continue
 
         if obj.type == 'LIGHT' and not use_scene_lights:
+            continue
+
+        if obj.type == 'CAMERA' and not use_scene_cameras:
             continue
 
         if space_data and not obj.visible_in_viewport_get(space_data):


### PR DESCRIPTION
### PURPOSE
A stage is created from all the enabled collections, so in case if active camera isn’t there, it doesn’t include into the stage for final render.
Result: null camera is set as active render camera.
Active camera needs to be added to a stage separately.

### EFFECT OF CHANGE
Render collections with expected result and without errors

### TECHNICAL STEPS
Added use_scene_cameras input for depsgraph_objects to be able exclude a camera for final render
Added sync camera object separately for final render
