### PR TITLE
RPRBLND-1965: Material isn’t updated in viewport

### DIFF
--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -91,12 +91,7 @@ def sync_update_all(root_prim, mat: bpy.types.Material):
 
     mx_file = utils.get_temp_file(".mtlx")
     mx.writeToXmlFile(doc, str(mx_file))
-    surfacematerial = next(node for node in doc.getNodes()
-                           if node.getCategory() == 'surfacematerial')
 
-    stage = root_prim.GetStage()
     for mat_prim in mat_prims:
-        shader = UsdShade.Shader.Define(stage, mat_prim.GetPath().AppendChild("rpr_materialx_node"))
-        shader.CreateInput("file", Sdf.ValueTypeNames.Asset).Set(f"./{mx_file.name}")
-        shader.CreateInput("surfaceElement", Sdf.ValueTypeNames.String).Set(
-            surfacematerial.getName())
+        mat_prim.GetReferences().ClearReferences()
+        mat_prim.GetReferences().AddReference(f"./{mx_file.name}", "/MaterialX")

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -101,7 +101,7 @@ def sync_update_all(root_prim, mat: bpy.types.Material):
         mat_prim.GetReferences().ClearReferences()
         mat_prim.GetReferences().AddReference(f"./{mx_file.name}", "/MaterialX")
 
-        # apply new bind if shader switched to MaterialX or vice verse
+        # apply new bind if shader switched to MaterialX or vice versa
         mesh_prim = next((prim for prim in mat_prim.GetParent().GetChildren() if prim.GetTypeName() == 'Mesh'), None)
         if not mesh_prim:
             return

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -43,7 +43,7 @@ def sync(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
         log.warn("MX export failed", mat)
         return None
 
-    mx_file = utils.get_temp_file(".mtlx")
+    mx_file = utils.get_temp_file(".mtlx", mat.name)
     mx.writeToXmlFile(doc, str(mx_file))
     surfacematerial = next(node for node in doc.getNodes()
                            if node.getCategory() == 'surfacematerial')
@@ -94,14 +94,14 @@ def sync_update_all(root_prim, mat: bpy.types.Material):
 
     stage = root_prim.GetStage()
 
-    mx_file = utils.get_temp_file(".mtlx")
+    mx_file = utils.get_temp_file(".mtlx", mat.name)
     mx.writeToXmlFile(doc, str(mx_file))
 
     for mat_prim in mat_prims:
         mat_prim.GetReferences().ClearReferences()
         mat_prim.GetReferences().AddReference(f"./{mx_file.name}", "/MaterialX")
 
-        # apply new bind if true shader changed to MateroalX or vice verse
+        # apply new bind if shader switched to MaterialX or vice verse
         mesh_prim = next((prim for prim in mat_prim.GetParent().GetChildren() if prim.GetTypeName() == 'Mesh'), None)
         if not mesh_prim:
             return


### PR DESCRIPTION
### PURPOSE
Material isn’t updated in viewport.

### EFFECT OF CHANGE
Material is updated in viewport.

### TECHNICAL STEPS
Update references wirh new *.mtlx temp file.
Added ability to update 'material:binding' attribute  while switch to MaterialX or vice versa.
