### PR TITLE
RPRBLND-1934: Downloading matlib materials in separate threads

### DIFF
--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -22,7 +22,7 @@ from ..usd_nodes import node_tree as usd_node_tree
 from ..engine.viewport_engine import ViewportEngineScene
 
 from ..utils import logging
-log = logging.Log(tag='export.material')
+log = logging.Log(tag='properties.material')
 
 
 class MaterialProperties(HdUSDProperties):

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -142,18 +142,34 @@ class MatlibProperties(bpy.types.PropertyGroup):
         return categories
 
     def get_packages_prop(self, context):
+        packages = []
         mat = self.material
         if not mat:
-            return []
+            return packages
 
-        return [(p.id, f"{p.label} ({p.size})", "")
-                for p in sorted(mat.packages)]
+        for i, p in enumerate(sorted(mat.packages)):
+            description = f"Package: {p.label} ({p.size})\nAuthor: {p.author}"
+            if p.has_file:
+                description += "\nReady to import"
+            icon_id = 'RADIOBUT_ON' if p.has_file else 'RADIOBUT_OFF'
 
-    def update_filter(self, context):
+            packages.append((p.id, f"{p.label} ({p.size})", description, icon_id, i))
+
+        return packages
+
+    def update_category(self, context):
+        materials = self.get_materials()
+        if materials:
+            mat = min(materials.values())
+            self.material_id = mat.id
+            self.package_id = min(mat.packages).id
+
+    def update_search(self, context):
         materials = self.get_materials()
         if materials and self.material_id not in materials:
-            self.material_id = next(iter(materials))
-            self.package_id = materials[self.material_id].packages[0].id
+            mat = min(materials.values())
+            self.material_id = mat.id
+            self.package_id = min(mat.packages).id
 
     material_id: bpy.props.EnumProperty(
         name="Material",
@@ -164,12 +180,12 @@ class MatlibProperties(bpy.types.PropertyGroup):
         name="Category",
         description="Select materials category",
         items=get_categories_prop,
-        update=update_filter,
+        update=update_category,
     )
     search: bpy.props.StringProperty(
         name="Search",
         description="Search materials by title",
-        update=update_filter,
+        update=update_search,
     )
     package_id: bpy.props.EnumProperty(
         name="Package",

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -27,9 +27,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
         materials = {}
         search_str = self.search.strip().lower()
 
-        # converting to list in thread safe purposes
-        materials_list = list(manager.materials.values())
-
+        materials_list = manager.materials_list
         for mat in materials_list:
             if search_str not in mat.title.lower():
                 continue
@@ -61,9 +59,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
 
         categories += [('ALL', "All Categories", "Show materials for all categories")]
 
-        # converting to list in thread safe purposes
-        categories_list = list(manager.categories.values())
-
+        categories_list = manager.categories_list
         categories += ((cat.id, cat.title, f"Show materials with category {cat.title}")
                        for cat in sorted(categories_list))
         return categories

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -12,96 +12,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from concurrent import futures
-import threading
-
 import bpy
 
 from . import HdUSDProperties
 
-from ..utils import matlib
+from ..utils.matlib import manager
 
 from ..utils import logging
 log = logging.Log(tag='properties.matlib')
 
 
-thread_pool = futures.ThreadPoolExecutor()
-mutex = threading.Lock()
-
-
 class MatlibProperties(bpy.types.PropertyGroup):
-    @classmethod
-    def load_data(cls):
-        cls.pcoll.materials = {}
-        cls.pcoll.categories = {}
-
-        def category_load(cat):
-            cat.get_info()
-            cls.pcoll.categories[cat.id] = cat
-
-        def material_load(mat):
-            for render in mat.renders:
-                render.get_info()
-                render.get_thumbnail()
-                render.thumbnail_load(cls.pcoll)
-
-            for package in mat.packages:
-                package.get_info()
-
-            cls.pcoll.materials[mat.id] = mat
-
-        def load():
-            with futures.ThreadPoolExecutor() as executor:
-                # getting cached materials
-                materials = {mat.id: mat for mat in matlib.Material.get_materials_cache()}
-                categories = {mat.category.id: mat.category for mat in materials.values()}
-
-                category_loaders = [executor.submit(category_load, cat)
-                                    for cat in categories.values()]
-                for _ in futures.as_completed(category_loaders):
-                    pass
-
-                for mat in materials.values():
-                    mat.category.get_info()
-
-                material_loaders = [executor.submit(material_load, mat)
-                                    for mat in materials.values()]
-                for _ in futures.as_completed(material_loaders):
-                    pass
-
-                # getting and syncing with online materials
-                online_materials = {mat.id: mat for mat in matlib.Material.get_materials()}
-                new_material_ids = online_materials.keys() - materials.keys()
-                new_materials = {mat_id: online_materials[mat_id] for mat_id in new_material_ids}
-
-                new_categories = {}
-                for mat in new_materials.values():
-                    cat = mat.category
-                    if cat.id not in categories and cat.id not in new_categories:
-                        new_categories[cat.id] = cat
-
-                category_loaders = [executor.submit(category_load, cat)
-                                    for cat in new_categories.values()]
-                for _ in futures.as_completed(category_loaders):
-                    pass
-
-                for mat in new_materials.values():
-                    mat.category.get_info()
-
-                material_loaders = [executor.submit(material_load, mat)
-                                    for mat in new_materials.values()]
-                for _ in futures.as_completed(material_loaders):
-                    pass
-
-        cls.load_thread = threading.Thread(target=load)
-        cls.load_thread.start()
-
     def get_materials(self) -> dict:
         materials = {}
         search_str = self.search.strip().lower()
 
         # converting to list in thread safe purposes
-        materials_list = list(self.pcoll.materials.values())
+        materials_list = list(manager.materials.values())
 
         for mat in materials_list:
             if search_str not in mat.title.lower():
@@ -129,13 +56,13 @@ class MatlibProperties(bpy.types.PropertyGroup):
 
     def get_categories_prop(self, context):
         categories = []
-        if self.pcoll.categories is None:
+        if manager.categories is None:
             return categories
 
         categories += [('ALL', "All Categories", "Show materials for all categories")]
 
         # converting to list in thread safe purposes
-        categories_list = list(self.pcoll.categories.values())
+        categories_list = list(manager.categories.values())
 
         categories += ((cat.id, cat.title, f"Show materials with category {cat.title}")
                        for cat in sorted(categories_list))
@@ -205,7 +132,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
 
     @property
     def material(self):
-        return self.pcoll.materials.get(self.material_id)
+        return manager.materials.get(self.material_id)
 
     @property
     def package(self):
@@ -214,21 +141,6 @@ class MatlibProperties(bpy.types.PropertyGroup):
             return None
 
         return next((p for p in mat.packages if p.id == self.package_id), None)
-
-    @classmethod
-    def register(cls):
-        import bpy.utils.previews
-        cls.pcoll = bpy.utils.previews.new()
-        cls.pcoll.materials = None
-        cls.pcoll.categories = None
-
-        # threading fields
-        cls.load_thread = None
-        cls.status = ""
-
-    @classmethod
-    def unregister(cls):
-        bpy.utils.previews.remove(cls.pcoll)
 
 
 class WindowManagerProperties(HdUSDProperties):

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -108,7 +108,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
             return []
 
         return [(p.id, f"{p.label} ({p.size})", "")
-                for p in mat.packages]
+                for p in sorted(mat.packages)]
 
     def update_filter(self, context):
         materials = self.get_materials()

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -148,12 +148,12 @@ class MatlibProperties(bpy.types.PropertyGroup):
             return packages
 
         for i, p in enumerate(sorted(mat.packages)):
-            description = f"Package: {p.label} ({p.size})\nAuthor: {p.author}"
+            description = f"Package: {p.label} ({p.size_str})\nAuthor: {p.author}"
             if p.has_file:
                 description += "\nReady to import"
             icon_id = 'RADIOBUT_ON' if p.has_file else 'RADIOBUT_OFF'
 
-            packages.append((p.id, f"{p.label} ({p.size})", description, icon_id, i))
+            packages.append((p.id, f"{p.label} ({p.size_str})", description, icon_id, i))
 
         return packages
 

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -142,7 +142,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
         return categories
 
     def get_packages_prop(self, context):
-        mat = self.pcoll.materials.get(self.material_id)
+        mat = self.material
         if not mat:
             return []
 
@@ -176,6 +176,18 @@ class MatlibProperties(bpy.types.PropertyGroup):
         description="Selected material package",
         items=get_packages_prop,
     )
+
+    @property
+    def material(self):
+        return self.pcoll.materials.get(self.material_id)
+
+    @property
+    def package(self):
+        mat = self.material
+        if not mat:
+            return None
+
+        return next((p for p in mat.packages if p.id == self.package_id), None)
 
     @classmethod
     def register(cls):

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -107,8 +107,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
             if search_str not in mat.title.lower():
                 continue
 
-            if not (mat.category.id == self.category_id or self.category_id == 'ALL' or
-                    (self.category_id == 'NONE' and mat.category.id == '')):
+            if not (mat.category.id == self.category_id or self.category_id == 'ALL'):
                 continue
 
             materials[mat.id] = mat
@@ -116,9 +115,17 @@ class MatlibProperties(bpy.types.PropertyGroup):
         return materials
 
     def get_materials_prop(self, context):
-        return [(mat.id, mat.title, mat.full_description,
-                 mat.renders[0].thumbnail_icon_id if mat.renders else 'MATERIAL', i)
-                for i, mat in enumerate(self.get_materials().values())]
+        materials = []
+        for i, mat in enumerate(sorted(self.get_materials().values())):
+            description = mat.title
+            if mat.description:
+                description += f"\n{mat.description}"
+            description += f"\nCategory: {mat.category.title}\nAuthor: {mat.author}"
+
+            icon_id = mat.renders[0].thumbnail_icon_id if mat.renders else 'MATERIAL'
+            materials.append((mat.id, mat.title, description, icon_id, i))
+
+        return materials
 
     def get_categories_prop(self, context):
         categories = []
@@ -126,14 +133,12 @@ class MatlibProperties(bpy.types.PropertyGroup):
             return categories
 
         categories += [('ALL', "All Categories", "Show materials for all categories")]
-        if '' in self.pcoll.categories:
-            categories += [('NONE', "No Category", "Show materials without category")]
 
         # converting to list in thread safe purposes
         categories_list = list(self.pcoll.categories.values())
 
         categories += ((cat.id, cat.title, f"Show materials with category {cat.title}")
-                       for cat in categories_list)
+                       for cat in sorted(categories_list))
         return categories
 
     def get_packages_prop(self, context):

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -37,7 +37,7 @@ class MatlibProperties(bpy.types.PropertyGroup):
             render.get_thumbnail()
             render.thumbnail_load(self.pcoll)
 
-        with futures.ThreadPoolExecutor(max_workers=5) as executor:
+        with futures.ThreadPoolExecutor() as executor:
             fs = {executor.submit(render_load, mat): mat for mat in materials}
             for f in futures.as_completed(fs):
                 mat = fs[f]

--- a/src/hdusd/properties/matlib.py
+++ b/src/hdusd/properties/matlib.py
@@ -157,24 +157,34 @@ class MatlibProperties(bpy.types.PropertyGroup):
 
         return packages
 
+    def update_material(self, context):
+        mat = self.material
+        if mat:
+            self.package_id = min(mat.packages).id
+
     def update_category(self, context):
         materials = self.get_materials()
-        if materials:
-            mat = min(materials.values())
-            self.material_id = mat.id
-            self.package_id = min(mat.packages).id
+        if not materials:
+            return
+
+        mat = min(materials.values())
+        self.material_id = mat.id
+        self.package_id = min(mat.packages).id
 
     def update_search(self, context):
         materials = self.get_materials()
-        if materials and self.material_id not in materials:
-            mat = min(materials.values())
-            self.material_id = mat.id
-            self.package_id = min(mat.packages).id
+        if not materials or self.material_id in materials:
+            return
+
+        mat = min(materials.values())
+        self.material_id = mat.id
+        self.package_id = min(mat.packages).id
 
     material_id: bpy.props.EnumProperty(
         name="Material",
         description="Select material",
         items=get_materials_prop,
+        update=update_material,
     )
     category_id: bpy.props.EnumProperty(
         name="Category",

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -103,9 +103,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     matlib.HDUSD_MATERIAL_OP_matlib_clear_search,
     matlib.HDUSD_MATLIB_OP_import_material,
     matlib.HDUSD_MATLIB_OP_load_package,
-    matlib.HDUSD_MATLIB_OP_select_package,
     matlib.HDUSD_MATLIB_PT_matlib,
-    matlib.HDUSD_MATLIB_MT_package_menu,
 
     world.HDUSD_WORLD_PT_surface,
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -80,9 +80,8 @@ class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
-        package = matlib_prop.package
+        manager.load_package(matlib_prop.package)
 
-        package.download()
         return {"FINISHED"}
 
 
@@ -99,10 +98,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         layout = self.layout
         matlib_prop = context.window_manager.hdusd.matlib
 
-        # status
-        if not manager.check_load_data():
-            layout.label(text="No materials loaded")
-            return
+        manager.check_load_materials()
 
         # category
         layout.prop(matlib_prop, 'category_id')

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -116,7 +116,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         if matlib_prop.search:
             row.operator(HDUSD_MATERIAL_OP_matlib_clear_search.bl_idname, icon='X')
 
-        if not matlib_prop.get_materials(context):
+        if not matlib_prop.get_materials():
             layout.label(text="No Materials Found")
             return
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -22,6 +22,7 @@ import bpy
 from . import HdUSD_Panel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree
 from ..utils import mx as mx_utils
+from ..utils.matlib import manager
 from .. import config
 
 from ..utils import logging
@@ -99,9 +100,8 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         matlib_prop = context.window_manager.hdusd.matlib
 
         # status
-        if matlib_prop.pcoll.materials is None:
+        if not manager.check_load_data():
             layout.label(text="No materials loaded")
-            matlib_prop.load_data()
             return
 
         # category

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -109,30 +109,27 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
     def draw(self, context):
         layout = self.layout
         matlib_prop = context.window_manager.hdusd.matlib
-        materials = matlib_prop.get_materials()
-        return
 
-        layout.prop(matlib_prop, "category")
+        layout.prop(matlib_prop, "category_id")
         row = layout.row(align=True)
         row.prop(matlib_prop, "search", text="", icon="VIEWZOOM")
         if matlib_prop.search:
             row.operator(HDUSD_MATERIAL_OP_matlib_clear_search.bl_idname, icon='X')
 
-        if not matlib_prop.get_materials():
+        materials = matlib_prop.get_materials()
+        if not materials:
             layout.label(text="No Materials Found")
             return
 
-        layout.template_icon_view(matlib_prop, "material", show_labels=True)
+        layout.template_icon_view(matlib_prop, "material_id", show_labels=True)
 
-        material = matlib_prop.pcoll.materials[matlib_prop.material]
+        material = materials.get(matlib_prop.material_id)
+        if not material:
+            return
+
         if len(material.renders) > 1:
             grid = layout.grid_flow(align=True)
             for i, render in enumerate(material.renders):
-                if render.thumbnail_icon_id is None:
-                    render.get_info()
-                    render.get_thumbnail()
-                    render.thumbnail_load(matlib_prop.pcoll)
-
                 if i % 6 == 0:
                     row = grid.row()
                     row.alignment = "CENTER"
@@ -142,6 +139,8 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         for line in material.full_description.splitlines():
             row = layout.row()
             row.label(text=line)
+
+        return
 
         split = layout.split(factor=0.25)
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -125,12 +125,10 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
         layout.template_icon_view(matlib_prop, "material", show_labels=True)
 
-        renders = matlib_prop.pcoll.materials[matlib_prop.material].renders
-
-        if len(renders) > 1:
+        material = matlib_prop.pcoll.materials[matlib_prop.material]
+        if len(material.renders) > 1:
             grid = layout.grid_flow(align=True)
-            row = None
-            for i, render in enumerate(renders):
+            for i, render in enumerate(material.renders):
                 if render.thumbnail_icon_id is None:
                     render.get_info()
                     render.get_thumbnail()
@@ -142,12 +140,9 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
                 row.template_icon(render.thumbnail_icon_id, scale=5)
 
-        if matlib_prop.pcoll.materials[matlib_prop.material] is not None:
-            material_description = matlib_prop.pcoll.materials[matlib_prop.material].get_description()
-
-            for line in material_description.splitlines():
-                row = layout.row()
-                row.label(text=line)
+        for line in material.full_description.splitlines():
+            row = layout.row()
+            row.label(text=line)
 
         split = layout.split(factor=0.25)
 
@@ -157,7 +152,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
         split = split.split(align=True, factor=0.9)
 
-        packages = matlib_prop.pcoll.materials[matlib_prop.material].packages
+        packages = material.packages
         package = None
 
         if matlib_prop.package_id:
@@ -181,7 +176,6 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
                              text=f"{package.label} ({package.size})" if package is not None else None,
                              icon='DOCUMENTS')
 
-        material = matlib_prop.pcoll.materials[matlib_prop.material]
         package = next(package for package in material.packages
                        if package.id == matlib_prop.package_id)
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -165,9 +165,12 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         col.label(text=f"Author: {mat.author}")
 
         # packages
+        package = next((p for p in mat.packages if p.id == matlib_prop.package_id), None)
+        if not package:
+            return
+
         row = layout.row(align=True)
         row.prop(matlib_prop, 'package_id', icon='DOCUMENTS')
-        package = next(p for p in mat.packages if p.id == matlib_prop.package_id)
         row.operator(HDUSD_MATLIB_OP_load_package.bl_idname, text="",
                      icon='FILE_REFRESH' if package.has_file else 'IMPORT')
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -50,11 +50,9 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
         package = next(package for package in material.packages
                        if package.id == matlib_prop.package_id)
 
-        if package.file_path is None or not package.file_path.is_file():
-            package.get_info(use_cache=True)
-            package.get_file(use_cache=True)
-
-        mtlx_file = package.unzip(use_cache=True)
+        package.get_info()
+        package.get_file()
+        mtlx_file = package.unzip()
 
         # getting/creating MxNodeTree
         bl_material = context.material
@@ -92,10 +90,9 @@ class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
         package = next(package for package in material.packages
                        if package.id == matlib_prop.package_id)
 
-        package.get_info(use_cache=False)
-        package.get_file(use_cache=False)
-
-        package.unzip(use_cache=False)
+        package.get_info(False)
+        package.get_file(False)
+        package.unzip(False)
 
         return {"FINISHED"}
 
@@ -179,7 +176,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         package = next(package for package in material.packages
                        if package.id == matlib_prop.package_id)
 
-        icon = "IMPORT" if package.file_path is None else "FILE_REFRESH"
+        icon = "FILE_REFRESH" if package.has_file else "IMPORT"
 
         row = split.row()
         row.alignment = 'RIGHT'

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -45,13 +45,8 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
-        material = matlib_prop.pcoll.materials[matlib_prop.material]
+        package = matlib_prop.package
 
-        # unzipping package
-        package = next(package for package in material.packages
-                       if package.id == matlib_prop.package_id)
-
-        package.get_info()
         package.get_file()
         mtlx_file = package.unzip()
 
@@ -79,17 +74,13 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
 
 
 class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
-    """Reload Material"""
+    """Load / Reload material package"""
     bl_idname = "hdusd.matlib_load_package"
-    bl_label = "Load package"
+    bl_label = "Load / Reload Package"
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
-        material = matlib_prop.pcoll.materials[matlib_prop.material]
-
-        # unzipping package
-        package = next(package for package in material.packages
-                       if package.id == matlib_prop.package_id)
+        package = matlib_prop.package
 
         package.get_info(False)
         package.get_file(False)
@@ -133,9 +124,11 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
             col.label(text="No materials found")
             return
 
+        col.label(text=f"Found {len(materials)} materials")
+
         col.template_icon_view(matlib_prop, 'material_id', show_labels=True)
 
-        mat = materials.get(matlib_prop.material_id)
+        mat = matlib_prop.material
         if not mat:
             return
 
@@ -165,7 +158,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         col.label(text=f"Author: {mat.author}")
 
         # packages
-        package = next((p for p in mat.packages if p.id == matlib_prop.package_id), None)
+        package = matlib_prop.package
         if not package:
             return
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -109,6 +109,8 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
     def draw(self, context):
         layout = self.layout
         matlib_prop = context.window_manager.hdusd.matlib
+        materials = matlib_prop.get_materials()
+        return
 
         layout.prop(matlib_prop, "category")
         row = layout.row(align=True)

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -73,9 +73,9 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
 
 
 class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
-    """Load material package"""
+    """Download material package"""
     bl_idname = "hdusd.matlib_load_package"
-    bl_label = "Load Package"
+    bl_label = "Download Package"
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
@@ -160,14 +160,16 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         if not package:
             return
 
-        row = layout.row(align=True)
-        row.prop(matlib_prop, 'package_id', icon='DOCUMENTS')
-        col1 = row.column()
-        col1.enabled = not package.has_file
-        col1.operator(HDUSD_MATLIB_OP_load_package.bl_idname, text="", icon='IMPORT')
+        layout.prop(matlib_prop, 'package_id', icon='DOCUMENTS')
 
-        # import button
         row = layout.row()
-        row.enabled = bool(context.material) and package.has_file
-        row.operator(HDUSD_MATLIB_OP_import_material.bl_idname, text="Import Material Package",
-                     icon='IMPORT')
+        if package.has_file:
+            row.operator(HDUSD_MATLIB_OP_import_material.bl_idname, icon='IMPORT')
+        else:
+            if package.size_load is None:
+                row.operator(HDUSD_MATLIB_OP_load_package.bl_idname, icon='IMPORT')
+            else:
+                percent = min(100, int(package.size_load * 100 / package.size))
+                row.operator(HDUSD_MATLIB_OP_load_package.bl_idname, icon='IMPORT',
+                             text=f"Downloading Package...{percent}%")
+                row.enabled = False

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -39,15 +39,14 @@ class HDUSD_MATERIAL_OP_matlib_clear_search(bpy.types.Operator):
 
 
 class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
-    """Import Material"""
+    """Import Material Package to material"""
     bl_idname = "hdusd.matlib_import_material"
-    bl_label = "Import Material"
+    bl_label = "Import Material Package"
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
         package = matlib_prop.package
 
-        package.get_file()
         mtlx_file = package.unzip()
 
         # getting/creating MxNodeTree
@@ -74,18 +73,15 @@ class HDUSD_MATLIB_OP_import_material(HdUSD_Operator):
 
 
 class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
-    """Load / Reload material package"""
+    """Load material package"""
     bl_idname = "hdusd.matlib_load_package"
-    bl_label = "Load / Reload Package"
+    bl_label = "Load Package"
 
     def execute(self, context):
         matlib_prop = context.window_manager.hdusd.matlib
         package = matlib_prop.package
 
-        package.get_info(False)
-        package.get_file(False)
-        package.unzip(False)
-
+        package.get_file()
         return {"FINISHED"}
 
 
@@ -124,7 +120,9 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
             col.label(text="No materials found")
             return
 
-        col.label(text=f"Found {len(materials)} materials")
+        row = col.row()
+        row.alignment = 'RIGHT'
+        row.label(text=f"{len(materials)} materials")
 
         col.template_icon_view(matlib_prop, 'material_id', show_labels=True)
 
@@ -164,11 +162,12 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
         row = layout.row(align=True)
         row.prop(matlib_prop, 'package_id', icon='DOCUMENTS')
-        row.operator(HDUSD_MATLIB_OP_load_package.bl_idname, text="",
-                     icon='FILE_REFRESH' if package.has_file else 'IMPORT')
+        col1 = row.column()
+        col1.enabled = not package.has_file
+        col1.operator(HDUSD_MATLIB_OP_load_package.bl_idname, text="", icon='IMPORT')
 
         # import button
         row = layout.row()
-        row.enabled = bool(context.material)
+        row.enabled = bool(context.material) and package.has_file
         row.operator(HDUSD_MATLIB_OP_import_material.bl_idname, text="Import Material Package",
                      icon='IMPORT')

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -81,7 +81,7 @@ class HDUSD_MATLIB_OP_load_package(HdUSD_Operator):
         matlib_prop = context.window_manager.hdusd.matlib
         package = matlib_prop.package
 
-        package.get_file()
+        package.download()
         return {"FINISHED"}
 
 

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -110,7 +110,13 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         layout = self.layout
         matlib_prop = context.window_manager.hdusd.matlib
 
+        if matlib_prop.pcoll.materials is None:
+            layout.label(text="No materials loaded")
+            matlib_prop.load_data()
+            return
+
         layout.prop(matlib_prop, "category_id")
+
         row = layout.row(align=True)
         row.prop(matlib_prop, "search", text="", icon="VIEWZOOM")
         if matlib_prop.search:
@@ -118,7 +124,7 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
         materials = matlib_prop.get_materials()
         if not materials:
-            layout.label(text="No Materials Found")
+            layout.label(text="No materials found")
             return
 
         layout.template_icon_view(matlib_prop, "material_id", show_labels=True)

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import traceback
+import textwrap
 
 import MaterialX as mx
 
@@ -148,14 +149,20 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
 
                 row.template_icon(render.thumbnail_icon_id, scale=5)
 
-        # material description
+        # material title
         row = col.row()
         row.alignment = 'CENTER'
         row.label(text=mat.title)
 
+        # material description
+        col = layout.column(align=True)
         if mat.description:
-            col.label(text=mat.description)
+            for line in textwrap.wrap(mat.description, 60):
+                col.label(text=line)
+
+        col = layout.column(align=True)
         col.label(text=f"Category: {mat.category.title}")
+        col.label(text=f"Author: {mat.author}")
 
         # packages
         row = layout.row(align=True)
@@ -164,40 +171,8 @@ class HDUSD_MATLIB_PT_matlib(HdUSD_Panel):
         row.operator(HDUSD_MATLIB_OP_load_package.bl_idname, text="",
                      icon='FILE_REFRESH' if package.has_file else 'IMPORT')
 
+        # import button
         row = layout.row()
         row.enabled = bool(context.material)
         row.operator(HDUSD_MATLIB_OP_import_material.bl_idname, text="Import Material Package",
                      icon='IMPORT')
-
-
-class HDUSD_MATLIB_MT_package_menu(bpy.types.Menu):
-    bl_label = "Package"
-    bl_idname = "HDUSD_MATLIB_MT_package_menu"
-
-    def draw(self, context):
-        layout = self.layout
-        op_idname = HDUSD_MATLIB_OP_select_package.bl_idname
-
-        matlib_prop = context.window_manager.hdusd.matlib
-        packages = matlib_prop.pcoll.materials[matlib_prop.material].packages
-
-        for package in packages:
-            if package.file is None:
-                package.get_info()
-
-            row = layout.row()
-            op = row.operator(op_idname, text=f"{package.label} ({package.size})",
-                              icon='DOCUMENTS')
-            op.matlib_package_id = package.id
-
-
-class HDUSD_MATLIB_OP_select_package(bpy.types.Operator):
-    """Select Package"""
-    bl_label = "Select Package"
-    bl_idname = "hdusd.matlib_select_package"
-
-    matlib_package_id: bpy.props.StringProperty(default="")
-
-    def execute(self, context):
-        context.window_manager.hdusd.matlib.package_id = self.matlib_package_id
-        return {"FINISHED"}

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -160,6 +160,20 @@ class Package:
         mtlx_file = next(path.glob("**/*.mtlx"))
         return mtlx_file
 
+    @property
+    def size_bytes(self):
+        n, b = self.size.split(" ")
+        size = float(n)
+        if b == "MB":
+            size *= 2 ^ 20
+        elif b == "KB":
+            size *= 2 ^ 10
+
+        return int(size)
+
+    def __lt__(self, other):
+        return self.size_bytes < other.size_bytes
+
 
 @dataclass
 class Category:

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -150,7 +150,7 @@ class Package:
     def __init__(self, id, material):
         self.id = id
         self.material = weakref.ref(material)
-        self.size_load = 0
+        self.size_load = None
         self.load_thread = None
 
     @property
@@ -176,6 +176,8 @@ class Package:
         self.size_str = json_data['size']
 
     def download(self, cache_check=True):
+        self.size_load = 0
+
         def callback(size):
             self.size_load = size
 

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -29,7 +29,6 @@ URL = "https://matlibapi.stvcis.com/api"
 MATLIB_DIR = LIBS_DIR.parent / "matlib"
 
 
-
 def download_file(url, path, cache_check=True):
     if cache_check and path.is_file():
         return path
@@ -56,12 +55,16 @@ def request_json(url, params, path, cache_check=True):
     res_json = response.json()
 
     if path:
-        path.parent.mkdir(parents=True, exist_ok=True)
-        with open(path, 'w') as outfile:
-            json.dump(res_json, outfile)
+        save_json(res_json, path)
 
     log("request_json", "done")
     return res_json
+
+
+def save_json(json_obj, path):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, 'w') as outfile:
+        json.dump(json_obj, outfile)
 
 
 @dataclass(init=False)
@@ -200,6 +203,8 @@ class Material:
         self.packages = []
         for id in mat_json['packages']:
             self.packages.append(Package(id, self))
+
+        save_json(mat_json, self.cache_dir / "info.json")
 
     @property
     def cache_dir(self):

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -203,9 +203,11 @@ class Package:
         n, b = self.size_str.split(" ")
         size = float(n)
         if b == "MB":
-            size *= 2 ** 20
+            size *= 1048576 # 2 ** 20
         elif b == "KB":
-            size *= 2 ** 10
+            size *= 1024    # 2 ** 10
+        elif b == "GB":
+            size *= 2 ** 30
 
         return int(size)
 
@@ -265,7 +267,7 @@ class Material:
         save_json(mat_json, self.cache_dir / "info.json")
 
     def __lt__(self, other):
-        return self.title < other.title
+        return self.title.lower() < other.title.lower()
 
     @property
     def cache_dir(self):

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -38,6 +38,10 @@ def download_file(url, path, cache_check=True):
     path.parent.mkdir(parents=True, exist_ok=True)
     with requests.get(url, stream=True) as response:
         with open(path, 'wb') as f:
+            # for chunk in response.iter_content(chunk_size=8192):
+            #     print(len(chunk))
+            #     f.write(chunk)
+
             shutil.copyfileobj(response.raw, f)
 
     log("download_file", "done")

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -193,6 +193,9 @@ class Category:
 
         self.title = json_data['title']
 
+    def __lt__(self, other):
+        return self.title < other.title
+
 
 @dataclass(init=False)
 class Material:
@@ -223,20 +226,12 @@ class Material:
 
         save_json(mat_json, self.cache_dir / "info.json")
 
+    def __lt__(self, other):
+        return self.title < other.title
+
     @property
     def cache_dir(self):
         return MATLIB_DIR / f"M-{self.id[:8]}"
-
-    @property
-    def full_description(self):
-        text = self.title
-        if self.description:
-            text += f"\n{self.description}"
-        if self.category:
-            text += f"\nCategory: {self.category.title}"
-        text += f"\nAuthor: {self.author}"
-
-        return text
 
     @classmethod
     def get_materials(cls):
@@ -250,7 +245,7 @@ class Material:
 
             for mat_json in res_json['results']:
                 mat = Material(mat_json)
-                if not mat.packages:
+                if not mat.packages or not mat.category.id:
                     continue
 
                 yield mat

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -171,6 +171,9 @@ class Category:
         return MATLIB_DIR
 
     def get_info(self, use_cache=True):
+        if not self.id:
+            return
+
         json_data = request_json(f"{URL}/categories/{self.id}", None,
                                  self.cache_dir / f"C-{self.id[:8]}.json", use_cache)
 
@@ -193,7 +196,7 @@ class Material:
         self.author = mat_json['author']
         self.title = mat_json['title']
         self.description = mat_json['description']
-        self.category = Category(mat_json['category']) if mat_json['category'] else None
+        self.category = Category(mat_json['category'])
         self.status = mat_json['status']
 
         self.renders = []

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -225,27 +225,22 @@ class Material:
         return text
 
     @classmethod
-    def get_materials(cls, limit=10, offset=0):
-        res_json = request_json(f"{URL}/materials", {'limit': limit, 'offset': offset}, None)
-
-        for mat_json in res_json['results']:
-            mat = Material(mat_json)
-            if not mat.packages:
-                continue
-
-            yield mat
-
-    @classmethod
-    def get_all_materials(cls):
+    def get_materials(cls):
         offset = 0
         limit = 500
 
         while True:
-            mat = None
-            for mat in cls.get_materials(limit, offset):
+            res_json = request_json(f"{URL}/materials", {'limit': limit, 'offset': offset}, None)
+
+            count = res_json['count']
+
+            for mat_json in res_json['results']:
+                mat = Material(mat_json)
+                if not mat.packages:
+                    continue
+
                 yield mat
 
-            if not mat:
-                break
-
             offset += limit
+            if offset >= count:
+                break

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -82,11 +82,11 @@ class Render:
 
     @property
     def cache_dir(self):
-        return self.material().cache_dir / f"R-{self.id}"
+        return self.material().cache_dir
 
     def get_info(self, cache_chek=True):
-        json_data = request_json(f"{URL}/renders/{self.id}", None, self.cache_dir / "info.json",
-                                 cache_chek)
+        json_data = request_json(f"{URL}/renders/{self.id}", None,
+                                 self.cache_dir / f"R-{self.id[:8]}.json", cache_chek)
 
         self.author = json_data['author']
         self.image = json_data['image']
@@ -95,12 +95,12 @@ class Render:
         self.thumbnail_url = json_data['thumbnail_url']
 
     def get_image(self, cache_check=True):
-        self.image_path = download_file(self.image_url, self.cache_dir / self.image,
-                                        cache_check)
+        self.image_path = download_file(self.image_url,
+                                        self.cache_dir / self.image, cache_check)
 
     def get_thumbnail(self, cache_check=True):
-        self.thumbnail_path = download_file(self.thumbnail_url, self.cache_dir / self.thumbnail,
-                                            cache_check)
+        self.thumbnail_path = download_file(self.thumbnail_url,
+                                            self.cache_dir / self.thumbnail, cache_check)
 
     def thumbnail_load(self, pcoll):
         thumb = pcoll.load(self.thumbnail, str(self.thumbnail_path), 'IMAGE')
@@ -123,11 +123,15 @@ class Package:
 
     @property
     def cache_dir(self):
-        return self.material().cache_dir / f"P-{self.id}"
+        return self.material().cache_dir / f"P-{self.id[:8]}"
+
+    @property
+    def has_file(self):
+        return bool(self.file_path)
 
     def get_info(self, cache_check=True):
-        json_data = request_json(f"{URL}/packages/{self.id}", None, self.cache_dir / "info.json",
-                                 cache_check)
+        json_data = request_json(f"{URL}/packages/{self.id}", None,
+                                 self.cache_dir / "info.json", cache_check)
 
         self.author = json_data['author']
         self.file = json_data['file']
@@ -136,8 +140,8 @@ class Package:
         self.size = json_data['size']
 
     def get_file(self, cache_check=True):
-        self.file_path = download_file(self.file_url, self.cache_dir / self.file,
-                                       cache_check)
+        self.file_path = download_file(self.file_url,
+                                       self.cache_dir / self.file, cache_check)
 
     def unzip(self, path=None, cache_check=True):
         if not path:
@@ -161,11 +165,11 @@ class Category:
 
     @property
     def cache_dir(self):
-        return MATLIB_DIR / "categories"
+        return MATLIB_DIR
 
     def get_info(self, use_cache=True):
         json_data = request_json(f"{URL}/categories/{self.id}", None,
-                                 self.cache_dir / f"{self.id}.json", use_cache)
+                                 self.cache_dir / f"C-{self.id[:8]}.json", use_cache)
 
         self.title = json_data['title']
 
@@ -199,7 +203,7 @@ class Material:
 
     @property
     def cache_dir(self):
-        return MATLIB_DIR / "materials" / self.id
+        return MATLIB_DIR / f"M-{self.id[:8]}"
 
     @property
     def full_description(self):

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -122,7 +122,6 @@ class Package:
     file: str = field(init=False, default=None)
     file_url: str = field(init=False, default=None)
     size: str = field(init=False, default=None)
-    file_path: Path = field(init=False, default=None)
 
     def __init__(self, id, material):
         self.id = id
@@ -133,8 +132,12 @@ class Package:
         return self.material().cache_dir / f"P-{self.id[:8]}"
 
     @property
+    def file_path(self):
+        return self.cache_dir / self.file
+
+    @property
     def has_file(self):
-        return bool(self.file_path)
+        return self.file_path.is_file()
 
     def get_info(self, cache_check=True):
         json_data = request_json(f"{URL}/packages/{self.id}", None,
@@ -147,8 +150,7 @@ class Package:
         self.size = json_data['size']
 
     def get_file(self, cache_check=True):
-        self.file_path = download_file(self.file_url,
-                                       self.cache_dir / self.file, cache_check)
+        download_file(self.file_url, self.cache_dir / self.file, cache_check)
 
     def unzip(self, path=None, cache_check=True):
         if not path:

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -203,9 +203,9 @@ class Package:
         n, b = self.size_str.split(" ")
         size = float(n)
         if b == "MB":
-            size *= 2 ^ 20
+            size *= 2 ** 20
         elif b == "KB":
-            size *= 2 ^ 10
+            size *= 2 ** 10
 
         return int(size)
 

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import requests
+from concurrent import futures
 from dataclasses import dataclass, field
 import shutil
 from pathlib import Path
@@ -47,7 +48,7 @@ def download_file(url, path, use_cache):
     return path
 
 
-def request_json(url, path, use_cache, params=None):
+def request_json(url, path, params=None, *, use_cache=True):
     log("Requesting json", f"url: {url}, path: {path}, use_cache: {use_cache}, params: {params}")
     if use_cache and path.is_file():
         log("Requesting json", "cached data found")
@@ -87,10 +88,11 @@ class Render:
     thumbnail_url: str = field(init=False, default=None)
     thumbnail_path: Path = field(init=False, default=None)
     thumbnail_icon_id: int = field(init=False, default=None)
+    future: futures.Future = field(init=False, default=None)
 
     def get_info(self, use_cache=True):
-        json_data = request_json(f"{URL}/renders/{self.id}", (MATLIB_DIR / self.id).with_suffix(".json"),
-                             use_cache)
+        json_data = request_json(f"{URL}/renders/{self.id}",
+                                 (MATLIB_DIR / self.id).with_suffix(".json"), use_cache)
 
         self.author = json_data['author']
         self.image = json_data['image']
@@ -154,7 +156,8 @@ class Category:
     title: str = field(init=False, default=None)
 
     def get_info(self, use_cache=True):
-        json_data = request_json(f"{URL}/categories/{self.id}", MATLIB_DIR / self.id / "Category.json",
+        json_data = request_json(f"{URL}/categories/{self.id}",
+                                 MATLIB_DIR / "categories/"Category.json",
                              use_cache)
 
         self.title = json_data['title']

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -258,3 +258,11 @@ class Material:
             offset += limit
             if offset >= count:
                 break
+
+    @classmethod
+    def get_materials_cache(cls):
+        for f in MATLIB_DIR.glob("M-*/info.json"):
+            with open(f) as json_file:
+                mat_json = json.load(json_file)
+
+            yield Material(mat_json)


### PR DESCRIPTION
### PURPOSE
Matlib implementation is initial and was made in one thread, therefore it is slow and freezes blender.

### EFFECT OF CHANGE
1. Improved speed of initial loading Material Libarary without freezing blender.
2. Improved UI for Material Libarary.
3. Implemented package downloading with downloading status and without freezing blender.
4. Made list of materials to be sorted by name and packages sorted by size.

### TECHNICAL STEPS
1. Initial loading of materials is made in separate thread with ThreadPoolExecutor usage for parallel material info loading. 
2. Improved matlib cache structure. Made initial matlib loading firstly look into cache, secondly sync with server.
3. Improved matlib UI, made code improvements and optimizations.
4. Implemented package loading in separate thread with showing loading status in UI.

### NOTES FOR REVIEWERS
Some cases aren't implemented yet like:
- errors handling during downloading (lost connection), 
- stop matlib loading when blender is closing,
- showing syncing status.
Propose to do this in separate task.