### PR TITLE
RPRBLND-1370: Reroute nodes

### DIFF
--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -66,6 +66,10 @@ node_categories = [
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_VECTOR', "Vector", items=[
         NodeItem('ShaderNodeNormalMap'),
     ], ),
+    HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_LAYOUT', "Layout", items=[
+        NodeItem('NodeReroute'),
+        NodeItem('NodeFrame'),
+    ], ),
 ]
 
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -18,6 +18,7 @@ import bpy
 import MaterialX as mx
 
 from ..utils import mx as mx_utils
+from ..utils import pass_node_reroute
 from ..mx_nodes.nodes import get_mx_node_cls 
 from . import log
 
@@ -337,24 +338,18 @@ class NodeParser:
         """Returns linked parsed node or None if nothing is linked or not link is not valid"""
 
         socket_in = self.node.inputs[in_key]
-        if not socket_in.is_linked:
+        if not socket_in.links:
             return None
 
         link = socket_in.links[0]
 
-        # # check if linked is correct
         if not link.is_valid:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
             return None
 
-        node = link.from_node
-        while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs[0].links:
-                return None
-
-            link = node.inputs[0].links[0]
-            if link.is_valid:
-                node = link.from_node
+        link = pass_node_reroute(link)
+        if not link:
+            return None
 
         return self._export_node(link.from_node, link.from_socket.identifier)
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -347,6 +347,15 @@ class NodeParser:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
             return None
 
+        if isinstance(self.node, bpy.types.NodeReroute):
+            return None
+
+        while isinstance(link.from_node, bpy.types.NodeReroute):
+            try:
+                link = link.from_node.inputs[0].links[0]
+            except:
+                break
+
         return self._export_node(link.from_node, link.from_socket.identifier)
 
     def get_input_value(self, in_key):

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -347,14 +347,14 @@ class NodeParser:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
             return None
 
-        if isinstance(self.node, bpy.types.NodeReroute):
-            return None
+        node = link.from_node
+        while isinstance(node, bpy.types.NodeReroute):
+            if not node.inputs or not node.inputs[0].links:
+                return None
 
-        while isinstance(link.from_node, bpy.types.NodeReroute):
-            try:
-                link = link.from_node.inputs[0].links[0]
-            except:
-                break
+            link = node.inputs[0].links[0]
+            if link.is_valid:
+                node = link.from_node
 
         return self._export_node(link.from_node, link.from_socket.identifier)
 

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -349,7 +349,7 @@ class NodeParser:
 
         node = link.from_node
         while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs or not node.inputs[0].links:
+            if not node.inputs[0].links:
                 return None
 
             link = node.inputs[0].links[0]

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -259,6 +259,15 @@ class NodeParser:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.world)
             return None
 
+        node = link.from_node
+        while isinstance(node, bpy.types.NodeReroute):
+            if not node.inputs[0].links:
+                return None
+
+            link = node.inputs[0].links[0]
+            if link.is_valid:
+                node = link.from_node
+
         return self._export_node(link.from_node, link.from_socket.identifier)
 
     def get_input_value(self, in_key):

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -16,6 +16,8 @@ import math
 
 import bpy
 
+from ...utils import pass_node_reroute
+
 from . import log
 
 
@@ -249,7 +251,7 @@ class NodeParser:
         """Returns linked parsed node or None if nothing is linked or not link is not valid"""
 
         socket_in = self.node.inputs[in_key]
-        if not socket_in.is_linked:
+        if not socket_in.links:
             return None
 
         link = socket_in.links[0]
@@ -259,14 +261,9 @@ class NodeParser:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.world)
             return None
 
-        node = link.from_node
-        while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs[0].links:
-                return None
-
-            link = node.inputs[0].links[0]
-            if link.is_valid:
-                node = link.from_node
+        link = pass_node_reroute(link)
+        if not link:
+            return None
 
         return self._export_node(link.from_node, link.from_socket.identifier)
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -326,6 +326,12 @@ class MxNode(bpy.types.ShaderNode):
             return None
 
         link = socket_in.links[0]
+        while isinstance(link.from_node, bpy.types.NodeReroute):
+            try:
+                link = link.from_node.inputs[0].links[0]
+            except:
+                break
+
         if not link.is_valid:
             log.error("Invalid link found", link, socket_in, self)
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -179,8 +179,17 @@ class MxNode(bpy.types.ShaderNode):
                 link = next((link for link in socket_in.links if link.is_valid), None)
                 if not link:
                     continue
-
                 node = link.from_node
+                while isinstance(node, bpy.types.NodeReroute):
+                    if not node.inputs[0].links:
+                        break
+
+                    link = node.inputs[0].links[0]
+                    if link.is_valid:
+                        node = link.from_node
+
+                if isinstance(node, bpy.types.NodeReroute):
+                    continue
 
                 split = layout.split(factor=0.1)
                 split.column()
@@ -332,7 +341,7 @@ class MxNode(bpy.types.ShaderNode):
 
         node = link.from_node
         while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs or not node.inputs[0].links:
+            if not node.inputs[0].links:
                 return None
 
             link = node.inputs[0].links[0]

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -330,14 +330,14 @@ class MxNode(bpy.types.ShaderNode):
         if not link.is_valid:
             log.error("Invalid link found", link, socket_in, self)
 
-        if isinstance(self, bpy.types.NodeReroute):
-            return None
+        node = link.from_node
+        while isinstance(node, bpy.types.NodeReroute):
+            if not node.inputs or not node.inputs[0].links:
+                return None
 
-        while isinstance(link.from_node, bpy.types.NodeReroute):
-            try:
-                link = link.from_node.inputs[0].links[0]
-            except:
-                break
+            link = node.inputs[0].links[0]
+            if link.is_valid:
+                node = link.from_node
 
         return self._compute_node(link.from_node, link.from_socket.name, **kwargs)
 

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -330,7 +330,7 @@ class MxNode(bpy.types.ShaderNode):
         if not link.is_valid:
             log.error("Invalid link found", link, socket_in, self)
 
-        if isinstance(self.node, bpy.types.NodeReroute):
+        if isinstance(self, bpy.types.NodeReroute):
             return None
 
         while isinstance(link.from_node, bpy.types.NodeReroute):

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -206,7 +206,6 @@ class MxNode(bpy.types.ShaderNode):
                 op.current_node_name = self.name
 
                 if socket_in.show_expanded:
-
                     link.from_node.draw_node_view(context, layout)
 
             else:

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -326,14 +326,18 @@ class MxNode(bpy.types.ShaderNode):
             return None
 
         link = socket_in.links[0]
+
+        if not link.is_valid:
+            log.error("Invalid link found", link, socket_in, self)
+
+        if isinstance(self.node, bpy.types.NodeReroute):
+            return None
+
         while isinstance(link.from_node, bpy.types.NodeReroute):
             try:
                 link = link.from_node.inputs[0].links[0]
             except:
                 break
-
-        if not link.is_valid:
-            log.error("Invalid link found", link, socket_in, self)
 
         return self._compute_node(link.from_node, link.from_socket.name, **kwargs)
 

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -40,7 +40,7 @@ def get_node_categories():
                                   for MxNode_cls in category_classes]))
 
     categories.append(MxNodeCategory('HdUSD_MX_NG_' + 'Layout', 'Layout',
-                           items=(NodeItem("NodeReroute"),
-                                  NodeItem("NodeFrame"))))
+                           items=[NodeItem("NodeReroute"),
+                                  NodeItem("NodeFrame")]))
 
     return categories

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -39,7 +39,7 @@ def get_node_categories():
                            items=[NodeItem(MxNode_cls.bl_idname)
                                   for MxNode_cls in category_classes]))
 
-    categories.append(MxNodeCategory('HdUSD_MX_NG_' + 'Layout', 'Layout',
+    categories.append(MxNodeCategory('HdUSD_MX_NG_LAYOUT', 'Layout',
                            items=[NodeItem("NodeReroute"),
                                   NodeItem("NodeFrame")]))
 

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -39,4 +39,7 @@ def get_node_categories():
                            items=[NodeItem(MxNode_cls.bl_idname)
                                   for MxNode_cls in category_classes]))
 
+    categories.append(MxNodeCategory('HdUSD_MX_NG_' + 'Layout', 'Layout',
+                           items=(NodeItem("NodeReroute"),)))
+
     return categories

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -40,6 +40,7 @@ def get_node_categories():
                                   for MxNode_cls in category_classes]))
 
     categories.append(MxNodeCategory('HdUSD_MX_NG_' + 'Layout', 'Layout',
-                           items=(NodeItem("NodeReroute"),)))
+                           items=(NodeItem("NodeReroute"),
+                                  NodeItem("NodeFrame"))))
 
     return categories

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -444,8 +444,15 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         layout.separator()
 
         node = link.from_node
-        if not isinstance(node, bpy.types.NodeReroute):
-            node.draw_node_view(context, layout)
+        while isinstance(node, bpy.types.NodeReroute):
+            if not node.inputs[0].links:
+                return None
+
+            link = node.inputs[0].links[0]
+            if link.is_valid:
+                node = link.from_node
+
+        node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
@@ -489,8 +496,15 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         layout.separator()
 
         node = link.from_node
-        if not isinstance(node, bpy.types.NodeReroute):
-            node.draw_node_view(context, layout)
+        while isinstance(node, bpy.types.NodeReroute):
+            if not node.inputs[0].links:
+                return None
+
+            link = node.inputs[0].links[0]
+            if link.is_valid:
+                node = link.from_node
+
+        node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -19,6 +19,7 @@ from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree, NODE_LAYER_SEPARATION_WIDTH
+from ..utils import pass_node_reroute
 
 
 NODE_SHADER_CATEGORIES = set(['PBR', 'RPR Shaders'])
@@ -443,16 +444,11 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
 
         layout.separator()
 
-        node = link.from_node
-        while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs[0].links:
-                return
+        link = pass_node_reroute(link)
+        if not link:
+            return
 
-            link = node.inputs[0].links[0]
-            if link.is_valid:
-                node = link.from_node
-
-        node.draw_node_view(context, layout)
+        link.from_node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
@@ -495,16 +491,11 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
 
         layout.separator()
 
-        node = link.from_node
-        while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs[0].links:
-                return
+        link = pass_node_reroute(link)
+        if not link:
+            return
 
-            link = node.inputs[0].links[0]
-            if link.is_valid:
-                node = link.from_node
-
-        node.draw_node_view(context, layout)
+        link.from_node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -446,7 +446,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         node = link.from_node
         while isinstance(node, bpy.types.NodeReroute):
             if not node.inputs[0].links:
-                return None
+                return
 
             link = node.inputs[0].links[0]
             if link.is_valid:
@@ -498,7 +498,7 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         node = link.from_node
         while isinstance(node, bpy.types.NodeReroute):
             if not node.inputs[0].links:
-                return None
+                return
 
             link = node.inputs[0].links[0]
             if link.is_valid:

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -444,7 +444,8 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         layout.separator()
 
         node = link.from_node
-        node.draw_node_view(context, layout)
+        if not isinstance(node, bpy.types.NodeReroute):
+            node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
@@ -488,7 +489,8 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         layout.separator()
 
         node = link.from_node
-        node.draw_node_view(context, layout)
+        if not isinstance(node, bpy.types.NodeReroute):
+            node.draw_node_view(context, layout)
 
 
 class HDUSD_MATERIAL_PT_output_node(HdUSD_ChildPanel):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -60,13 +60,16 @@ class USDTree(bpy.types.ShaderNodeTree):
         self._is_resetting = True
 
         try:
-            nodes = tuple(node for node in nodes if is_hard or node.use_hard_reset)
+            nodes = tuple(node for node in nodes if not isinstance(node, bpy.types.NodeReroute)
+                          and (is_hard or node.use_hard_reset))
 
             for node in nodes:
-                node.free()
+                if not isinstance(node, bpy.types.NodeReroute):
+                    node.free()
 
             for node in nodes:
-                node.final_compute()
+                if not isinstance(node, bpy.types.NodeReroute):
+                    node.final_compute()
 
         finally:
             self._is_resetting = False
@@ -86,7 +89,8 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            node.depsgraph_update(depsgraph)
+            if not isinstance(node, bpy.types.NodeReroute):
+                node.depsgraph_update(depsgraph)
 
     def frame_change(self, depsgraph):
         if self._is_resetting:
@@ -100,7 +104,8 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            node.material_update(depsgraph)
+            if not isinstance(node, bpy.types.NodeReroute):
+                node.material_update(depsgraph)
 
     def no_update_call(self, op, *args, **kwargs):
         """This function prevents call of self.update() during calling our function"""

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -64,12 +64,10 @@ class USDTree(bpy.types.ShaderNodeTree):
                           and (is_hard or node.use_hard_reset))
 
             for node in nodes:
-                if not isinstance(node, bpy.types.NodeReroute):
-                    node.free()
+                node.free()
 
             for node in nodes:
-                if not isinstance(node, bpy.types.NodeReroute):
-                    node.final_compute()
+                node.final_compute()
 
         finally:
             self._is_resetting = False

--- a/src/hdusd/usd_nodes/nodes/__init__.py
+++ b/src/hdusd/usd_nodes/nodes/__init__.py
@@ -49,6 +49,10 @@ node_categories = [
     USDNodeCategory('HdUSD_USD_TRANSFORMATIONS', 'Transformations', items=[
         NodeItem('usd.TransformNode'),
     ]),
+    USDNodeCategory('HdUSD_USD_LAYOUT', 'Layout', items=[
+        NodeItem('NodeReroute'),
+        NodeItem('NodeFrame'),
+    ]),
 ]
 
 # nodes to register

--- a/src/hdusd/usd_nodes/nodes/base_node.py
+++ b/src/hdusd/usd_nodes/nodes/base_node.py
@@ -108,7 +108,7 @@ class USDNode(bpy.types.Node):
 
         node = link.from_node
         while isinstance(node, bpy.types.NodeReroute):
-            if not node.inputs or not node.inputs[0].links:
+            if not node.inputs[0].links:
                 return None
 
             link = node.inputs[0].links[0]

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -120,3 +120,15 @@ def title_str(str):
 
 def code_str(str):
     return str.replace(' ', '_').replace('.', '_')
+
+
+def pass_node_reroute(link):
+    while isinstance(link.from_node, bpy.types.NodeReroute):
+        if not link.from_node.inputs[0].links:
+            return None
+
+        link = link.from_node.inputs[0].links[0]
+        if not link.is_valid:
+            return None
+
+    return link

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -128,7 +128,5 @@ def pass_node_reroute(link):
             return None
 
         link = link.from_node.inputs[0].links[0]
-        if not link.is_valid:
-            return None
 
-    return link
+    return link if link.is_valid else None


### PR DESCRIPTION
### PURPOSE
Add Reroute nodes to MaterialX, Shader/World Editor, USD Editor.
Optionally add Frame node.

### EFFECT OF CHANGE
Added Layout node category to MaterialX, Shader Editor, USD Editor.
Added Reroute and Frame nodes to MaterialX, Shader Editor, USD Editor.

### TECHNICAL STEPS
Registered new category Layout in USD, MaterialX, Shader Editor.
Changed get_input_link method so it skips all NodeReroute objects. It's has done in MxNode, NodeParser, USDNode.
In HDUSD_MATERIAL_PT_material_settings_surface, HDUSD_MATERIAL_PT_material_settings_displacement, changed draw method so it skips all NodeReroute objects.
Changed _reset_next method so it skips all NodeReroute objects in USDNode.
