### PR TITLE
RPRBLND-1881: 'MeshData' object has no attribute 'uv_indices'

### DIFF
--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -69,6 +69,7 @@ class MeshData:
                                                 (len_loop_triangles * 3, 3))
 
         data.uv_layers = {}
+        data.uv_indices = None
         for uv_layer in mesh.uv_layers:
             uvs = get_data_from_collection(uv_layer.data, 'uv', (len(uv_layer.data), 2))
             uv_indices = get_data_from_collection(mesh.loop_triangles, 'loops',


### PR DESCRIPTION
### PURPOSE
Fix mesh sync, get expexted render result

### EFFECT OF CHANGE
Render as expected without an error

### TECHNICAL STEPS
Added attribute data.uv_indices, set to None

### NOTES FOR REVIEWERS
In final render Camera object sync still goes after scene objects sync so in future maybe more camera errors but it will be easier to catch error of wrong object sync