### PR TITLE
RPRBLND-1901: TypeError: 'float' object is not iterable

### DIFF
--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -38,7 +38,10 @@ class NodeItem:
         self.id = id
         self.doc = doc
         self.data = data
-        self.nodedef = get_mx_node_cls(data.getCategory(), data.getType()).get_nodedef(self.type) if isinstance(data, mx.Node) else None
+        self.nodedef = None
+        if isinstance(data, mx.Node):
+            MxNode_cls, _ = get_mx_node_cls(data)
+            self.nodedef = MxNode_cls.get_nodedef(self.type)
 
     def node_item(self, value):
         if isinstance(value, NodeItem):

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -122,9 +122,9 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                 try:
                     MxNode_cls, data_type = get_mx_node_cls(mx_node)
 
-                except KeyError:
+                except KeyError as e:
                     if not look_nodedef:
-                        log.warn(f"Corresponding MxNode for {mx_node} wasn't found")
+                        log.warn(e)
                         return None
 
                     # looking for nodedef and switching to another nodegraph defined in doc
@@ -164,15 +164,17 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                         continue
 
                     node_name = mx_input.getNodeName()
+                    mx_output_name = mx_input.getAttribute('output')
+
                     if node_name:
                         new_mx_node = mx_nodegraph.getNode(node_name)
                         new_node = import_node(new_mx_node, layer + 1)
-                        self.links.new(new_node.outputs[0], node.inputs[input_name])
+                        self.links.new(new_node.outputs[mx_output_name] if mx_output_name else
+                                       new_node.outputs[0], node.inputs[input_name])
                         continue
 
                     new_nodegraph_name = mx_input.getAttribute('nodegraph')
                     if new_nodegraph_name:
-                        mx_output_name = mx_input.getAttribute('output')
                         new_mx_nodegraph = mx_nodegraph.getNodeGraph(new_nodegraph_name)
                         mx_output = new_mx_nodegraph.getOutput(mx_output_name)
                         node_name = mx_output.getNodeName()

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -184,7 +184,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                         self.links.new(new_node.outputs[0], node.inputs[input_name])
                         continue
 
-                node.ui_folders_check()
+                node.check_ui_folders()
                 return node
 
             mx_node = next(n for n in doc.getNodes() if n.getCategory() == 'surfacematerial')

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -120,7 +120,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                     return self.nodes[node_path]
 
                 try:
-                    MxNode_cls = get_mx_node_cls(mx_node.getCategory(), mx_node.getType())
+                    MxNode_cls, data_type = get_mx_node_cls(mx_node)
 
                 except KeyError:
                     if not look_nodedef:
@@ -133,6 +133,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                                    nd.getType() == mx_node.getType())
                     new_mx_nodegraph = next(ng for ng in doc.getNodeGraphs()
                                             if ng.getNodeDefString() == nodedef.getName())
+                    assert mx_output_name
                     mx_output = new_mx_nodegraph.getOutput(mx_output_name)
                     node_name = mx_output.getNodeName()
                     new_mx_node = new_mx_nodegraph.getNode(node_name)
@@ -143,7 +144,7 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                 node.name = node_path
                 layers[node_path] = layer
 
-                node.data_type = mx_node.getType()
+                node.data_type = data_type
                 for mx_param in mx_node.getParameters():
                     node.set_param_value(
                         mx_param.getName(),

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -63,12 +63,14 @@ def get_mx_node_cls(mx_node):
                {f"p_{p.getName()}:{p.getType()}" for p in node.getParameters()} | \
                {out_type}
 
-    node_params = params_set(mx_node, node_type)
+    node_params_set = params_set(mx_node, mx_node.getType())
 
     for cls in classes:
         for nodedef, data_type in cls.get_nodedefs():
-            nd_params = params_set(nodedef, nodedef.getOutputs()[0].getType())
-            if node_params.issubset(nd_params):
+            nd_outputs = nodedef.getOutputs()
+            nd_params_set = params_set(nodedef, 'multioutput' if len(nd_outputs) > 1 else
+                                       nd_outputs[0].getType())
+            if node_params_set.issubset(nd_params_set):
                 return cls, data_type
 
-    raise KeyError(f"Unable to find suitable nodedef for {mx_node}")
+    raise TypeError(f"Unable to find suitable nodedef for {mx_node}")

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -51,7 +51,6 @@ def unregister():
 
 def get_mx_node_cls(mx_node):
     node_name = mx_node.getCategory()
-    node_type = mx_node.getType()
 
     suffix = f'_{node_name}'
     classes = tuple(cls for cls in mx_node_classes if cls.__name__.endswith(suffix))

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -219,9 +219,9 @@ class MxNode(bpy.types.ShaderNode):
 
             if isinstance(val, tuple) and isinstance(val[0], mx.Node):
                 # node with multioutput type
-                in_node, out_name = val
+                in_node, in_nd_output = val
                 mx_input = mx_node.addInput(nd_input.getName(), nd_type)
-                mx_utils.set_param_value(mx_input, in_node, nd_type, out_name)
+                mx_utils.set_param_value(mx_input, in_node, nd_type, in_nd_output)
                 continue
 
             if mx_utils.is_shader_type(nd_type):
@@ -249,7 +249,7 @@ class MxNode(bpy.types.ShaderNode):
 
         if len(nodedef.getOutputs()) > 1:
             mx_node.setType('multioutput')
-            return mx_node, nd_output.getName()
+            return mx_node, nd_output
 
         return mx_node
 
@@ -262,6 +262,10 @@ class MxNode(bpy.types.ShaderNode):
             node_name = mx_utils.get_node_name_by_node_path(node.name)
             mx_node = mx_nodegraph.getNode(node_name)
             if mx_node:
+                if mx_node.getType() == 'multioutput':
+                    nd_output = node.get_nodedef_output(out_key)
+                    return mx_node, nd_output
+
                 return mx_node
 
         return node.compute(out_key, **kwargs)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -122,13 +122,15 @@ class MxNode(bpy.types.ShaderNode):
         nodetree.update_()
 
     def update_data_type(self, context):
+        # updating names for inputs and outputs
         nodedef = self.nodedef
+        for i, nd_input in enumerate(nodedef.getInputs()):
+            self.inputs[i].name = nd_input.getName()
         for i, nd_output in enumerate(nodedef.getOutputs()):
             self.outputs[i].name = nd_output.getName()
 
     def init(self, context):
         def init_():
-
             nodedef = self.nodedef
 
             for mx_input in nodedef.getInputs():
@@ -266,19 +268,19 @@ class MxNode(bpy.types.ShaderNode):
         return self.get_input_default(in_key)
 
     def get_input_default(self, in_key: [str, int]):
-        return getattr(self, self._input_prop_name(self.inputs[in_key].identifier))
+        return getattr(self, self._input_prop_name(self.inputs[in_key].name))
 
     def get_param_value(self, name):
         return getattr(self, self._param_prop_name(name))
 
     def get_nodedef_input(self, in_key: [str, int]):
-        return self.nodedef.getInput(self.inputs[in_key].identifier)
+        return self.nodedef.getInput(self.inputs[in_key].name)
 
     def get_nodedef_output(self, out_key: [str, int]):
-        return self.nodedef.getOutput(self.outputs[out_key].identifier)
+        return self.nodedef.getOutput(self.outputs[out_key].name)
 
     def set_input_value(self, in_key, value):
-        setattr(self, self._input_prop_name(self.inputs[in_key].identifier), value)
+        setattr(self, self._input_prop_name(self.inputs[in_key].name), value)
 
     def set_param_value(self, name, value):
         setattr(self, self._param_prop_name(name), value)
@@ -323,7 +325,9 @@ class MxNode(bpy.types.ShaderNode):
         self.update_ui_folders(None)
 
     def create_input(self, mx_input):
-        return self.inputs.new(MxNodeInputSocket.bl_idname, mx_input.getName())
+        input = self.inputs.new(MxNodeInputSocket.bl_idname, f'in_{len(self.inputs)}')
+        input.name = mx_input.getName()
+        return input
 
     def create_output(self, mx_output):
         output = self.outputs.new(MxNodeOutputSocket.bl_idname, f'out_{len(self.outputs)}')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -121,6 +121,11 @@ class MxNode(bpy.types.ShaderNode):
         nodetree = self.id_data
         nodetree.update_()
 
+    def update_data_type(self, context):
+        nodedef = self.nodedef
+        for i, nd_output in enumerate(nodedef.getOutputs()):
+            self.outputs[i].name = nd_output.getName()
+
     def init(self, context):
         def init_():
 
@@ -136,7 +141,7 @@ class MxNode(bpy.types.ShaderNode):
                 self.create_output(mx_output)
 
             if self._ui_folders:
-                self.ui_folders_update(context)
+                self.update_ui_folders(context)
 
         nodetree = self.id_data
         nodetree.no_update_call(init_)
@@ -282,7 +287,7 @@ class MxNode(bpy.types.ShaderNode):
     def poll(cls, tree):
         return tree.bl_idname == 'hdusd.MxNodeTree'
 
-    def ui_folders_update(self, context):
+    def update_ui_folders(self, context):
         for i, mx_input in enumerate(self.nodedef.getInputs()):
             f = mx_input.getAttribute('uifolder')
             if f:
@@ -291,7 +296,7 @@ class MxNode(bpy.types.ShaderNode):
         nodetree = self.id_data
         nodetree.update_()
 
-    def ui_folders_check(self):
+    def check_ui_folders(self):
         if not self._ui_folders:
             return
 
@@ -315,10 +320,12 @@ class MxNode(bpy.types.ShaderNode):
 
             setattr(self, self._folder_prop_name(f), True)
 
-        self.ui_folders_update(None)
+        self.update_ui_folders(None)
 
     def create_input(self, mx_input):
         return self.inputs.new(MxNodeInputSocket.bl_idname, mx_input.getName())
 
     def create_output(self, mx_output):
-        return self.outputs.new(MxNodeOutputSocket.bl_idname, mx_output.getName())
+        output = self.outputs.new(MxNodeOutputSocket.bl_idname, f'out_{len(self.outputs)}')
+        output.name = mx_output.getName()
+        return output

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -99,6 +99,11 @@ class MxNode(bpy.types.ShaderNode):
 
         return cls._data_types[data_type]['nd']
 
+    @classmethod
+    def get_nodedefs(cls):
+        for data_type in cls._data_types.keys():
+            yield cls.get_nodedef(data_type), data_type
+
     @property
     def nodedef(self):
         return self.get_nodedef(self.data_type)

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -28,13 +28,15 @@ log = logging.Log(tag='utils.mx')
 MX_LIBS_DIR = LIBS_DIR / "materialx/libraries"
 
 
-def set_param_value(mx_param, val, nd_type):
+def set_param_value(mx_param, val, nd_type, out_name=None):
     if isinstance(val, mx.Node):
         param_nodegraph = mx_param.getParent().getParent()
         val_nodegraph = val.getParent()
         node_name = val.getName()
         if val_nodegraph == param_nodegraph:
             mx_param.setNodeName(node_name)
+            if out_name:
+                mx_param.setAttribute('output', out_name)
         else:
             # checking nodegraph paths
             val_ng_path = val_nodegraph.getNamePath()

--- a/tools/generate_mx_classes.py
+++ b/tools/generate_mx_classes.py
@@ -255,7 +255,8 @@ class {class_name}(MxNode):
 
     code_strings += [
         f'    data_type: EnumProperty(name="Type", description="Input Data Type", '
-        f"items={data_type_items}, default='{data_type_items[index_default][0]}')",
+        f"items={data_type_items}, default='{data_type_items[index_default][0]}', "
+        f"update=MxNode.update_data_type)",
     ]
 
     for i, f in enumerate(ui_folders):
@@ -264,7 +265,7 @@ class {class_name}(MxNode):
 
         code_strings.append(
             f'    {folder_prop_name(f)}: BoolProperty(name="{f}", '
-            f'description="Enable {f}", default={i == 0}, update=MxNode.ui_folders_update)')
+            f'description="Enable {f}", default={i == 0}, update=MxNode.update_ui_folders)')
 
     for nd in nodedefs:
         nd_type = nodedef_data_type(nd)


### PR DESCRIPTION
### PURPOSE
There are several issues related to MaterialX nodes: 
- bug in generate_mx_classes.py after #99 which produces `TypeError: 'float' object is not iterable`
- creating incorrect node during importing mtlx, especially noticeable with materials from matlib
- multioutput nodes aren't supported

### EFFECT OF CHANGE
Fixed bugs with creating incorrect node during import of mtlx, including materials from matlib.
Implemented support of multioutput nodes.

### TECHNICAL STEPS
1. Fixes in generate_mx_classes.py:
    - fixed bug which produces incorrect inputs types
    - fixed nodedef_data_type(), now it returns correct nodedef data type
    - made code improvements
2. Fixed `mx_nodes.nodes.get_mx_node_cls()`. Now returns correct MxNode class by comparing mx_node structure with nodedef structure.
3. Implemented support of multioutput node: 
    - implemented export/import of multioutput node
    - implemented support of multioutput nodes inside nodegraphs
4. Made some code improvements.