### PR TITLE
RPRBLND-1931: Hierarchy of USD objects in outliner is not the same as in USD

### DIFF
--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -65,7 +65,7 @@ class ObjectData:
                           use_scene_lights=True, use_scene_cameras=True):
         for instance in depsgraph.object_instances:
             obj = instance.object
-            if obj.type not in SUPPORTED_TYPES:
+            if obj.type not in SUPPORTED_TYPES or instance.object.hdusd.is_usd:
                 continue
 
             if obj.type == 'LIGHT' and not use_scene_lights:


### PR DESCRIPTION
### PURPOSE
There are duplicates of existing objects if selected data source for viewport rendering is NodeTree

### EFFECT OF CHANGE
No more duplicates in outliner and USD 

### TECHNICAL STEPS
Added check if object from depsgraph is from USD