### PR TITLE
RPRBLND-1880: Make correct "Add new Material" function for MaterialX

### DIFF
--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -80,6 +80,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_PT_context,
     material.HDUSD_MATERIAL_PT_preview,
     material.HDUSD_MATERIAL_OP_new_mx_node_tree,
+    material.HDUSD_MATERIAL_OP_duplicate_mx_node_tree,
+    material.HDUSD_MATERIAL_OP_duplicate_mat_mx_node_tree,
     material.HDUSD_MATERIAL_OP_link_mx_node_tree,
     material.HDUSD_MATERIAL_OP_unlink_mx_node_tree,
     material.HDUSD_MATERIAL_MT_mx_node_tree,

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -73,7 +73,7 @@ class HDUSD_MATERIAL_PT_context(HdUSD_Panel):
         split = layout.split(factor=0.65)
 
         if object:
-            split.template_ID(object, "active_material", new="material.new")
+            split.template_ID(object, "active_material", new="hdusd.material_duplicate_mat_mx_node_tree")
             row = split.row()
 
             if slot:
@@ -110,6 +110,32 @@ class HDUSD_MATERIAL_OP_new_mx_node_tree(bpy.types.Operator):
             'RPR_rpr_uberv2' if context.scene.hdusd.use_rpr_mx_nodes else 'PBR_standard_surface')
 
         mat.hdusd.mx_node_tree = mx_node_tree
+        return {"FINISHED"}
+
+
+class HDUSD_MATERIAL_OP_duplicate_mat_mx_node_tree(bpy.types.Operator):
+    """Create duplicates of Material and MaterialX node tree for selected material"""
+    bl_idname = "hdusd.material_duplicate_mat_mx_node_tree"
+    bl_label = ""
+
+    def execute(self, context):
+        bpy.ops.material.new()
+        bpy.ops.hdusd.material_duplicate_mx_node_tree()
+        return {"FINISHED"}
+
+
+class HDUSD_MATERIAL_OP_duplicate_mx_node_tree(bpy.types.Operator):
+    """Create duplicate of MaterialX node tree for selected material"""
+    bl_idname = "hdusd.material_duplicate_mx_node_tree"
+    bl_label = ""
+
+    def execute(self, context):
+        mat = context.object.active_material
+        mx_node_tree = mat.hdusd.mx_node_tree
+
+        if mx_node_tree:
+            mat.hdusd.mx_node_tree = mx_node_tree.copy()
+
         return {"FINISHED"}
 
 
@@ -178,6 +204,7 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
 
         if mat_hdusd.mx_node_tree:
             row.prop(mat_hdusd.mx_node_tree, 'name', text="")
+            row.operator(HDUSD_MATERIAL_OP_duplicate_mx_node_tree.bl_idname, icon='DUPLICATE')
             row.operator(HDUSD_MATERIAL_OP_unlink_mx_node_tree.bl_idname, icon='X')
 
         else:


### PR DESCRIPTION
### PURPOSE
Blender creates a Copy of the Current Material, but MaterialX left the old MaterialXNode attached to the new Material.
Make Blender duplicate MaterialXNode with duplicate Material.

### EFFECT OF CHANGE
MaterialX now duplicates with Material.

### TECHNICAL STEPS
Added operator HDUSD_MATERIAL_OP_duplicate_mx_node_tree.
Added operator HDUSD_MATERIAL_OP_duplicate_mat_mx_node_tree.
Added duplicate button for MaterialX.
Binded HDUSD_MATERIAL_OP_duplicate_mat_mx_node_tree operator to the material duplicate button.
