### PR TITLE
RPRBLND-1969: ERROR hdusd.engine: Error: Image 'roughness.png' does not have any image data

### DIFF
--- a/src/hdusd/bl_nodes/nodes/texture.py
+++ b/src/hdusd/bl_nodes/nodes/texture.py
@@ -42,10 +42,6 @@ class ShaderNodeTexImage(NodeParser):
         if not image or image.source in ('TILED', 'SEQUENCE'):
             return image_error_result
 
-        # there were scenes in Linux that have 0x0x0 image packed
-        if image.size[0] * image.size[1] * image.channels == 0:
-            return image_error_result
-
         img_path = cache_image_file(image)
         if not img_path:
             return image_error_result

--- a/src/hdusd/bl_nodes/nodes/texture.py
+++ b/src/hdusd/bl_nodes/nodes/texture.py
@@ -41,6 +41,8 @@ class ShaderNodeTexImage(NodeParser):
 
         # TODO support UDIM Tilesets and SEQUENCE
         if not image or image.source in ('TILED', 'SEQUENCE'):
+            if not image.has_data:
+                log.warn("Image is missing", image, image.filepath)
             return image_error_result
 
         # there were scenes in Linux that have 0x0x0 image packed

--- a/src/hdusd/bl_nodes/nodes/texture.py
+++ b/src/hdusd/bl_nodes/nodes/texture.py
@@ -15,7 +15,6 @@
 import os
 
 from ..node_parser import NodeParser
-from ... import utils
 from ...utils.image import cache_image_file
 from . import log
 
@@ -41,8 +40,6 @@ class ShaderNodeTexImage(NodeParser):
 
         # TODO support UDIM Tilesets and SEQUENCE
         if not image or image.source in ('TILED', 'SEQUENCE'):
-            if not image.has_data:
-                log.warn("Image is missing", image, image.filepath)
             return image_error_result
 
         # there were scenes in Linux that have 0x0x0 image packed
@@ -50,6 +47,8 @@ class ShaderNodeTexImage(NodeParser):
             return image_error_result
 
         img_path = cache_image_file(image)
+        if not img_path:
+            return image_error_result
 
         # TODO use Vector input for UV
         uv = self.create_node('texcoord', 'vector2', {})

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -92,8 +92,10 @@ class WorldData:
         color = node_data.get('color')
         if color is None:
             image = node_data.get('image')
-            if image:
+            if image and image.has_data:
                 data.image = cache_image_file(image)
+            else:
+                log.warn("Image is missing", image, image.filepath)
 
         elif isinstance(color, float):
             data.color = (color, color, color)
@@ -105,8 +107,10 @@ class WorldData:
 
         else:   # dict
             image = color.get('image')
-            if image:
+            if image and image.has_data:
                 data.image = cache_image_file(image)
+            else:
+                log.warn("Image is missing", image, image.filepath)
 
         rotation = node_data.get('rotation')
         if isinstance(rotation, tuple):

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -131,10 +131,8 @@ class WorldData:
         color = node_data.get('color')
         if color is None:
             image = node_data.get('image')
-            if image and image.has_data:
+            if image:
                 data.image = cache_image_file(image)
-            else:
-                log.warn("Image is missing", image, image.filepath)
 
         elif isinstance(color, float):
             data.color = (color, color, color)
@@ -146,10 +144,8 @@ class WorldData:
 
         else:   # dict
             image = color.get('image')
-            if image and image.has_data:
+            if image:
                 data.image = cache_image_file(image)
-            else:
-                log.warn("Image is missing", image, image.filepath)
 
         rotation = node_data.get('rotation')
         if isinstance(rotation, tuple):

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -26,7 +26,7 @@ BLENDER_DEFAULT_FORMAT = "HDR"
 
 
 def cache_image_file(image: bpy.types.Image, cache_check=True):
-    # at fist start image.has_data = False even if filepath correct
+    # at fist start image.has_data = False even if filepath is correct
     if not image.has_data:
         temp_path = Path(image.filepath_from_user())
         if not temp_path.is_file():
@@ -38,7 +38,6 @@ def cache_image_file(image: bpy.types.Image, cache_check=True):
             f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
         return Path(image.filepath_from_user())
 
-    # if image packed in .blend file
     old_filepath = image.filepath_raw
     old_file_format = image.file_format
 

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -26,17 +26,22 @@ BLENDER_DEFAULT_FORMAT = "HDR"
 
 
 def cache_image_file(image: bpy.types.Image, cache_check=True):
-    # at fist start image.has_data = False even if filepath is correct
-    if not image.has_data:
-        temp_path = Path(image.filepath_from_user())
-        if not temp_path.is_file():
-            log.warn("Image is missing", image, image.filepath)
-            return None
-
+    image_path = Path(image.filepath_from_user())
     if not image.packed_file and image.source != 'GENERATED' and \
             Path(image.filepath).suffix.lower() in SUPPORTED_FORMATS and \
             f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
-        return Path(image.filepath_from_user())
+
+        if not image_path.is_file():
+            log.warn("Image is missing", image, image_path)
+            return None
+
+        return image_path
+
+    # at fist start image.has_data is False even if filepath is correct and image if valid
+    if not image.has_data:
+        if not image_path.is_file():
+            log.warn("Image is missing", image, image_path)
+            return None
 
     old_filepath = image.filepath_raw
     old_file_format = image.file_format

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -27,21 +27,14 @@ BLENDER_DEFAULT_FORMAT = "HDR"
 
 def cache_image_file(image: bpy.types.Image, cache_check=True):
     image_path = Path(image.filepath_from_user())
-    if not image.packed_file and image.source != 'GENERATED' and \
-            Path(image.filepath).suffix.lower() in SUPPORTED_FORMATS and \
-            f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
-
+    if not image.packed_file and image.source != 'GENERATED':
         if not image_path.is_file():
             log.warn("Image is missing", image, image_path)
             return None
 
-        return image_path
-
-    # at fist start image.has_data is False even if filepath is correct and image if valid
-    if not image.has_data:
-        if not image_path.is_file():
-            log.warn("Image is missing", image, image_path)
-            return None
+        if Path(image.filepath).suffix.lower() in SUPPORTED_FORMATS and \
+                f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
+            return image_path
 
     old_filepath = image.filepath_raw
     old_file_format = image.file_format

--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -17,6 +17,7 @@ from pathlib import Path
 import bpy
 
 from . import get_temp_file
+from . import log
 
 
 SUPPORTED_FORMATS = {".png", ".jpeg", ".jpg", ".hdr", ".tga", ".bmp"}
@@ -25,6 +26,13 @@ BLENDER_DEFAULT_FORMAT = "HDR"
 
 
 def cache_image_file(image: bpy.types.Image, cache_check=True):
+    # at fist start image.has_data = False even if filepath correct
+    if not image.has_data:
+        temp_path = Path(image.filepath_from_user())
+        if not temp_path.is_file():
+            log.warn("Image is missing", image, image.filepath)
+            return None
+
     if not image.packed_file and image.source != 'GENERATED' and \
             Path(image.filepath).suffix.lower() in SUPPORTED_FORMATS and \
             f".{image.file_format.lower()}" in SUPPORTED_FORMATS:

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -67,10 +67,9 @@ def set_param_value(mx_param, val, nd_type, nd_output=None):
 
     elif nd_type == 'filename':
         if isinstance(val, bpy.types.Image):
-            if val.has_data:
-                mx_param.setValueString(str(cache_image_file(val)))
-            else:
-                log.warn("Image is missing", val, val.filepath)
+            image_path = cache_image_file(val)
+            if image_path:
+                mx_param.setValueString(str(image_path))
         else:
             mx_param.setValueString(str(val))
 

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -67,7 +67,10 @@ def set_param_value(mx_param, val, nd_type, nd_output=None):
 
     elif nd_type == 'filename':
         if isinstance(val, bpy.types.Image):
-            mx_param.setValueString(str(cache_image_file(val)))
+            if val.has_data:
+                mx_param.setValueString(str(cache_image_file(val)))
+            else:
+                log.warn("Image is missing", val, val.filepath)
         else:
             mx_param.setValueString(str(val))
 


### PR DESCRIPTION
### PURPOSE
ERROR hdusd.engine: Error: Image 'roughness.png' does not have any image data.

### EFFECT OF CHANGE
No error if the image path is invalid or the image has no data.

### TECHNICAL STEPS
Added check image.has_data in case "Can't load image".
Added log.warn for missing images.
