### PR TITLE
RPRBLND-1820: add MaterialX channels animation support.

### DIFF
--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -18,6 +18,7 @@ import bpy
 import MaterialX as mx
 
 from ..utils.mx import set_param_value
+from ..mx_nodes.nodes import get_mx_node_cls 
 from . import log
 
 
@@ -37,6 +38,7 @@ class NodeItem:
         self.id = id
         self.doc = doc
         self.data = data
+        self.nodedef = get_mx_node_cls(data.getCategory(), data.getType()).get_nodedef(self.type) if isinstance(data, mx.Node) else None
 
     def node_item(self, value):
         if isinstance(value, NodeItem):

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -18,7 +18,6 @@ import bpy
 import MaterialX as mx
 
 from ..utils.mx import set_param_value
-from ..mx_nodes.nodes import get_node_def_cls
 from . import log
 
 
@@ -38,8 +37,6 @@ class NodeItem:
         self.id = id
         self.doc = doc
         self.data = data
-        self.nodedef = get_node_def_cls(data.getCategory(), data.getType()).nodedef() \
-            if isinstance(data, mx.Node) else None
 
     def node_item(self, value):
         if isinstance(value, NodeItem):

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -105,7 +105,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                     input_name = mx_input.getName()
                     val = mx_input.getValue()
                     if val is not None:
-                        node.set_input_default(
+                        node.set_input_value(
                             input_name,
                             mx_utils.parse_value(node, val, mx_input.getType(), file_prefix))
                         continue

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -24,23 +24,19 @@ from . import base_node, categories
 gen_modules = [importlib.import_module(f"hdusd.mx_nodes.nodes.{f.name[:-len(f.suffix)]}")
                for f in Path(__file__).parent.glob("gen_*.py")]
 
-mx_nodedef_classes = []
 mx_node_classes = []
 for m in gen_modules:
-    mx_nodedef_classes.extend(m.mx_nodedef_classes)
     mx_node_classes.extend(m.mx_node_classes)
 
 register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
     base_node.MxNodeInputSocket,
     base_node.MxNodeOutputSocket,
 ])
-register_nodedefs, unregister_nodedefs = bpy.utils.register_classes_factory(mx_nodedef_classes)
 register_nodes, unregister_nodes = bpy.utils.register_classes_factory(mx_node_classes)
 
 
 def register():
     register_sockets()
-    register_nodedefs()
     register_nodes()
 
     nodeitems_utils.register_node_categories("'HdUSD_MX_NODES", categories.get_node_categories())
@@ -50,22 +46,7 @@ def unregister():
     nodeitems_utils.unregister_node_categories("'HdUSD_MX_NODES")
 
     unregister_nodes()
-    unregister_nodedefs()
     unregister_sockets()
-
-
-def get_node_def_cls(node_name, nd_type):
-    nd_name = f"ND_{node_name}_{nd_type}"
-    node_def_cls = next((cls for cls in mx_nodedef_classes if cls.__name__.endswith(nd_name)), None)
-    if node_def_cls:
-        return node_def_cls
-
-    node_def_cls = next((cls for cls in mx_nodedef_classes if cls._node_name == node_name), None)
-
-    if node_def_cls:
-        return node_def_cls
-
-    raise KeyError("Unable to find MaterialX nodedef class", node_name, nd_type)
 
 
 def get_mx_node_cls(node_name, nd_type):

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -89,7 +89,6 @@ class MxNode(bpy.types.ShaderNode):
 
     @classmethod
     def nodedef(cls, file_path):
-
         doc = mx.createDocument()
         mx.readFromXmlFile(doc, str(LIBS_DIR / file_path))
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -143,6 +143,10 @@ class MxNode(bpy.types.ShaderNode):
         return 'nd_' + name
 
     @staticmethod
+    def _param_prop_name(data_type, name):
+        return 'nd_' + data_type + '_p_' + name
+
+    @staticmethod
     def _node_prop_name(data_type, name, is_output):
         in_out = "out" if is_output else "in"
         return 'nd_' + data_type + "_" + in_out + "_" + name
@@ -199,11 +203,11 @@ class MxNode(bpy.types.ShaderNode):
                 col.label(text=mx_param.getAttribute('uiname') if mx_param.hasAttribute('uiname')
                           else title_str(name))
                 col = split.column()
-                col.template_ID(self.prop, MxNodeDef._param_prop_name(name),
+                col.template_ID(self, MxNode._param_prop_name(self.data_type, name),
                                 open="image.open", new="image.new")
 
             else:
-                layout.prop(self.prop, MxNodeDef._param_prop_name(name))
+                layout.prop(self, MxNode._param_prop_name(self.data_type, name))
 
     # COMPUTE FUNCTION
     def compute(self, out_key, **kwargs):
@@ -286,10 +290,10 @@ class MxNode(bpy.types.ShaderNode):
         return self.get_input_default(in_key)
 
     def get_input_default(self, in_key: [str, int]):
-        return self.prop.get_input(self.inputs[in_key].identifier)
+        return getattr(self, self._node_prop_name(self.data_type, self.inputs[in_key].identifier, self.inputs[in_key].is_output))
 
     def get_param_value(self, name):
-        return self.prop.get_param(name)
+        return getattr(self, self._param_prop_name(self.data_type, name))
 
     def get_input_param_value(self, name):
         return self.prop.get_input(name)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -273,7 +273,7 @@ class MxNode(bpy.types.ShaderNode):
     def get_nodedef_output(self, out_key: [str, int]):
         return self.get_nodedef(self.data_type).getOutput(self.outputs[out_key].identifier)
 
-    def set_input_default(self, in_key, value):
+    def set_input_value(self, in_key, value):
         setattr(self, self._node_prop_name(self.data_type, self.inputs[in_key].identifier, False), value)
 
     def set_param_value(self, name, value):

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -48,7 +48,7 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
             else:
                 layout.label(text=f"{uiname}: {uitype}")
         else:
-            layout.prop(node.prop, MxNodeDef._input_prop_name(self.name), text=uiname)
+            layout.prop(node, node._node_prop_name(node.data_type, self.name, self.is_output), text=uiname)
 
     def draw_color(self, context, node):
         return self.get_color(node.prop.nodedef().getInput(self.name).getType())
@@ -141,6 +141,11 @@ class MxNode(bpy.types.ShaderNode):
     @staticmethod
     def _nodedef_prop_name(name):
         return 'nd_' + name
+
+    @staticmethod
+    def _node_prop_name(data_type, name, is_output):
+        in_out = "out" if is_output else "in"
+        return 'nd_' + data_type + "_" + in_out + "_" + name
 
     def init(self, context):
         def init_():

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -110,10 +110,6 @@ class MxNode(bpy.types.ShaderNode):
         return 'f_' + code_str(name.lower())
 
     @staticmethod
-    def _nodedef_prop_name(name):
-        return 'nd_' + name
-
-    @staticmethod
     def _param_prop_name(data_type, name):
         return 'nd_' + data_type + '_p_' + name
 
@@ -165,7 +161,7 @@ class MxNode(bpy.types.ShaderNode):
             if f and not getattr(self, self._folder_prop_name(f)):
                 continue
 
-            layout.prop(self, MxNode._node_prop_name(mx_input.getName()))
+            layout.prop(self, MxNode._node_prop_name(self.data_type, mx_input.getName(), False))
 
         for mx_param in nodedef.getParameters():
             f = mx_param.getAttribute('uifolder')
@@ -270,9 +266,6 @@ class MxNode(bpy.types.ShaderNode):
 
     def get_param_value(self, name):
         return getattr(self, self._param_prop_name(self.data_type, name))
-
-    def get_input_param_value(self, name):
-        return getattr(self, self._node_prop_name(self.data_type, name, False))
 
     def get_nodedef_input(self, in_key: [str, int]):
         return self.get_nodedef(self.data_type).getInput(self.inputs[in_key].identifier)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -88,7 +88,7 @@ class MxNode(bpy.types.ShaderNode):
     category = ""
 
     @classmethod
-    def nodedef(cls, file_path):
+    def load_nodedefs(cls, file_path):
         doc = mx.createDocument()
         mx.readFromXmlFile(doc, str(LIBS_DIR / file_path))
 
@@ -101,7 +101,7 @@ class MxNode(bpy.types.ShaderNode):
     def get_nodedef(cls, data_type):
         nodedef_name = cls._data_types[data_type]['nodedef_name']
         if cls._data_types[data_type][nodedef_name] is None:
-            cls.nodedef(cls._file_path)
+            cls.load_nodedefs(cls._file_path)
 
         return cls._data_types[data_type][nodedef_name]
 

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -211,6 +211,8 @@ class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
     _nodedef_name = '{nodedef.getName()}'
     _node_name = '{nodedef.getNodeString()}'""")
 
+    return '\n'.join(code_strings)
+
     nodegroup = nodedef.getAttribute('nodegroup')
 
     for i, param in enumerate(nodedef.getParameters()):

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -256,7 +256,6 @@ class {class_name}(MxNode):
             index_default = i
 
     code_strings += [
-        "",
         f'    data_type: EnumProperty(name="Type", description="Input Data Type", '
         f"items={data_type_items}, default='{data_type_items[index_default][0]}')",
     ]
@@ -269,30 +268,20 @@ class {class_name}(MxNode):
             f'    {folder_prop_name(f)}: BoolProperty(name="{f}", '
             f'description="Enable {f}", default={i == 0}, update=MxNode.ui_folders_update)')
 
-    if class_name == "MxNode_STD_image":
-        a = 1
-
     for j, nd in enumerate(nodedefs):
         nodegroup = nd.getAttribute('nodegroup')
         nd_type = nodedef_data_type(nd)
-        for i, param in enumerate(nd.getParameters()):
-            if i == 0:
-                code_strings.append("")
+        code_strings.append("")
 
+        for i, param in enumerate(nd.getParameters()):
             prop_code = generate_property_code(param, nodegroup)
             code_strings.append(f"    nd_{nd_type}_{param_prop_name(param.getName())}: {prop_code}")
 
         for i, input in enumerate(nodedef.getInputs()):
-            if i == 0:
-                code_strings.append("")
-
             prop_code = generate_property_code(input, nodegroup)
             code_strings.append(f"    nd_{nd_type}_{input_prop_name(input.getName())}: {prop_code}")
 
         for i, output in enumerate(nodedef.getOutputs()):
-            if i == 0:
-                code_strings.append("")
-
             prop_code = generate_property_code(output, nodegroup)
             code_strings.append(f"    nd_{nd_type}_{output_prop_name(output.getName())}: {prop_code}")
 

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -173,6 +173,13 @@ def nodedef_data_type(nodedef):
 
     return "multitypes"
 
+def generate_data_type(nodedef):
+    outputs = nodedef.getOutputs()
+    if len(outputs) != 1:
+        return f"{{'multitypes': {{'{nodedef.getName()}': None}}}}"
+
+    return f"{{'{nodedef.getOutputs()[0].getType()}': {{'{nodedef.getName()}': None}}}}"
+
 
 def param_prop_name(name):
     return 'p_' + name
@@ -207,7 +214,6 @@ def generate_mx_nodedef_class_code(nodedef: mx.NodeDef, prefix: str):
     code_strings.append(
 f"""
 class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
-    _file_path = FILE_PATH
     _nodedef_name = '{nodedef.getName()}'
     _node_name = '{nodedef.getNodeString()}'""")
 
@@ -247,16 +253,21 @@ def generate_mx_node_class_code(nodedefs, prefix, category):
 
     class_name = get_mx_node_class_name(nodedef, prefix)
     code_strings = []
+
+    _data_types = {}
+    for nd in nodedefs:
+        _data_types.update(eval(generate_data_type(nd)))
+
     code_strings.append(
 f"""
 class {class_name}(MxNode):
+    _file_path = FILE_PATH
+    
     bl_label = '{get_attr(nodedef, 'uiname', title_str(nodedef.getNodeString()))}'
     bl_idname = 'hdusd.{class_name}'
     bl_description = "{get_attr(nodedef, 'doc')}"
-    
+    _data_types = {_data_types}
     category = '{category}'
-    
-    _data_types = {tuple(nodedef_data_type(nd) for nd in nodedefs)}
 """)
 
     ui_folders = []

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -176,7 +176,7 @@ def nodedef_data_type(nodedef):
 def generate_data_type(nodedef):
     outputs = nodedef.getOutputs()
     if len(outputs) != 1:
-        return f"{{'multitypes': {{'{nodedef.getName()}': None}}}}"
+        return f"{{'multitypes': {{'{nodedef.getName()}': None, 'nodedef_name': '{nodedef.getName()}'}}}}"
 
     return f"{{'{nodedef.getOutputs()[0].getType()}': {{'{nodedef.getName()}': None, 'nodedef_name': '{nodedef.getName()}'}}}}"
 

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -295,6 +295,33 @@ class {class_name}(MxNode):
             f'    {folder_prop_name(f)}: BoolProperty(name="{f}", '
             f'description="Enable {f}", default={i == 0}, update=MxNode.ui_folders_update)')
 
+    if class_name == "MxNode_STD_image":
+        a = 1
+
+    for j, nd in enumerate(nodedefs):
+        nodegroup = nd.getAttribute('nodegroup')
+        nd_type = nodedef_data_type(nd)
+        for i, param in enumerate(nd.getParameters()):
+            if i == 0:
+                code_strings.append("")
+
+            prop_code = generate_property_code(param, nodegroup)
+            code_strings.append(f"    nd_{nd_type}_{param_prop_name(param.getName())}: {prop_code}")
+
+        for i, input in enumerate(nodedef.getInputs()):
+            if i == 0:
+                code_strings.append("")
+
+            prop_code = generate_property_code(input, nodegroup)
+            code_strings.append(f"    nd_{nd_type}_{input_prop_name(input.getName())}: {prop_code}")
+
+        for i, output in enumerate(nodedef.getOutputs()):
+            if i == 0:
+                code_strings.append("")
+
+            prop_code = generate_property_code(output, nodegroup)
+            code_strings.append(f"    nd_{nd_type}_{output_prop_name(output.getName())}: {prop_code}")
+
     code_strings.append("")
     return '\n'.join(code_strings)
 

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -209,43 +209,6 @@ def get_mx_node_class_name(nodedef, prefix):
     return f"MxNode_{prefix}_{nodedef.getNodeString()}"
 
 
-def generate_mx_nodedef_class_code(nodedef: mx.NodeDef, prefix: str):
-    code_strings = []
-    code_strings.append(
-f"""
-class {get_mx_nodedef_class_name(nodedef, prefix)}(MxNodeDef):
-    _nodedef_name = '{nodedef.getName()}'
-    _node_name = '{nodedef.getNodeString()}'""")
-
-    return '\n'.join(code_strings)
-
-    nodegroup = nodedef.getAttribute('nodegroup')
-
-    for i, param in enumerate(nodedef.getParameters()):
-        if i == 0:
-            code_strings.append("")
-
-        prop_code = generate_property_code(param, nodegroup)
-        code_strings.append(f"    {param_prop_name(param.getName())}: {prop_code}")
-
-    for i, input in enumerate(nodedef.getInputs()):
-        if i == 0:
-            code_strings.append("")
-
-        prop_code = generate_property_code(input, nodegroup)
-        code_strings.append(f"    {input_prop_name(input.getName())}: {prop_code}")
-
-    for i, output in enumerate(nodedef.getOutputs()):
-        if i == 0:
-            code_strings.append("")
-
-        prop_code = generate_property_code(output, nodegroup)
-        code_strings.append(f"    {output_prop_name(output.getName())}: {prop_code}")
-
-    code_strings.append("")
-    return '\n'.join(code_strings)
-
-
 def generate_mx_node_class_code(nodedefs, prefix, category):
     nodedef = nodedefs[0]
     if not category:


### PR DESCRIPTION
### PURPOSE
Need to add support for material X channels animation, like in default blender materials and RPR plugin.

Our custom socket doesn't work with standard blender animation functionality.

### EFFECT OF CHANGE
Enable Keyframes support for nodes.

### TECHNICAL STEPS
- Moved everything from MxNodeDef to MxNode
- Refactoring to work with MxNode instead of MxNodeDef
- Modified generator for mx classes

### NOTES FOR REVIEWERS
You need to regenerate mx-classes to get new MxNodes
Some nodes doesn't work (e.g separate) - the reason is more global.