### PR TITLE
RPRBLND-1950: KeyError: 'BSDF' with USD_Hydra

### DIFF
--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -311,6 +311,7 @@ class ShaderNodeBsdfDiffuse(NodeParser):
         roughness = self.get_input_value('Roughness')
         normal = self.get_input_link('Normal')
 
+        # Also tried burley_diffuse_bsdf and oren_nayar_diffuse_bsdf here, but Blender crashes with them
         # CREATING STANDARD SURFACE
         result = self.create_node('standard_surface', 'surfaceshader', {
             'base_color': color,

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -311,9 +311,10 @@ class ShaderNodeBsdfDiffuse(NodeParser):
         roughness = self.get_input_value('Roughness')
         normal = self.get_input_link('Normal')
 
-        result = self.create_node('diffuse_brdf', 'BSDF', {
-            'color': color,
-            'roughness': roughness,
+        # CREATING STANDARD SURFACE
+        result = self.create_node('standard_surface', 'surfaceshader', {
+            'base_color': color,
+            'diffuse_roughness': 1.0 - roughness,
             'normal': normal,
         })
 


### PR DESCRIPTION
### PURPOSE
Fix not working Diffuse BSDF node

### EFFECT OF CHANGE
Enable support of Diffuse BSDF node.

### TECHNICAL STEPS
- Changed created node from diffuse_brdf to standard_surface
- Adjusted inputs values
