### PR TITLE
RPRBLND-1870: GL delegate doesn't work properly with world light

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -278,7 +278,8 @@ class FinalEngineScene(FinalEngine):
 
             object.sync(root_prim, obj_data)
 
-        world.sync(root_prim, depsgraph.scene.world)
+        if depsgraph.scene.world is not None:
+            world.sync(root_prim, depsgraph.scene.world)
 
         object.sync(stage.GetPseudoRoot(), object.ObjectData.from_object(depsgraph.scene.camera),
                     scene=depsgraph.scene)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -72,7 +72,7 @@ class FinalEngine(Engine):
 
         bgl.glEnable(bgl.GL_DEPTH_TEST)
         bgl.glViewport(0, 0, self.width, self.height)
-        bgl.glClearColor(*CLEAR_COLOR)
+
         bgl.glClearDepth(CLEAR_DEPTH)
         bgl.glClear(bgl.GL_COLOR_BUFFER_BIT | bgl.GL_DEPTH_BUFFER_BIT)
 
@@ -80,7 +80,17 @@ class FinalEngine(Engine):
         params = UsdImagingGL.RenderParams()
         params.renderResolution = (self.width, self.height)
         params.frame = Usd.TimeCode.Default()
-        params.clearColor = CLEAR_COLOR
+
+
+        world_color = world.WorldData.init_from_world(scene.world)
+        color_final = (*(color * world_color.intensity for color in world_color.color),)
+
+        if world_color.image is None:
+            bgl.glClearColor(*color_final, world_color.transparency)
+            params.clearColor = (*color_final, world_color.transparency)
+        else:
+            bgl.glClearColor(*CLEAR_COLOR)
+            params.clearColor = CLEAR_COLOR
 
         try:
             renderer.Render(root, params)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -218,7 +218,13 @@ class ViewportEngine(Engine):
 
         self.render_params = UsdImagingGL.RenderParams()
         self.render_params.frame = Usd.TimeCode.Default()
-        self.render_params.clearColor = (0, 0, 0, 0)
+
+        world_color = world.WorldData.init_from_world(context.scene.world)
+        
+        if world_color.image is None:
+            self.render_params.clearColor = (*(color * world_color.intensity for color in world_color.color), world_color.transparency)
+        else:
+            self.render_params.clearColor = (0, 0, 0, 0)
 
         self.renderer = UsdImagingGL.Engine()
 
@@ -287,8 +293,15 @@ class ViewportEngine(Engine):
         else:
             bgl.glDisable(bgl.GL_DEPTH_TEST)
 
+        world_color = world.WorldData.init_from_world(context.scene.world)
+
         bgl.glViewport(*view_settings.border[0], *view_settings.border[1])
-        bgl.glClearColor(0.0, 0.0, 0.0, 0.0)
+
+        if world_color.image is None:
+            bgl.glClearColor(*(color * world_color.intensity for color in world_color.color), world_color.transparency)
+        else:
+            bgl.glClearColor(0.0, 0.0, 0.0, 0.0)
+
         bgl.glClearDepth(1.0)
         bgl.glClear(bgl.GL_COLOR_BUFFER_BIT | bgl.GL_DEPTH_BUFFER_BIT)
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -309,8 +309,6 @@ class ViewportEngine(Engine):
         else:
             bgl.glDisable(bgl.GL_DEPTH_TEST)
 
-        world_color = world.WorldData.init_from_world(context.scene.world)
-
         bgl.glViewport(*view_settings.border[0], *view_settings.border[1])
         bgl.glClearColor(0.0, 0.0, 0.0, 0.0)
         bgl.glClearDepth(1.0)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -228,11 +228,9 @@ class ViewportEngine(Engine):
         else:
             world_data = world.WorldData.init_from_world(scene.world)
 
-        clear_color = [color * world_data.intensity for color in world_data.color]
-        clear_color.append(world_data.transparency)
-        self.render_params.clearColor = clear_color
+        self.render_params.clearColor = world_data.clear_color
 
-        usd_utils.set_variant_delegate(self.cached_stage(), self.is_gl_delegate)
+        usd_utils.set_variant_delegate(self.stage, self.is_gl_delegate)
 
         self.is_synced = True
         log('Finish sync')
@@ -385,6 +383,7 @@ class ViewportEngineScene(ViewportEngine):
             object.sync(root_prim, obj_data)
 
         world.sync(root_prim, depsgraph.scene.world)
+        self.render_params.clearColor = world.get_clear_color(root_prim, depsgraph.scene.world)
 
     def _sync_update(self, context, depsgraph):
         super()._sync_update(context, depsgraph)
@@ -415,6 +414,7 @@ class ViewportEngineScene(ViewportEngine):
             if isinstance(update.id, bpy.types.World):
                 wld = update.id
                 world.sync_update(root_prim, wld)
+                self.render_params.clearColor = world.get_clear_color(root_prim, wld)
                 continue
 
     def _sync_objects_collection(self, depsgraph):

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -132,6 +132,7 @@ class WorldData:
         if light_prim:
             data.color = light_prim.GetAttribute('inputs:color').Get()
             data.intensity = light_prim.GetAttribute('inputs:intensity').Get()
+            data.transparency = light_prim.GetAttribute('inputs:transparency').Get()
 
         return data
 
@@ -168,7 +169,11 @@ def sync_update(root_prim, world: bpy.types.World):
 
     # removing prev settings
     usd_light.CreateColorAttr().Clear()
-    usd_light.CreateTextureFileAttr().Clear()
+    usd_light.CreateIntensityAttr().Clear()
+
+    if usd_light.GetTextureFileAttr().Get() is not None:
+        usd_light.CreateTextureFileAttr().Clear()
+
     usd_light.ClearXformOpOrder()
 
     sync(root_prim, world)

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -36,6 +36,7 @@ class WorldData:
     image: str = None
     intensity: float = 1.0
     rotation: tuple = (0.0, 0.0, 0.0)
+    transparency: float = 1.0
 
     @staticmethod
     def init_from_world(world: bpy.types.World):
@@ -44,6 +45,7 @@ class WorldData:
 
         if not world.use_nodes:
             data.color = tuple(world.color)
+            data.transparency = world.color[3]
             return data
 
         output_node = next((node for node in world.node_tree.nodes
@@ -63,10 +65,12 @@ class WorldData:
 
         if isinstance(node_data, float):
             data.color = (node_data, node_data, node_data)
+            data.transparency = node_data
             return data
 
         if isinstance(node_data, tuple):
             data.color = node_data[:3]
+            data.transparency = node_data[3]
             return data
 
         # node_data is dict here
@@ -85,9 +89,11 @@ class WorldData:
 
         elif isinstance(color, float):
             data.color = (color, color, color)
+            data.transparency = color
 
         elif isinstance(color, tuple):
             data.color = color[:3]
+            data.transparency = color[3]
 
         else:   # dict
             image = color.get('image')

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -152,6 +152,7 @@ def sync(root_prim, world: bpy.types.World):
         usd_light.CreateColorAttr(data.color)
 
     usd_light.CreateIntensityAttr(data.intensity)
+    usd_light.CreateInput("transparency", Sdf.ValueTypeNames.Float).Set(data.transparency)
 
     # # set correct Dome light rotation
     usd_light.AddRotateXOp().Set(180.0)
@@ -171,3 +172,14 @@ def sync_update(root_prim, world: bpy.types.World):
     usd_light.ClearXformOpOrder()
 
     sync(root_prim, world)
+
+
+def get_clear_color(root_prim, world: bpy.types.World):
+    light_prim = root_prim.GetStage().GetPrimAtPath(root_prim.GetPath().AppendChild(PRIM_NAME).
+                                                    AppendChild(Tf.MakeValidIdentifier(world.name)))
+    color = light_prim.GetAttribute('inputs:color').Get()
+    intensity = light_prim.GetAttribute('inputs:intensity').Get()
+    transparency = light_prim.GetAttribute('inputs:transparency').Get()
+    clear_color = [c * intensity for c in color]
+    clear_color.append(transparency)
+    return tuple(clear_color)

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -38,10 +38,19 @@ class WorldData:
     rotation: tuple = (0.0, 0.0, 0.0)
     transparency: float = 1.0
 
+    @property
+    def clear_color(self):
+        color = [c * self.intensity for c in self.color]
+        color.append(self.transparency)
+        return tuple(color)
+
     @staticmethod
     def init_from_world(world: bpy.types.World):
         """ Returns WorldData from bpy.types.World """
         data = WorldData()
+
+        if not world:
+            return data
 
         if not world.use_nodes:
             data.color = tuple(world.color)
@@ -65,7 +74,7 @@ class WorldData:
 
         if isinstance(node_data, float):
             data.color = (node_data, node_data, node_data)
-            data.transparency = node_data
+            data.transparency = 1.0
             return data
 
         if isinstance(node_data, tuple):
@@ -112,6 +121,18 @@ class WorldData:
         data.intensity = shading.studio_light_intensity
         data.rotation = (0.0, 0.0, shading.studio_light_rotate_z)
         data.image = BLENDER_DATA_DIR / "studiolights/world" / shading.studio_light
+        return data
+
+    @staticmethod
+    def init_from_stage(stage):
+        data = WorldData()
+
+        light_prim = next((prim for prim in stage.TraverseAll() if
+                           prim.GetTypeName() == 'DomeLight'), None)
+        if light_prim:
+            data.color = light_prim.GetAttribute('inputs:color').Get()
+            data.intensity = light_prim.GetAttribute('inputs:intensity').Get()
+
         return data
 
 

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -187,7 +187,8 @@ class BlenderDataNode(USDNode):
             for obj_data in ObjectData.depsgraph_objects(depsgraph):
                 object.sync(root_prim, obj_data, **kwargs)
 
-            world.sync(root_prim, depsgraph.scene.world)
+            if depsgraph.scene.world is not None:
+                world.sync(root_prim, depsgraph.scene.world)
 
         elif self.data == 'COLLECTION':
             if not self.collection:


### PR DESCRIPTION
### PURPOSE
GL delegate doesn't work properly with world light.

### EFFECT OF CHANGE
Viewport and Final render with GL delegate now uses world light.

### TECHNICAL STEPS
- Added "transparency" parameter for WorldData class
- Added getting world light parameters for viewport and final renders

### NOTES FOR REVIEWERS
Didn't find transparency option for USD, so it doesn't work if source is USD file and transparency works only with GL delegate