### PR TITLE
RPRBLND-1846: Scene Instances support

### DIFF
--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -20,7 +20,6 @@ import bpy
 from pxr import UsdGeom
 
 from ..utils.stage_cache import CachedStage
-from ..utils import depsgraph_objects
 from ..export import object, world
 
 from ..utils import logging
@@ -50,9 +49,9 @@ class Engine:
         root_prim = stage.GetPseudoRoot()
 
         objects_len = len(depsgraph.objects)
-        for i, obj in enumerate(depsgraph_objects(depsgraph,
-                                                  space_data=space_data,
-                                                  use_scene_lights=use_scene_lights)):
+        for i, obj in enumerate(object.depsgraph_objects(depsgraph,
+                                                         space_data=space_data,
+                                                         use_scene_lights=use_scene_lights)):
             if test_break and test_break():
                 return None
 

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -50,7 +50,9 @@ class Engine:
         root_prim = stage.GetPseudoRoot()
 
         objects_len = len(depsgraph.objects)
-        for i, obj in enumerate(depsgraph_objects(depsgraph, space_data, use_scene_lights)):
+        for i, obj in enumerate(depsgraph_objects(depsgraph,
+                                                  space_data=space_data,
+                                                  use_scene_lights=use_scene_lights)):
             if test_break and test_break():
                 return None
 

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -38,33 +38,6 @@ class Engine:
     def stage(self):
         return self.cached_stage()
 
-    def _export_depsgraph(self, stage, depsgraph, *,
-                          sync_callback=None, test_break=None,
-                          space_data=None, use_scene_lights=True, **kwargs):
-        log("sync", depsgraph)
-
-        UsdGeom.SetStageMetersPerUnit(stage, 1)
-        UsdGeom.SetStageUpAxis(stage, UsdGeom.Tokens.z)
-
-        root_prim = stage.GetPseudoRoot()
-
-        objects_len = len(depsgraph.objects)
-        for i, obj in enumerate(object.depsgraph_objects(depsgraph,
-                                                         space_data=space_data,
-                                                         use_scene_lights=use_scene_lights)):
-            if test_break and test_break():
-                return None
-
-            if sync_callback:
-                sync_callback(f"Syncing object {i}/{objects_len}: {obj.name}")
-
-            try:
-                object.sync(root_prim, obj, **kwargs)
-            except Exception as e:
-                log.error(e, 'EXCEPTION:', traceback.format_exc())
-
-        world.sync(root_prim, depsgraph.scene.world)
-
 
 from . import final_engine, viewport_engine, preview_engine
 
@@ -95,7 +68,10 @@ class HdUSDEngine(bpy.types.RenderEngine):
                 engine_cls = preview_engine.PreviewEngine
 
             else:
-                engine_cls = final_engine.FinalEngine
+                if depsgraph.scene.hdusd.final.data_source:
+                    engine_cls = final_engine.FinalEngineNodetree
+                else:
+                    engine_cls = final_engine.FinalEngineScene
 
             self.engine = engine_cls(self)
             self.engine.sync(depsgraph)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -273,7 +273,7 @@ class FinalEngineScene(FinalEngine):
         for i, obj_data in enumerate(object.ObjectData.depsgraph_objects(
                                      depsgraph, use_scene_cameras=False)):
             if self.render_engine.test_break():
-                return None
+                return
 
             self.notify_status(0.0, f"Syncing object {i}/{objects_len}: {obj_data.object.name}")
 
@@ -281,7 +281,8 @@ class FinalEngineScene(FinalEngine):
 
         world.sync(root_prim, depsgraph.scene.world)
 
-        object.sync(stage.GetPseudoRoot(), object.ObjectData.from_object(depsgraph.scene.camera))
+        object.sync(stage.GetPseudoRoot(), object.ObjectData.from_object(depsgraph.scene.camera),
+                    scene=depsgraph.scene)
 
 
 class FinalEngineNodetree(FinalEngine):

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -365,7 +365,8 @@ class ViewportEngineScene(ViewportEngine):
 
         root_prim = stage.GetPseudoRoot()
 
-        for obj_data in object.ObjectData.depsgraph_objects(depsgraph, space_data=self.space_data):
+        for obj_data in object.ObjectData.depsgraph_objects(depsgraph,
+                space_data=self.space_data, use_scene_cameras=False):
             object.sync(root_prim, obj_data)
 
         world.sync(root_prim, depsgraph.scene.world)
@@ -376,7 +377,7 @@ class ViewportEngineScene(ViewportEngine):
         root_prim = self.stage.GetPseudoRoot()
 
         for update in depsgraph.updates:
-            log("sync_update", update.id)
+            log("sync_update", update.id, type(update.id))
 
             if isinstance(update.id, (bpy.types.Collection, bpy.types.Scene)):
                 self._sync_objects_collection(depsgraph)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -398,7 +398,7 @@ class ViewportEngineScene(ViewportEngine):
                 if obj.type == 'LIGHT' and not self.shading_data.use_scene_lights:
                     continue
 
-                object.sync_update(root_prim, obj,
+                object.sync_update(root_prim, object.ObjectData.from_object(obj),
                                    update.is_updated_geometry,
                                    update.is_updated_transform,
                                    is_gl_delegate=self.is_gl_delegate)
@@ -414,7 +414,9 @@ class ViewportEngineScene(ViewportEngine):
 
         def dg_objects():
             yield from object.ObjectData.depsgraph_objects(depsgraph,
-                space_data=self.space_data, use_scene_lights=self.shading_data.use_scene_lights)
+                space_data=self.space_data,
+                use_scene_lights=self.shading_data.use_scene_lights,
+                use_scene_cameras=False)
 
         depsgraph_keys = set(obj_data.sdf_name for obj_data in dg_objects())
         usd_object_keys = set(prim.GetName() for prim in root_prim.GetAllChildren()
@@ -425,7 +427,7 @@ class ViewportEngineScene(ViewportEngine):
         if keys_to_remove:
             log("Object keys to remove", keys_to_remove)
             for key in keys_to_remove:
-                self.stage.RemovePrim(f"{root_prim.GetPath()}/{key}")
+                self.stage.RemovePrim(root_prim.GetPath().AppendChild(key))
 
         if keys_to_add:
             log("Object keys to add", keys_to_add)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -397,8 +397,9 @@ class ViewportEngineScene(ViewportEngine):
         root_prim = self.stage.GetPseudoRoot()
 
         def dg_objects():
-            yield from depsgraph_objects(depsgraph, self.space_data,
-                                         self.shading_data.use_scene_lights)
+            yield from depsgraph_objects(depsgraph,
+                                         space_data=self.space_data,
+                                         use_scene_lights=self.shading_data.use_scene_lights)
 
         depsgraph_keys = set(object.sdf_name(obj) for obj in dg_objects())
         usd_object_keys = set(prim.GetName() for prim in root_prim.GetAllChildren()

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -23,7 +23,7 @@ import weakref
 from pxr import Usd, UsdGeom
 from pxr import UsdImagingGL
 
-from .engine import Engine, depsgraph_objects
+from .engine import Engine
 from ..export import camera, material, object, world
 from .. import utils
 from ..utils import usd as usd_utils
@@ -397,9 +397,9 @@ class ViewportEngineScene(ViewportEngine):
         root_prim = self.stage.GetPseudoRoot()
 
         def dg_objects():
-            yield from depsgraph_objects(depsgraph,
-                                         space_data=self.space_data,
-                                         use_scene_lights=self.shading_data.use_scene_lights)
+            yield from object.depsgraph_objects(depsgraph,
+                                                space_data=self.space_data,
+                                                use_scene_lights=self.shading_data.use_scene_lights)
 
         depsgraph_keys = set(object.sdf_name(obj) for obj in dg_objects())
         usd_object_keys = set(prim.GetName() for prim in root_prim.GetAllChildren()

--- a/src/hdusd/export/camera.py
+++ b/src/hdusd/export/camera.py
@@ -290,8 +290,7 @@ class CameraData:
 
 def sync(obj_prim, obj: bpy.types.Object, **kwargs):
     """Creates Usd camera from obj.data: bpy.types.Camera"""
-
-    scene = bpy.context.scene
+    scene = kwargs['scene']
     screen_ratio = scene.render.resolution_x / scene.render.resolution_y
 
     camera = obj.data
@@ -302,6 +301,7 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
 
     settings = CameraData.init_from_camera(camera, obj.matrix_world, screen_ratio)
     settings.export(usd_camera)
+
 
 def sync_update(obj_prim, obj: bpy.types.Object, **kwargs):
     """ Update existing camera from obj.data: bpy.types.Camera or create a new light """

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -24,7 +24,7 @@ from ..utils import logging
 log = logging.Log(tag='export.instance')
 
 
-SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA')
+SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA', 'EMPTY')
 
 
 @dataclass(init=False)
@@ -32,6 +32,7 @@ class ObjectData:
     object: bpy.types.Object
     instance_id: int
     transform: mathutils.Matrix
+    parent: bpy.types.Object
 
     @staticmethod
     def from_object(obj):
@@ -39,6 +40,7 @@ class ObjectData:
         data.object = obj
         data.instance_id = 0
         data.transform = obj.matrix_world.transposed()
+        data.parent = obj.parent
         return data
 
     @staticmethod
@@ -47,6 +49,7 @@ class ObjectData:
         data.object = instance.object
         data.instance_id = abs(instance.random_id)
         data.transform = instance.matrix_world.transposed()
+        data.parent = instance.parent
         return data
 
     @property
@@ -110,6 +113,9 @@ def sync(objects_prim, obj_data: ObjectData, **kwargs):
 
     elif obj.type == 'CAMERA':
         camera.sync(obj_prim, obj, **kwargs)
+
+    elif obj.type == 'EMPTY':
+        pass
 
     else:
         to_mesh.sync(obj_prim, obj, **kwargs)

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -18,7 +18,6 @@ from pxr import UsdGeom
 
 from .base_node import USDNode
 from ...export import object, material, world
-from ...utils import depsgraph_objects
 
 
 #
@@ -183,7 +182,7 @@ class BlenderDataNode(USDNode):
         root_prim = stage.GetPseudoRoot()
 
         if self.data == 'SCENE':
-            for obj in depsgraph_objects(depsgraph):
+            for obj in object.depsgraph_objects(depsgraph):
                 object.sync(root_prim, obj)
 
             world.sync(root_prim, depsgraph.scene.world)
@@ -268,7 +267,7 @@ class BlenderDataNode(USDNode):
                 current_keys = set(prim.GetName() for prim in root_prim.GetAllChildren())
                 required_keys = set()
                 depsgraph_keys = set(object.sdf_name(obj)
-                                     for obj in depsgraph_objects(depsgraph))
+                                     for obj in object.depsgraph_objects(depsgraph))
 
                 if self.data == 'SCENE':
                     required_keys = depsgraph_keys
@@ -300,7 +299,7 @@ class BlenderDataNode(USDNode):
                     is_updated = True
 
                 if keys_to_add:
-                    for obj in depsgraph_objects(depsgraph):
+                    for obj in object.depsgraph_objects(depsgraph):
                         obj_key = object.sdf_name(obj)
                         if obj_key not in keys_to_add:
                             continue

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -182,8 +182,8 @@ class BlenderDataNode(USDNode):
         root_prim = stage.GetPseudoRoot()
 
         if self.data == 'SCENE':
-            for obj in object.depsgraph_objects(depsgraph):
-                object.sync(root_prim, obj)
+            for obj_data in object.ObjectData.depsgraph_objects(depsgraph):
+                object.sync(root_prim, obj_data)
 
             world.sync(root_prim, depsgraph.scene.world)
 
@@ -195,7 +195,8 @@ class BlenderDataNode(USDNode):
                 if obj_col.hdusd.is_usd:
                     continue
 
-                object.sync(root_prim, obj_col.evaluated_get(depsgraph))
+                object.sync(root_prim, object.ObjectData.from_object(
+                    obj_col.evaluated_get(depsgraph)))
 
         elif self.data == 'OBJECT':
             if not self.object or self.object.hdusd.is_usd:
@@ -266,8 +267,8 @@ class BlenderDataNode(USDNode):
 
                 current_keys = set(prim.GetName() for prim in root_prim.GetAllChildren())
                 required_keys = set()
-                depsgraph_keys = set(object.sdf_name(obj)
-                                     for obj in object.depsgraph_objects(depsgraph))
+                depsgraph_keys = set(obj_data.sdf_name for obj_data in
+                                     object.ObjectData.depsgraph_objects(depsgraph))
 
                 if self.data == 'SCENE':
                     required_keys = depsgraph_keys
@@ -299,12 +300,11 @@ class BlenderDataNode(USDNode):
                     is_updated = True
 
                 if keys_to_add:
-                    for obj in object.depsgraph_objects(depsgraph):
-                        obj_key = object.sdf_name(obj)
-                        if obj_key not in keys_to_add:
+                    for obj_data in object.ObjectData.depsgraph_objects(depsgraph):
+                        if obj_data.sdf_name not in keys_to_add:
                             continue
 
-                        object.sync(root_prim, obj)
+                        object.sync(root_prim, obj_data)
 
                     is_updated = True
 

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -18,7 +18,7 @@ from pxr import UsdGeom
 
 from .base_node import USDNode
 from ...export import object, material, world
-from ...export.object import ObjectData
+from ...export.object import ObjectData, SUPPORTED_TYPES
 
 
 #
@@ -98,7 +98,7 @@ class HDUSD_USD_NODETREE_MT_blender_data_object(bpy.types.Menu):
         objects = bpy.data.objects
 
         for obj in objects:
-            if obj.hdusd.is_usd:
+            if obj.hdusd.is_usd or obj.type not in SUPPORTED_TYPES:
                 continue
 
             row = layout.row()
@@ -204,7 +204,8 @@ class BlenderDataNode(USDNode):
             if not self.object or self.object.hdusd.is_usd:
                 return
 
-            object.sync(root_prim, self.object.evaluated_get(depsgraph), **kwargs)
+            object.sync(root_prim, ObjectData.from_object(self.object.evaluated_get(depsgraph)),
+                        **kwargs)
 
         return stage
 

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -108,35 +108,6 @@ def time_str(val):
     return f"{math.floor(val / 60):02}:{math.floor(val % 60):02}.{math.floor((val % 1) * 100):02}"
 
 
-def depsgraph_objects(depsgraph, *, space_data=None, use_scene_lights=True):
-    SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA')
-
-    for obj in depsgraph.objects:
-        if obj.type not in SUPPORTED_TYPES:
-            continue
-
-        if obj.type == 'LIGHT' and not use_scene_lights:
-            continue
-
-        if space_data and not obj.visible_in_viewport_get(space_data):
-            continue
-
-        yield obj
-
-    for instance in depsgraph.object_instances:
-        obj = instance.object
-        if obj.type not in SUPPORTED_TYPES:
-            continue
-
-        if obj.type == 'LIGHT' and not use_scene_lights:
-            continue
-
-        # if space_data and not instance.visible_in_viewport_get(space_data):
-        #     continue
-
-        yield instance
-
-
 def title_str(str):
     s = str.replace('_', ' ')
     return s[:1].upper() + s[1:]

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -108,10 +108,11 @@ def time_str(val):
     return f"{math.floor(val / 60):02}:{math.floor(val % 60):02}.{math.floor((val % 1) * 100):02}"
 
 
-def depsgraph_objects(depsgraph, space_data=None, use_scene_lights=True):
+def depsgraph_objects(depsgraph, *, space_data=None, use_scene_lights=True):
+    SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA')
+
     for obj in depsgraph.objects:
-        if obj.type not in ('MESH', 'LIGHT', 'CURVE', 'FONT',
-                            'SURFACE', 'META', 'VOLUME', 'CAMERA'):
+        if obj.type not in SUPPORTED_TYPES:
             continue
 
         if obj.type == 'LIGHT' and not use_scene_lights:
@@ -121,6 +122,19 @@ def depsgraph_objects(depsgraph, space_data=None, use_scene_lights=True):
             continue
 
         yield obj
+
+    for instance in depsgraph.object_instances:
+        obj = instance.object
+        if obj.type not in SUPPORTED_TYPES:
+            continue
+
+        if obj.type == 'LIGHT' and not use_scene_lights:
+            continue
+
+        # if space_data and not instance.visible_in_viewport_get(space_data):
+        #     continue
+
+        yield instance
 
 
 def title_str(str):


### PR DESCRIPTION
### PURPOSE
Object instances export isn't implemented yet. 

### EFFECT OF CHANGE
Implemented exporting of object instances for Final and Viewport renderes and for Blender Data USD Node.
Fixed setting correct resolution in camera export in some cases.

### TECHNICAL STEPS
1. Created ObjectData dataclass in export/object.py. 
    - Made it to work with scene object and scene instance.
    - Moved depsgraph_objects() from utils/\_\_init__.py to ObjectData as more related
    - adjusted object.sync(0 and object.sync_update() functions
2. Adjusted FinalEngine, ViewportEngine, BlendDataNode to work with ObjectData.
3. Fixed camera export by providing more correct scene resolution.
4. Refactoring, which will be helpful for future development:
    - Splitted FinalEngine to FinalEngineScene and FinalEngineNodetree. .
    - Reimplemented PreviewEngine, made it independent from FinalEngine and simplified its code. Fixed bug with samples number.
