### PR TITLE
Fix error in RPRBLND-1833

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -153,7 +153,7 @@ class FinalEngine(Engine):
         if scene.hdusd.final.nodetree_camera != '' and scene.hdusd.final.data_source:
             usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, scene.hdusd.final.nodetree_camera)
         else:
-            usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, Tf.MakeValidIdentifier(scene.camera.name))
+            usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, Tf.MakeValidIdentifier(scene.camera.data.name))
        
         gf_camera = usd_camera.GetCamera()
         renderer.SetCameraState(gf_camera.frustum.ComputeViewMatrix(),


### PR DESCRIPTION
### PURPOSE
get RuntimeError: Accessed schema on invalid prim after fix the collections render error. Found the error raises when a camera object and a camera data have different name.

### EFFECT OF CHANGE
Render as expected without an error.

### TECHNICAL STEPS
Fixes when a camera object and a camera data names are different.
