### PR TITLE
RPRBLND-1911: Implement full-fledged matlib UI

### DIFF
--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -51,7 +51,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
                 description += f"\nCategory: {mat.category.title}"
             description += f"\nAuthor: {mat.author}"
 
-            materials.append((mat.id, mat.title, description,mat.renders[0].thumbnail_icon_id, i))
+            materials.append((mat.id, mat.title, description, mat.renders[0].thumbnail_icon_id, i))
 
         return materials
 
@@ -88,6 +88,10 @@ class MatlibProperties(bpy.types.PropertyGroup):
         description="Select materials category",
         items=get_categories,
         update=update_category,
+    )
+    package_id: bpy.props.StringProperty(
+        name="Package id",
+        description="Selected material package"
     )
 
     @classmethod

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -77,6 +77,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
     def update_category(self, context):
         materials = self.get_materials(context)
         self.material = materials[0][0]
+        self.package_id = self.pcoll.materials[self.material].packages[0].id
 
     material: bpy.props.EnumProperty(
         name="Material",

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -92,7 +92,9 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_PT_export_mx,
 
     matlib.HDUSD_MATLIB_OP_import_material,
+    matlib.HDUSD_MATLIB_OP_select_package,
     matlib.HDUSD_MATLIB_PT_matlib,
+    matlib.HDUSD_MATLIB_MT_package_menu,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -92,6 +92,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_PT_export_mx,
 
     matlib.HDUSD_MATLIB_OP_import_material,
+    matlib.HDUSD_MATLIB_OP_reload_material,
     matlib.HDUSD_MATLIB_OP_select_package,
     matlib.HDUSD_MATLIB_PT_matlib,
     matlib.HDUSD_MATLIB_MT_package_menu,

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -37,7 +37,8 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
         material = matlib_prop.pcoll.materials[matlib_prop.material]
 
         # unzipping package
-        package = material.packages[0]
+        package = next(package for package in material.packages
+                                   if package.id == matlib_prop.package_id)
         package.get_info()
         package.get_file()
         mtlx_file = package.unzip()
@@ -107,12 +108,16 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
             else:
                 package = packages[0]
 
-            if package is not None and package.file is None:
-                package.get_info()
+            if package is not None:
 
-            col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
-                     text=package.label + " size=" + package.size if package is not None else None,
-                     icon='DOCUMENTS')
+                if package.file is None:
+                    package.get_info()
+
+                matlib_prop.package_id = package.id
+
+                col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
+                         text=package.label + " size=" + package.size if package is not None else None,
+                         icon='DOCUMENTS')
 
 
 class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -17,6 +17,7 @@ import traceback
 import MaterialX as mx
 
 import bpy
+import math
 
 from . import HdUSD_Panel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree
@@ -126,6 +127,18 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         layout.prop(matlib_prop, "category")
         layout.template_icon_view(matlib_prop, "material")
 
+        renders = matlib_prop.pcoll.materials[matlib_prop.material].renders
+        split = layout.row(align=True).split(factor=math.floor(1 / len(renders)))
+
+        for render in renders:
+            if render.thumbnail_icon_id is None:
+                render.get_info()
+                render.get_thumbnail()
+                render.thumbnail_load(matlib_prop.pcoll)
+
+            col = split.column()
+            col.template_icon(render.thumbnail_icon_id, scale=2.5)
+
         if matlib_prop.pcoll.materials[matlib_prop.material] is not None:
             material_description = matlib_prop.pcoll.materials[matlib_prop.material].get_description()
 
@@ -162,7 +175,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
                 matlib_prop.package_id = package.id
 
                 col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
-                         text=f"{package.label} size= {package.size}" if package is not None else None,
+                         text=f"{package.label} ({package.size})" if package is not None else None,
                          icon='DOCUMENTS')
 
         split = layout.row(align=True).split()
@@ -191,7 +204,7 @@ class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
                 package.get_info()
 
             row = layout.row()
-            op = row.operator(op_idname, text=f"{package.label} size= {package.size}",
+            op = row.operator(op_idname, text=f"{package.label} ({package.size})",
                               icon='DOCUMENTS')
             op.matlib_package_id = package.id
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -85,3 +85,64 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         row.enabled = bool(context.material)
         row.operator(HDUSD_MATLIB_OP_import_material.bl_idname)
 
+        split = layout.row(align=True).split(factor=0.4)
+        col = split.column()
+        col.alignment = 'LEFT'
+        col.label(text="Package")
+        col = split.column()
+
+        matlib_prop = context.window_manager.hdusd.matlib
+
+        if matlib_prop.material:
+            packages = matlib_prop.pcoll.materials[matlib_prop.material].packages
+            package = None
+
+            if matlib_prop.package_id:
+                # TODO maybe need to find a better way than try/except but it's too late now
+                try:
+                    package = next(package for package in packages
+                                   if package.id == matlib_prop.package_id)
+                except:
+                    package = packages[0]
+            else:
+                package = packages[0]
+
+            if package is not None and package.file is None:
+                package.get_info()
+
+            col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
+                     text=package.label + "size=" + package.size if package is not None else None,
+                     icon='DOCUMENTS')
+
+
+class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
+    bl_label = "Package"
+    bl_idname = "HDUSD_MATLIB_MT_package_menu"
+
+    def draw(self, context):
+        layout = self.layout
+        op_idname = HDUSD_MATLIB_OP_select_package.bl_idname
+
+        matlib_prop = context.window_manager.hdusd.matlib
+        packages = matlib_prop.pcoll.materials[matlib_prop.material].packages
+
+        for package in packages:
+            if package.file is None:
+                package.get_info()
+
+            row = layout.row()
+            op = row.operator(op_idname, text=package.label + "  s ize=" + package.size,
+                              icon='DOCUMENTS')
+            op.matlib_package_id = package.id
+
+
+class HDUSD_MATLIB_OP_select_package(bpy.types.Operator):
+    """Select Package"""
+    bl_label = "Select Package"
+    bl_idname = "hdusd.matlib_select_package"
+
+    matlib_package_id: bpy.props.StringProperty(default="")
+
+    def execute(self, context):
+        context.window_manager.hdusd.matlib.package_id = self.matlib_package_id
+        return {"FINISHED"}

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -39,8 +39,11 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
         # unzipping package
         package = next(package for package in material.packages
                                    if package.id == matlib_prop.package_id)
-        package.get_info()
-        package.get_file()
+        
+        if package.file_path is None:
+            package.get_info()
+            package.get_file()
+
         mtlx_file = package.unzip()
 
         # getting/creating MxNodeTree

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -128,16 +128,20 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         layout.template_icon_view(matlib_prop, "material")
 
         renders = matlib_prop.pcoll.materials[matlib_prop.material].renders
-        split = layout.row(align=True).split(factor=math.floor(1 / len(renders)))
 
-        for render in renders:
+        grid = layout.grid_flow(align=True)
+        row = None
+        for i, render in enumerate(renders):
             if render.thumbnail_icon_id is None:
                 render.get_info()
                 render.get_thumbnail()
                 render.thumbnail_load(matlib_prop.pcoll)
 
-            col = split.column()
-            col.template_icon(render.thumbnail_icon_id, scale=2.5)
+            if i % 6 == 0:
+                row = grid.row()
+                row.alignment = "CENTER"
+
+            row.template_icon(render.thumbnail_icon_id, scale=5)
 
         if matlib_prop.pcoll.materials[matlib_prop.material] is not None:
             material_description = matlib_prop.pcoll.materials[matlib_prop.material].get_description()

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -126,15 +126,12 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         layout.prop(matlib_prop, "category")
         layout.template_icon_view(matlib_prop, "material")
 
-        split = layout.row(align=True).split()
+        if matlib_prop.pcoll.materials[matlib_prop.material] is not None:
+            material_description = matlib_prop.pcoll.materials[matlib_prop.material].get_description()
 
-        col = split.column()
-        col.enabled = bool(context.material)
-        col.operator(HDUSD_MATLIB_OP_import_material.bl_idname)
-
-        col = split.column()
-        col.enabled = bool(context.material)
-        col.operator(HDUSD_MATLIB_OP_reload_material.bl_idname)
+            for line in material_description.splitlines():
+                row = layout.row()
+                row.label(text=line)
 
         split = layout.row(align=True).split(factor=0.25)
         
@@ -142,8 +139,6 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         col.alignment = 'LEFT'
         col.label(text="Package")
         col = split.column()
-
-        matlib_prop = context.window_manager.hdusd.matlib
 
         if matlib_prop.material:
             packages = matlib_prop.pcoll.materials[matlib_prop.material].packages
@@ -167,9 +162,18 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
                 matlib_prop.package_id = package.id
 
                 col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
-                         text=package.label + " size=" + package.size if package is not None else None,
+                         text=f"{package.label} size= {package.size}" if package is not None else None,
                          icon='DOCUMENTS')
 
+        split = layout.row(align=True).split()
+
+        col = split.column()
+        col.enabled = bool(context.material)
+        col.operator(HDUSD_MATLIB_OP_import_material.bl_idname, icon="IMPORT")
+
+        col = split.column()
+        col.enabled = bool(context.material)
+        col.operator(HDUSD_MATLIB_OP_reload_material.bl_idname, icon="FILE_REFRESH")
 
 class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
     bl_label = "Package"
@@ -187,7 +191,7 @@ class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
                 package.get_info()
 
             row = layout.row()
-            op = row.operator(op_idname, text=package.label + " size=" + package.size,
+            op = row.operator(op_idname, text=f"{package.label} size= {package.size}",
                               icon='DOCUMENTS')
             op.matlib_package_id = package.id
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -17,7 +17,6 @@ import traceback
 import MaterialX as mx
 
 import bpy
-import math
 
 from . import HdUSD_Panel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -111,7 +111,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
                 package.get_info()
 
             col.menu(HDUSD_MATLIB_MT_package_menu.bl_idname,
-                     text=package.label + "size=" + package.size if package is not None else None,
+                     text=package.label + " size=" + package.size if package is not None else None,
                      icon='DOCUMENTS')
 
 
@@ -131,7 +131,7 @@ class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
                 package.get_info()
 
             row = layout.row()
-            op = row.operator(op_idname, text=package.label + "  s ize=" + package.size,
+            op = row.operator(op_idname, text=package.label + " size=" + package.size,
                               icon='DOCUMENTS')
             op.matlib_package_id = package.id
 

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -163,6 +163,16 @@ class Material:
         for id in mat_json['packages']:
             self.packages.append(Package(id))
 
+    def get_description(self):
+        description = f"{self.title}"
+        if self.description:
+            description += f"\n{self.description}"
+        if self.category:
+            description += f"\nCategory: {self.category.title}"
+        description += f"\nAuthor: {self.author}"
+
+        return description
+
     @classmethod
     def get_materials(cls, limit=10, offset=0):
         response = requests.get(f"{URL}/materials", params={'limit': limit, 'offset': offset})

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -23,7 +23,7 @@ from .. import config
 from . import LIBS_DIR, log
 
 
-URL = "https://matlibapi.cistest.luxoft.com/api"
+URL = "https://matlibapi.stvcis.online/api"
 MATLIB_DIR = LIBS_DIR.parent / "matlib"
 
 
@@ -103,7 +103,7 @@ class Package:
     file_path: Path = field(init=False, default=None)
 
     def get_info(self, use_cache=True):
-        json_path = MATLIB_DIR / self.id / "info.json"
+        json_path = MATLIB_DIR / self.id / "Package.json"
 
         if not (use_cache and json_path.is_file()):
             response = requests.get(f"{URL}/packages/{self.id}")
@@ -149,10 +149,23 @@ class Category:
     id: str
     title: str = field(init=False, default=None)
 
-    def get_info(self):
-        response = requests.get(f"{URL}/categories/{self.id}")
-        res_json = response.json()
-        self.title = res_json['title']
+    def get_info(self, use_cache=True):
+        json_path = MATLIB_DIR / self.id / "Category.json"
+
+        if not (use_cache and json_path.is_file()):
+            response = requests.get(f"{URL}/categories/{self.id}")
+            res_json = response.json()
+            self.title = res_json['title']
+
+            if not json_path.parent.is_dir():
+                json_path.parent.mkdir(parents=True)
+
+            with open(json_path, 'w') as outfile:
+                json.dump(res_json, outfile)
+        else:
+            with open(json_path) as json_file:
+                json_data = json.load(json_file)
+                self.title = json_data['title']
 
 
 @dataclass(init=False)

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -94,12 +94,13 @@ class Package:
     def get_file(self):
         self.file_path = download_file(self.file_url, MATLIB_DIR / self.id / self.file)
 
-    def unzip(self, path=None):
+    def unzip(self, path=None, use_cache=True):
         if not path:
             path = self.file_path.parent
 
-        with zipfile.ZipFile(self.file_path) as z:
-            z.extractall(path=path)
+        if not (use_cache and Path(str(path) + "/" + self.file_path.stem).is_dir()):
+            with zipfile.ZipFile(self.file_path) as z:
+                z.extractall(path=path)
 
         mtlx_file = next(path.glob("*/*.mtlx"))
         return mtlx_file

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -99,7 +99,7 @@ class Package:
                 json_path.parent.mkdir(parents=True)
 
             with open(json_path, 'w') as outfile:
-                json.dump(self.__dict__, outfile)
+                json.dump(res_json, outfile)
         else:
             with open(json_path) as json_file:
                 json_data = json.load(json_file)
@@ -109,8 +109,9 @@ class Package:
                 self.label = json_data['label']
                 self.size = json_data['size']
 
-    def get_file(self):
-        self.file_path = download_file(self.file_url, MATLIB_DIR / self.id / self.file)
+    def get_file(self, use_cache=True):
+        self.file_path = download_file(self.file_url, MATLIB_DIR / self.id / self.file,
+                                       use_cache=use_cache)
 
     def unzip(self, path=None, use_cache=True):
         if not path:


### PR DESCRIPTION
### PURPOSE
Now we have basic UI without any useful features, so we need to add them.

### EFFECT OF CHANGE
- UI works faster
- Added Packages to choose
- Added various Renders (previews) for selected material
- Added Reload button
- Changed URL to matlib

### TECHNICAL STEPS
- Added cache whenever it is possible.
- Added Reload button to ignore cache
- Added menu with available Packages for selected material

### NOTES FOR REVIEWERS
Enable matlib in hdusd/config.py
Clean matlib directory for first launch. Second launch will be much faster