### PR TITLE
RPRBLND-1932: World light disappears after changing data source for viewport from scene to Nodetree.

### DIFF
--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -163,8 +163,24 @@ def sync(root_prim, world: bpy.types.World):
 def sync_update(root_prim, world: bpy.types.World):
     stage = root_prim.GetStage()
 
+    # TODO: think if i can do it better
+    activate = bool(world)
+    world_prim = stage.GetPrimAtPath(f"/{PRIM_NAME}")
+
+    if world is None:
+        for child in world_prim.GetChildren():
+            child.SetActive(activate)
+
+        return
+
+    if world_prim.IsValid():
+        for child in world_prim.GetChildren():
+            if child.GetName() != Tf.MakeValidIdentifier(world.name):
+                child.SetActive(False)
+
     usd_light = UsdLux.DomeLight.Define(stage,
         Sdf.Path(f"/{PRIM_NAME}").AppendChild(Tf.MakeValidIdentifier(world.name)))
+    usd_light.GetPrim().SetActive(True)
 
     # removing prev settings
     usd_light.CreateColorAttr().Clear()

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -163,20 +163,19 @@ def sync(root_prim, world: bpy.types.World):
 def sync_update(root_prim, world: bpy.types.World):
     stage = root_prim.GetStage()
 
-    # TODO: think if i can do it better
-    activate = bool(world)
-    world_prim = stage.GetPrimAtPath(f"/{PRIM_NAME}")
+    world_prim = stage.DefinePrim(root_prim.GetPath().AppendChild(PRIM_NAME))
 
     if world is None:
-        for child in world_prim.GetChildren():
-            child.SetActive(activate)
+        world_prim.SetActive(False)
 
         return
 
-    if world_prim.IsValid():
-        for child in world_prim.GetChildren():
-            if child.GetName() != Tf.MakeValidIdentifier(world.name):
-                child.SetActive(False)
+    if not world_prim.IsActive():
+        world_prim.ClearActive()
+
+    for child in world_prim.GetChildren():
+        if child.GetName() != Tf.MakeValidIdentifier(world.name):
+            child.SetActive(False)
 
     usd_light = UsdLux.DomeLight.Define(stage,
         Sdf.Path(f"/{PRIM_NAME}").AppendChild(Tf.MakeValidIdentifier(world.name)))

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -224,10 +224,8 @@ class BlenderDataNode(USDNode):
         for update in depsgraph.updates:
             if isinstance(update.id, bpy.types.Scene):
                 scene = update.id
+                world.sync_update(root_prim, scene.world)
                 for prim in root_prim.GetAllChildren():
-                    if prim.GetName() == world.PRIM_NAME:
-                        world.sync_update(root_prim, scene.world)
-
                     vsets = prim.GetVariantSets()
                     if 'delegate' not in vsets.GetNames():
                         continue
@@ -305,6 +303,9 @@ class BlenderDataNode(USDNode):
 
                 if keys_to_remove:
                     for key in keys_to_remove:
+                        if key == world.PRIM_NAME:
+                            continue
+                            
                         root_prim.GetStage().RemovePrim(root_prim.GetPath().AppendChild(key))
 
                     is_updated = True

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -225,6 +225,9 @@ class BlenderDataNode(USDNode):
             if isinstance(update.id, bpy.types.Scene):
                 scene = update.id
                 for prim in root_prim.GetAllChildren():
+                    if prim.GetName() == world.PRIM_NAME:
+                        world.sync_update(root_prim, scene.world)
+
                     vsets = prim.GetVariantSets()
                     if 'delegate' not in vsets.GetNames():
                         continue


### PR DESCRIPTION
### PURPOSE
Fix bug when we loss world light after change data source for viewport from scene to Nodetree.

### EFFECT OF CHANGE
World light will not be lost after changing data source

### TECHNICAL STEPS
- Improvement sync_update to cover various cases of world light state
- Added call to sync_update when we update scene
- Added check so we don't need to remove world because ObjectData.depsgraph_objects(depsgraph) doesn't return world (we sync world individually)