### PR TITLE
RPRBLND-1852: Add MaterialX settings to "Material Properties" UI.

### DIFF
--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -26,6 +26,8 @@ from . import log
 NODE_LAYER_SEPARATION_WIDTH = 280
 NODE_LAYER_SHIFT_X = 30
 NODE_LAYER_SHIFT_Y = 100
+AREA_TO_UPDATE = 'PROPERTIES'
+REGION_TO_UPDATE = 'WINDOW'
 
 
 class MxNodeTree(bpy.types.ShaderNodeTree):
@@ -249,3 +251,12 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         for material in bpy.data.materials:
             if material.hdusd.mx_node_tree and material.hdusd.mx_node_tree.name == self.name:
                 material.hdusd.update()
+
+        for window in bpy.context.window_manager.windows:
+            for area in window.screen.areas:
+                if area.type == AREA_TO_UPDATE:
+                    for region in area.regions:
+                        if region.type == REGION_TO_UPDATE:
+                            region.tag_redraw()
+                            break
+                    break

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -225,7 +225,7 @@ class MxNode(bpy.types.ShaderNode):
                     op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname,
                                       icon='HANDLETYPE_AUTO_CLAMP_VEC')
                     op.input_num = i
-                    op.new_node_name = self.name
+                    op.current_node_name = self.name
 
                     row = split.row()
                     socket_in.draw(context, row, self, '')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -212,19 +212,22 @@ class MxNode(bpy.types.ShaderNode):
             else:
                 mx_input = self.nodedef.getInput(socket_in.name)
                 f = mx_input.getAttribute('uifolder')
+                is_draw = True
                 if f:
-                    if getattr(self, self._folder_prop_name(f)):
-                        split = layout.split(factor=0.075)
-                        col = split.column()
-                        col.emboss = 'PULLDOWN_MENU'
+                    if not getattr(self, self._folder_prop_name(f)):
+                        is_draw = False
 
-                        op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
-                        op.input_num = i
+                if is_draw:
+                    split = layout.split(factor=0.075)
+                    col = split.column()
+                    col.emboss = 'PULLDOWN_MENU'
 
-                        col = split.column()
-                        socket_in.draw(context, col, self, '')
-                else:
-                    row = layout.row()
+                    op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname,
+                                      icon='HANDLETYPE_AUTO_CLAMP_VEC')
+                    op.input_num = i
+                    op.new_node_name = self.name
+
+                    row = split.row()
                     socket_in.draw(context, row, self, '')
 
     # COMPUTE FUNCTION

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -184,9 +184,11 @@ class MxNode(bpy.types.ShaderNode):
                 layout.prop(self, self._param_prop_name(name))
 
     def draw_node_view(self, context, layout):
-        node_tree = context.material.hdusd.mx_node_tree
+        from ...ui.material import HDUSD_MATERIAL_OP_invoke_popup_input_nodes
+
         self.draw_buttons(context, layout)
-        for socket_in in self.inputs:
+
+        for i, socket_in in enumerate(self.inputs):
             if socket_in.is_linked:
                 link = next((link for link in socket_in.links if link.is_valid), None)
                 if not link:
@@ -213,8 +215,9 @@ class MxNode(bpy.types.ShaderNode):
                 if f:
                     if getattr(self, self._folder_prop_name(f)):
                         row = layout.row()
-                        #row.template_node_socket()
-                        #row.template_node_link(node_tree, self, socket_in)
+                        op = row.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname)
+                        op.input_num = i
+
                         socket_in.draw(context, row, self, '')
                 else:
                     row = layout.row()

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -217,8 +217,6 @@ class MxNode(bpy.types.ShaderNode):
                 if socket_in.show_expanded:
                     node.draw_node_view(context, layout)
 
-                continue
-
             else:
                 mx_input = self.nodedef.getInput(socket_in.name)
                 f = mx_input.getAttribute('uifolder')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -214,11 +214,15 @@ class MxNode(bpy.types.ShaderNode):
                 f = mx_input.getAttribute('uifolder')
                 if f:
                     if getattr(self, self._folder_prop_name(f)):
-                        row = layout.row()
-                        op = row.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname)
+                        split = layout.split(factor=0.075)
+                        col = split.column()
+                        col.emboss = 'PULLDOWN_MENU'
+
+                        op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
                         op.input_num = i
 
-                        socket_in.draw(context, row, self, '')
+                        col = split.column()
+                        socket_in.draw(context, col, self, '')
                 else:
                     row = layout.row()
                     socket_in.draw(context, row, self, '')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -42,7 +42,11 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
             uiname = f"{uifolder} {uiname}"
 
         if self.is_linked or mx_utils.is_shader_type(nd_type) or nd_input.getValue() is None:
-            layout.label(text=uiname)
+            uitype = title_str(nd_type)
+            if uiname.lower() == uitype.lower():
+                layout.label(text=uitype)
+            else:
+                layout.label(text=f"{uiname}: {uitype}")
         else:
             layout.prop(node, node._input_prop_name(self.name), text=uiname)
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -42,14 +42,7 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
             uiname = f"{uifolder} {uiname}"
 
         if self.is_linked or mx_utils.is_shader_type(nd_type) or nd_input.getValue() is None:
-            uitype = title_str(nd_type)
-            if uiname.lower() == uitype.lower():
-                layout.label(text=uitype)
-            else:
-                link = next((link for link in self.links if link.is_valid), None)
-                from_node = link.from_node if link else None
-                label_text = from_node.name if from_node else uitype
-                layout.label(text=f"{uiname}: {label_text}")
+            layout.label(text=uiname)
         else:
             layout.prop(node, node._input_prop_name(self.name), text=uiname)
 
@@ -207,6 +200,16 @@ class MxNode(bpy.types.ShaderNode):
 
                 socket_in.draw(context, row, self, '')
 
+                box = row.box()
+                box.scale_x = 1.025
+                box.scale_y = 0.5
+                box.emboss = 'UI_EMBOSS_NONE_OR_STATUS'
+
+                op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname,
+                                  icon='HANDLETYPE_AUTO_CLAMP_VEC', text=node.name)
+                op.input_num = i
+                op.current_node_name = self.name
+
                 if socket_in.show_expanded:
                     node.draw_node_view(context, layout)
 
@@ -223,11 +226,13 @@ class MxNode(bpy.types.ShaderNode):
                 if is_draw:
                     split = layout.split(factor=0.1)
                     split.column()
-                    split = split.split(factor=0.075)
-                    col = split.column()
-                    col.emboss = 'PULLDOWN_MENU'
+                    split = split.split(factor=0.085)
 
-                    op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname,
+                    box = split.box()
+                    box.scale_y = 0.5
+                    box.emboss = 'UI_EMBOSS_NONE_OR_STATUS'
+
+                    op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname,
                                       icon='HANDLETYPE_AUTO_CLAMP_VEC')
                     op.input_num = i
                     op.current_node_name = self.name

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -196,13 +196,16 @@ class MxNode(bpy.types.ShaderNode):
 
                 node = link.from_node
 
-                row = layout.row()              
+                split = layout.split(factor=0.1)
+                split.column()
+
+                row = split.row()
                 row.prop(socket_in, "show_expanded",
                          icon="TRIA_DOWN" if socket_in.show_expanded else "TRIA_RIGHT",
                          icon_only=True, emboss=False
                          )
-                
-                socket_in.draw(context, row, self, node.name)
+
+                socket_in.draw(context, row, self, '')
 
                 if socket_in.show_expanded:
                     node.draw_node_view(context, layout)
@@ -218,7 +221,9 @@ class MxNode(bpy.types.ShaderNode):
                         is_draw = False
 
                 if is_draw:
-                    split = layout.split(factor=0.075)
+                    split = layout.split(factor=0.1)
+                    split.column()
+                    split = split.split(factor=0.075)
                     col = split.column()
                     col.emboss = 'PULLDOWN_MENU'
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -180,6 +180,16 @@ class MxNode(bpy.types.ShaderNode):
             else:
                 layout.prop(self, self._param_prop_name(name))
 
+    def draw_inputs(self, context, layout):
+        for socket_in in self.inputs:
+            mx_input = self.nodedef.getInput(socket_in.name)
+            f = mx_input.getAttribute('uifolder')
+            if f:
+                if getattr(self, self._folder_prop_name(f)):
+                    socket_in.draw(context, layout, self, '')
+            else:
+                socket_in.draw(context, layout, self, '')
+
     # COMPUTE FUNCTION
     def compute(self, out_key, **kwargs):
         log("compute", self, out_key)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -162,13 +162,6 @@ class MxNode(bpy.types.ShaderNode):
                     r = col.row(align=True)
                 r.prop(self, self._folder_prop_name(f), toggle=True)
 
-        for mx_input in mx_utils.get_nodedef_inputs(nodedef, True):
-            f = mx_input.getAttribute('uifolder')
-            if f and not getattr(self, self._folder_prop_name(f)):
-                continue
-
-            layout.prop(self, self._input_prop_name(mx_input.getName()))
-
         for mx_param in nodedef.getParameters():
             f = mx_param.getAttribute('uifolder')
             if f and not getattr(self, self._folder_prop_name(f)):

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -92,6 +92,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_invoke_popup_shader_nodes,
     material.HDUSD_MATERIAL_OP_remove_node,
     material.HDUSD_MATERIAL_OP_disconnect_node,
+    material.HDUSD_MATERIAL_PT_material_settings_displacement,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -84,6 +84,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_unlink_mx_node_tree,
     material.HDUSD_MATERIAL_MT_mx_node_tree,
     material.HDUSD_MATERIAL_PT_material,
+    material.HDUSD_MATERIAL_PT_material_settings_surface,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -85,6 +85,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_MT_mx_node_tree,
     material.HDUSD_MATERIAL_PT_material,
     material.HDUSD_MATERIAL_PT_material_settings_surface,
+    material.HDUSD_MATERIAL_OP_link_mx_node,
+    material.HDUSD_MATERIAL_OP_invoke_popup_input_nodes,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -88,6 +88,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_OP_link_mx_node,
     material.HDUSD_MATERIAL_OP_invoke_popup_input_nodes,
     material.HDUSD_MATERIAL_OP_invoke_popup_shader_nodes,
+    material.HDUSD_MATERIAL_OP_remove_node,
+    material.HDUSD_MATERIAL_OP_disconnect_node,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -87,6 +87,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     material.HDUSD_MATERIAL_PT_material_settings_surface,
     material.HDUSD_MATERIAL_OP_link_mx_node,
     material.HDUSD_MATERIAL_OP_invoke_popup_input_nodes,
+    material.HDUSD_MATERIAL_OP_invoke_popup_shader_nodes,
     material.HDUSD_MATERIAL_PT_output_surface,
     material.HDUSD_MATERIAL_PT_output_displacement,
     material.HDUSD_MATERIAL_PT_output_volume,

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -21,7 +21,7 @@ from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree, NODE_LAYER_SEPARATION_WIDTH
 
 
-NODE_SHADER_CATEGORIES = sorted(set(['PBR', 'RPR Shaders']))
+NODE_SHADER_CATEGORIES = set(['PBR', 'RPR Shaders'])
 NODE_EXCLUDE_CATEGORIES = set(['material'])
 NODE_LINK_CATEGORY = 'Link'
 
@@ -319,7 +319,7 @@ class HDUSD_MATERIAL_OP_invoke_popup_shader_nodes(bpy.types.Operator):
         row = self.layout.split().row()
 
         output_node = context.material.hdusd.mx_node_tree.output_node
-        for category in NODE_SHADER_CATEGORIES:
+        for category in sorted(NODE_SHADER_CATEGORIES):
             col = row.column()
             col.emboss = 'PULLDOWN_MENU'
             col.label(text=category)

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -363,14 +363,12 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         output_node = node_tree.output_node
         if not output_node:
             layout.label(text="No output node")
-            node_tree.interface_update(context=context)
             return
 
         input = output_node.inputs[self.bl_label]
         link = next((link for link in input.links if link.is_valid), None)
         if not link:
             layout.label(text="No input node")
-            node_tree.interface_update(context=context)
             return
 
         node = link.from_node
@@ -389,8 +387,6 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         col.separator()
 
         node.draw_node_view(context, layout)
-
-        node_tree.interface_update(context=context)
 
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -188,6 +188,28 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
         layout.label(text=f"Material: {context.material.name}")
 
 
+class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
+    bl_label = "Surfaceshader"
+    bl_parent_id = 'HDUSD_MATERIAL_PT_material'
+
+    @classmethod
+    def poll(cls, context):
+        return bool(context.material.hdusd.mx_node_tree)
+
+    def draw(self, context):
+        layout = self.layout
+        mx_node_tree = context.material.hdusd.mx_node_tree
+
+        node = mx_node_tree.nodes.active
+        if not node:
+            layout.label(text="No active node")
+            return
+
+        for socket in node.inputs:
+            if socket.name == 'surfaceshader':
+                layout.template_node_view(mx_node_tree, node, socket)
+
+
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
     bl_label = ""
     bl_parent_id = 'HDUSD_MATERIAL_PT_material'

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -239,8 +239,6 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
     def draw(self, context):
         from ..mx_nodes.nodes import mx_node_classes
 
-        node_groups = bpy.data.node_groups
-
         row = self.layout.split().row()
         col = row.column()
 
@@ -248,6 +246,7 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
         for i, category in enumerate(categories):
             if i % 4 == 0:
                 col = row.column()
+            col.emboss = 'PULLDOWN_MENU'
             col.label(text=category)
             for node in mx_node_classes:
                 if node.category == category:

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -207,8 +207,15 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
             return
 
         input = output_node.inputs[self.bl_label]
-        layout.template_node_view(node_tree, output_node, input)
-        
+        link = next((link for link in input.links if link.is_valid), None)
+        if not link:
+            layout.label(text="No input node")
+            return
+
+        node = link.from_node
+        node.draw_buttons(context, layout)
+        node.draw_inputs(context, layout)
+
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
     bl_label = ""

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -440,6 +440,50 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         node.draw_node_view(context, layout)
 
 
+class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
+    bl_label = "displacementshader"
+    bl_parent_id = 'HDUSD_MATERIAL_PT_material'
+
+    @classmethod
+    def poll(cls, context):
+        return bool(context.material.hdusd.mx_node_tree)
+
+    def draw(self, context):
+        layout = self.layout
+
+        node_tree = context.material.hdusd.mx_node_tree
+        output_node = node_tree.output_node
+        if not output_node:
+            layout.label(text="No output node")
+            return
+
+        input = output_node.inputs[self.bl_label]
+        link = next((link for link in input.links if link.is_valid), None)
+
+        split = layout.split(factor=0.09)
+        col = split.column()
+
+        row = split.row()
+        row.label(text='Displacement')
+
+        box = row.column().box()
+        box.scale_x = 1.53
+        box.scale_y = 0.5
+
+        box.emboss = 'UI_EMBOSS_NONE_OR_STATUS'
+        op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname,
+                          icon='HANDLETYPE_AUTO_CLAMP_VEC', text=link.from_node.name if link else 'None')
+
+        if not link:
+            layout.label(text="No input node")
+            return
+
+        layout.separator()
+
+        node = link.from_node
+        node.draw_node_view(context, layout)
+
+
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
     bl_label = ""
     bl_parent_id = 'HDUSD_MATERIAL_PT_material'

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -237,15 +237,18 @@ class HDUSD_MATERIAL_OP_link_mx_node(bpy.types.Operator):
 
         input = current_node.inputs[self.input_num]
         link = next((link for link in input.links), None) if input.is_linked else None
-        linked_node_name = link.from_node.bl_idname if link else self.new_node_name
+        linked_node_name = link.from_node.bl_idname if link else None
 
-        if linked_node_name != self.new_node_name:
-            bpy.ops.hdusd.material_remove_node(input_node_name=link.from_node.name)
+        if linked_node_name:
+            if linked_node_name != self.new_node_name:
+                bpy.ops.hdusd.material_remove_node(input_node_name=link.from_node.name)
+            else:
+                return {"FINISHED"}
 
-            new_node = node_tree.nodes.new(self.new_node_name)
-            new_node.location = (current_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
-                             current_node.location[1])
-            node_tree.links.new(new_node.outputs[0], current_node.inputs[self.input_num])
+        new_node = node_tree.nodes.new(self.new_node_name)
+        new_node.location = (current_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
+                            current_node.location[1])
+        node_tree.links.new(new_node.outputs[0], current_node.inputs[self.input_num])
 
         return {"FINISHED"}
 

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -189,7 +189,7 @@ class HDUSD_MATERIAL_PT_material(HdUSD_Panel):
 
 
 class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
-    bl_label = "Surfaceshader"
+    bl_label = "surfaceshader"
     bl_parent_id = 'HDUSD_MATERIAL_PT_material'
 
     @classmethod
@@ -198,17 +198,17 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
 
     def draw(self, context):
         layout = self.layout
-        mx_node_tree = context.material.hdusd.mx_node_tree
 
-        node = mx_node_tree.nodes.active
-        if not node:
-            layout.label(text="No active node")
+        node_tree = context.material.hdusd.mx_node_tree
+
+        output_node = node_tree.output_node
+        if not output_node:
+            layout.label(text="No output node")
             return
 
-        for socket in node.inputs:
-            if socket.name == 'surfaceshader':
-                layout.template_node_view(mx_node_tree, node, socket)
-
+        input = output_node.inputs[self.bl_label]
+        layout.template_node_view(node_tree, output_node, input)
+        
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
     bl_label = ""

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -250,7 +250,7 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
 
 
 class HDUSD_MATERIAL_OP_invoke_popup_shader_nodes(bpy.types.Operator):
-    """Open modal panel"""
+    """Open modal panel with shaders"""
     bl_idname = "hdusd.material_invoke_popup_shader_nodes"
     bl_label = ""
 
@@ -307,20 +307,21 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
             node_tree.interface_update(context=context)
             return
 
-        split = layout.split(factor=0.25)
+        node = link.from_node
+
+        split = layout.split(factor=0.01)
         col = split.column()
 
         row = split.row()
         row.label(text=self.bl_label)
 
         col = row.column()
-        col.scale_x = 4
+        col.scale_x = 1.6
         op = col.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname,
-                          icon='HANDLETYPE_AUTO_CLAMP_VEC')
+                          icon='HANDLETYPE_AUTO_CLAMP_VEC', text=node.name)
 
         col.separator()
 
-        node = link.from_node
         node.draw_node_view(context, layout)
 
         node_tree.interface_update(context=context)

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -193,32 +193,20 @@ class HDUSD_MATERIAL_OP_link_mx_node(bpy.types.Operator):
     bl_idname = "hdusd.material_link_mx_node"
     bl_label = ""
 
-    mx_node: bpy.props.StringProperty(default="")
+    input_node: bpy.props.StringProperty()
     input_num: bpy.props.IntProperty()
+    new_node_name: bpy.props.StringProperty()
 
     def execute(self, context):
         layout = self.layout
 
         node_tree = context.material.hdusd.mx_node_tree
-        output_node = node_tree.output_node
-        if not output_node:
-            layout.label(text="No output node")
-            node_tree.interface_update(context=context)
-            return
+        new_node = context.material.hdusd.mx_node_tree.nodes[self.new_node_name]
 
-        input = output_node.inputs[HDUSD_MATERIAL_PT_material_settings_surface.bl_label]
-        link = next((link for link in input.links if link.is_valid), None)
-        if not link:
-            layout.label(text="No input node")
-            node_tree.interface_update(context=context)
-            return
-
-        node = link.from_node
-
-        input_node = node_tree.nodes.new(self.mx_node)
-        input_node.location = (node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
-                         node.location[1])
-        node_tree.links.new(input_node.outputs[0], node.inputs[self.input_num])
+        input_node = node_tree.nodes.new(self.input_node)
+        input_node.location = (new_node.location[0] - NODE_LAYER_SEPARATION_WIDTH,
+                         new_node.location[1])
+        node_tree.links.new(input_node.outputs[0], new_node.inputs[self.input_num])
 
         return {"FINISHED"}
 
@@ -229,6 +217,7 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
     bl_label = ""
 
     input_num: bpy.props.IntProperty()
+    new_node_name: bpy.props.StringProperty()
 
     def execute(self, context):
         return {'FINISHED'}
@@ -252,8 +241,9 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
                 if node.category == category:
                     op = col.operator(HDUSD_MATERIAL_OP_link_mx_node.bl_idname,
                                       text=node.bl_label)
-                    op.mx_node = node.bl_idname
+                    op.input_node = node.bl_idname
                     op.input_num = self.input_num
+                    op.new_node_name = self.new_node_name
 
 
 class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -204,17 +204,20 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         output_node = node_tree.output_node
         if not output_node:
             layout.label(text="No output node")
+            node_tree.interface_update(context=context)
             return
 
         input = output_node.inputs[self.bl_label]
         link = next((link for link in input.links if link.is_valid), None)
         if not link:
             layout.label(text="No input node")
+            node_tree.interface_update(context=context)
             return
 
         node = link.from_node
         node.draw_node_view(context, layout)
 
+        node_tree.interface_update(context=context)
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):
     bl_label = ""

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -213,8 +213,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
             return
 
         node = link.from_node
-        node.draw_buttons(context, layout)
-        node.draw_inputs(context, layout)
+        node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -146,15 +146,7 @@ def parse_value_str(val_str, mx_type, *, first_only=False, is_enum=False):
 
 def get_nodedef_inputs(nodedef, uniform=None):
     for input in nodedef.getInputs():
-        if uniform is None:
-            yield input
-
-        elif input.getAttribute('uniform') == 'true':
-            if uniform:
-                yield input
-        else:
-            if not uniform:
-                yield input
+        yield input
 
 
 def get_file_prefix(mx_node, file_path):

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -144,11 +144,6 @@ def parse_value_str(val_str, mx_type, *, first_only=False, is_enum=False):
     return val_str
 
 
-def get_nodedef_inputs(nodedef, uniform=None):
-    for input in nodedef.getInputs():
-        yield input
-
-
 def get_file_prefix(mx_node, file_path):
     file_prefix = file_path.parent
     n = mx_node


### PR DESCRIPTION
### PURPOSE
Add panel to UI with MaterialX settings to work with Node Tree similar to common Blender functionality

### EFFECT OF CHANGE
Now it is available to edit MaterialX node tree via UI in common Blender way.

- Added subpanel for surfaceshader
- Added subpanel for displacementshader
- Added possibility to add/remove/disconnect nodes to/from any available input in node tree and edit their values via UI.

### TECHNICAL STEPS

- Added method draw_node_view of MxNode to draw node with links itself
- Added update of UI due to update of node tree

<br/>

- Added child panel surfaceshader for surfaceshader input of Surfacematerial node
- Added child panel displacementshader for displacementshader input of Surfacematerial node

<br/>

- Added separate operator to invoke popup window which contains list of available shader nodes to link to Surfacematerial node
- Added separate operator to invoke popup window which contains list of available MaterialX nodes to link to shader node
- Added separate operators to remove/disconnect selected node