### PR TITLE
RPRBLND-1927: Image caching doesn't take into account output properties.

### DIFF
--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -28,16 +28,8 @@ def cache_image_file(image: bpy.types.Image):
     if image.packed_file is not None or image.source == 'GENERATED' or \
             Path(image.filepath).suffix.lower() not in SUPPORTED_FORMATS or \
             f".{image.file_format.lower()}" not in SUPPORTED_FORMATS:
-
-        image_settings = bpy.context.scene.render.image_settings
-        old_file_format = image_settings.file_format
-        image_settings.file_format = 'HDR'
-
         temp_path = get_temp_file(DEFAULT_FORMAT)
         image.save_render(str(temp_path))
-
-        image_settings.file_format = old_file_format
-
         return temp_path
 
     return Path(image.filepath_from_user())

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -37,10 +37,12 @@ def cache_image_file(image: bpy.types.Image):
 
         image.filepath_raw = str(temp_path)
         image.file_format = BLENDER_DEFAULT_FORMAT
-        image.save()
 
-        image.filepath_raw = old_filepath
-        image.file_format = old_file_format
+        try:
+            image.save()
+        finally:
+            image.filepath_raw = old_filepath
+            image.file_format = old_file_format
 
         return temp_path
 

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -28,8 +28,16 @@ def cache_image_file(image: bpy.types.Image):
     if image.packed_file is not None or image.source == 'GENERATED' or \
             Path(image.filepath).suffix.lower() not in SUPPORTED_FORMATS or \
             f".{image.file_format.lower()}" not in SUPPORTED_FORMATS:
+
+        image_settings = bpy.context.scene.render.image_settings
+        old_file_format = image_settings.file_format
+        image_settings.file_format = 'HDR'
+
         temp_path = get_temp_file(DEFAULT_FORMAT)
         image.save_render(str(temp_path))
+
+        image_settings.file_format = old_file_format
+
         return temp_path
 
     return Path(image.filepath_from_user())

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -21,6 +21,7 @@ from . import get_temp_file
 
 SUPPORTED_FORMATS = {".png", ".jpeg", ".jpg", ".hdr", ".tga", ".bmp"}
 DEFAULT_FORMAT = ".hdr"
+BLENDER_DEFAULT_FORMAT = "HDR"
 
 
 def cache_image_file(image: bpy.types.Image):
@@ -29,14 +30,17 @@ def cache_image_file(image: bpy.types.Image):
             Path(image.filepath).suffix.lower() not in SUPPORTED_FORMATS or \
             f".{image.file_format.lower()}" not in SUPPORTED_FORMATS:
 
-        image_settings = bpy.context.scene.render.image_settings
-        old_file_format = image_settings.file_format
-        image_settings.file_format = 'HDR'
+        old_filepath = image.filepath_raw
+        old_file_format = image.file_format
 
         temp_path = get_temp_file(DEFAULT_FORMAT)
-        image.save_render(str(temp_path))
 
-        image_settings.file_format = old_file_format
+        image.filepath_raw = str(temp_path)
+        image.file_format = BLENDER_DEFAULT_FORMAT
+        image.save()
+
+        image.filepath_raw = old_filepath
+        image.file_format = old_file_format
 
         return temp_path
 


### PR DESCRIPTION
### PURPOSE
We need to change internal image Format, not just write extension to file.

### EFFECT OF CHANGE
Images saved now properly with correct extension and internal format.

### TECHNICAL STEPS
- changed image.save_render() to image.save()
- added changing and reverting changes to image

### NOTES FOR REVIEWERS
To test if it works - this scene must be rendered: https://cloud.blender.org/p/gallery/5dd6d7044441651fa3decb56