### PR TITLE
fix_RPRBLND-1969: Error: Image 'roughness.png' does not have any image data

### DIFF
--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -43,6 +43,7 @@ def cache_image_file(image: bpy.types.Image, cache_check=True):
     if cache_check and image.source != 'GENERATED' and temp_path.is_file():
         return temp_path
 
+    image_source = image.source
     image.filepath_raw = str(temp_path)
     image.file_format = BLENDER_DEFAULT_FORMAT
 
@@ -51,6 +52,7 @@ def cache_image_file(image: bpy.types.Image, cache_check=True):
     finally:
         image.filepath_raw = old_filepath
         image.file_format = old_file_format
+        image.source = image_source
 
     return temp_path
 


### PR DESCRIPTION
### PURPOSE
Investigated an issue with 'GENERATED' source images while caching. The image source is being changed from 'GENERATED' to 'FILE'.

### EFFECT OF CHANGE
Scene with 'GENERATED' source images renders as expected. 

### TECHNICAL STEPS
Set back initial image.source after caching.
