### PR TITLE
RPRBLND-1947: Improve log warnings in Node parser system + Logging implementation improvement

### DIFF
--- a/src/hdusd/.gitignore
+++ b/src/hdusd/.gitignore
@@ -1,3 +1,3 @@
-/*.log
+/*.log*
 /configdev.py
 

--- a/src/hdusd/__init__.py
+++ b/src/hdusd/__init__.py
@@ -32,7 +32,7 @@ from . import config
 from .utils import logging
 
 
-log = logging.Log(tag='init')
+log = logging.Log('init')
 log.info(f"Loading USD Hydra addon version={bl_info['version']}, build={version_build}")
 
 

--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -23,7 +23,7 @@ from nodeitems_builtins import (
 )
 
 from ..utils import logging
-log = logging.Log("bl_nodes")
+log = logging.LogOnce("bl_nodes")
 
 
 class HdUSD_CompatibleShaderNodeCategory(NodeCategory):
@@ -35,10 +35,6 @@ class HdUSD_CompatibleShaderNodeCategory(NodeCategory):
 
 
 # add nodes here once they are supported
-# TODO support Textures
-# TODO support Vector operations and Bumb/Normal
-# TODO support Converter->Math and other values-operations
-# TODO support reroute
 node_categories = [
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_INPUT', "Input", items=[
         NodeItem('ShaderNodeRGB'),

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -283,7 +283,7 @@ class NodeParser:
         # getting corresponded NodeParser class
         NodeParser_cls = self.get_node_parser_cls(node.bl_idname)
         if not NodeParser_cls:
-            log.warn("Ignoring unsupported node", node, self.material)
+            log.warn(f"Ignoring unsupported node {node.bl_idname}", node, self.material)
             self.cached_nodes[(node.name, out_key)] = None
             return None
 

--- a/src/hdusd/bl_nodes/nodes/__init__.py
+++ b/src/hdusd/bl_nodes/nodes/__init__.py
@@ -12,8 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from ...utils import logging
-log = logging.Log("bl_nodes.nodes")
+from .. import log
 
 from .input import *
 from .output import *

--- a/src/hdusd/bl_nodes/nodes/input.py
+++ b/src/hdusd/bl_nodes/nodes/input.py
@@ -12,10 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-import os
-
 from ..node_parser import NodeParser
-from . import log
 
 
 class ShaderNodeValue(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 #********************************************************************
 from ..node_parser import NodeParser, Id
-from . import log
 
 
 class ShaderNodeOutputMaterial(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/texture.py
+++ b/src/hdusd/bl_nodes/nodes/texture.py
@@ -12,25 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-import os
-
 from ..node_parser import NodeParser
 from ...utils.image import cache_image_file
-from . import log
 
 
 TEXTURE_ERROR_COLOR = (1.0, 0.0, 1.0)  # following Cycles color for wrong Texture nodes
-
-# image format conversion for packed pixel/generated images
-IMAGE_FORMATS = {
-    'OPEN_EXR_MULTILAYER': ('OPEN_EXR', 'exr'),
-    'OPEN_EXR': ('OPEN_EXR', 'exr'),
-    'HDR': ('HDR', 'hdr'),
-    'TARGA': ('TARGA', 'tga'),
-    'TARGA_RAW': ('TARGA', 'tga'),
-    # TIFF and everything else will be stored as PNG
-}
-DEFAULT_FORMAT = ('PNG', 'png')
 
 
 class ShaderNodeTexImage(NodeParser):

--- a/src/hdusd/bl_nodes/nodes/vector.py
+++ b/src/hdusd/bl_nodes/nodes/vector.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-import os
-
 from ..node_parser import NodeParser
 from . import log
 

--- a/src/hdusd/config.py
+++ b/src/hdusd/config.py
@@ -13,8 +13,11 @@
 # limitations under the License.
 #********************************************************************
 
-log_level_show_min = 'INFO'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'
+# logging
+logging_level = 'INFO'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'
+logging_backups = 5
 
+# other settings
 matlib_enabled = False
 engine_use_preview = True
 

--- a/src/hdusd/config.py
+++ b/src/hdusd/config.py
@@ -12,19 +12,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
-from .utils import logging
 
-logging.limit_log('default', logging.INFO)
+log_level_show_min = 'INFO'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'
 
 matlib_enabled = False
 engine_use_preview = True
 
 try:
-    # configdev.py example for logging setup:
-    # from .utils import logging
-    # logging.limit_log('default', logging.DEBUG)
-    # from . import config
-    # config.<parameter> = True
+    # Trying to load configdev.py if it exist
+    # example for logging setup:
+    #   from . import config
+    #   config.<parameter> = <value>
 
     from . import configdev
 

--- a/src/hdusd/config.py
+++ b/src/hdusd/config.py
@@ -27,7 +27,6 @@ try:
     # config.<parameter> = True
 
     from . import configdev
-    logging.info('Loaded configdev', tag='')
 
 except ImportError:
     pass

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -21,7 +21,7 @@ from .. import config
 from ..utils.stage_cache import CachedStage
 
 from ..utils import logging
-log = logging.Log(tag='engine')
+log = logging.Log('engine')
 
 
 class Engine:

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -27,7 +27,7 @@ from ..utils import usd as usd_utils
 from ..export import object, world
 
 from ..utils import logging
-log = logging.Log(tag='final_engine')
+log = logging.Log('final_engine')
 
 
 class FinalEngine(Engine):

--- a/src/hdusd/engine/preview_engine.py
+++ b/src/hdusd/engine/preview_engine.py
@@ -21,7 +21,7 @@ from .engine import Engine
 from ..export import object, world
 
 from ..utils import logging
-log = logging.Log(tag='preview_engine')
+log = logging.Log('preview_engine')
 
 
 class PreviewEngine(Engine):

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -25,11 +25,10 @@ from pxr import UsdImagingGL
 
 from .engine import Engine
 from ..export import camera, material, object, world
-from .. import utils
 from ..utils import usd as usd_utils
 from ..utils import time_str
 from ..utils import logging
-log = logging.Log(tag='viewport_engine')
+log = logging.Log('viewport_engine')
 
 
 @dataclass(init=False, eq=True)

--- a/src/hdusd/export/camera.py
+++ b/src/hdusd/export/camera.py
@@ -18,10 +18,8 @@ import numpy as np
 from pxr import UsdGeom, Gf, Tf
 import bpy
 
-from . import object
-
 from ..utils import logging
-log = logging.Log(tag='export.camera')
+log = logging.Log('export.camera')
 
 
 # Core has issues with drawing faces in orthographic camera view with big

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -20,7 +20,7 @@ import bpy
 
 
 from ..utils import logging
-log = logging.Log(tag='export.light')
+log = logging.Log('export.light')
 
 
 def get_radiant_power(light: bpy.types.Light):

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -19,7 +19,7 @@ import MaterialX as mx
 
 from .. import utils
 from ..utils import logging
-log = logging.Log(tag='export.material')
+log = logging.Log('export.material')
 
 
 def sdf_name(mat: bpy.types.Material, input_socket_key='Surface'):

--- a/src/hdusd/export/mesh.py
+++ b/src/hdusd/export/mesh.py
@@ -25,7 +25,7 @@ from . import material
 from ..utils import get_data_from_collection
 
 from ..utils import logging
-log = logging.Log(tag='export.mesh')
+log = logging.Log('export.mesh')
 
 
 @dataclass(init=False)

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -21,7 +21,7 @@ import mathutils
 from . import mesh, camera, to_mesh, light, material
 
 from ..utils import logging
-log = logging.Log(tag='export.object')
+log = logging.Log('export.object')
 
 
 SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA', 'EMPTY')

--- a/src/hdusd/export/to_mesh.py
+++ b/src/hdusd/export/to_mesh.py
@@ -22,7 +22,7 @@ import bpy
 from . import mesh
 
 from ..utils import logging
-log = logging.Log(tag='export.to_mesh')
+log = logging.Log('export.to_mesh')
 
 
 def sync(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -24,7 +24,7 @@ from ...utils.image import cache_image_file, cache_image_file_path
 from ...utils import BLENDER_DATA_DIR
 
 from ...utils import logging
-log = logging.Log(tag='export.world')
+log = logging.Log('export.world')
 
 
 OBJ_PRIM_NAME = "World"

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -17,7 +17,7 @@ import bpy
 from ..utils import stage_cache
 
 from ..utils import logging
-log = logging.Log(tag='properties')
+log = logging.Log('properties')
 
 
 class HdUSDProperties(bpy.types.PropertyGroup):

--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -22,7 +22,7 @@ from ..usd_nodes import node_tree as usd_node_tree
 from ..engine.viewport_engine import ViewportEngineScene
 
 from ..utils import logging
-log = logging.Log(tag='export.material')
+log = logging.Log('export.material')
 
 
 class MaterialProperties(HdUSDProperties):

--- a/src/hdusd/ui/matlib.py
+++ b/src/hdusd/ui/matlib.py
@@ -24,7 +24,7 @@ from ..utils import mx as mx_utils
 from .. import config
 
 from ..utils import logging
-log = logging.Log(tag='ui.matlib')
+log = logging.Log('ui.matlib')
 
 
 class HDUSD_MATERIAL_OP_matlib_clear_search(bpy.types.Operator):

--- a/src/hdusd/ui/mx_nodes.py
+++ b/src/hdusd/ui/mx_nodes.py
@@ -25,7 +25,7 @@ from ..mx_nodes.node_tree import MxNodeTree
 from ..utils import mx as mx_utils
 
 from ..utils import logging
-log = logging.Log(tag='ui.mx_nodes')
+log = logging.Log('ui.mx_nodes')
 
 
 class HDUSD_MX_OP_import_file(HdUSD_Operator, ImportHelper):

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -20,7 +20,7 @@ from . import HdUSD_Panel, HdUSD_Operator
 from ..usd_nodes.nodes.base_node import USDNode
 
 from ..utils import logging
-log = logging.Log(tag='ui.usd_list')
+log = logging.Log('ui.usd_list')
 
 
 class HDUSD_OP_usd_list_item_expand(bpy.types.Operator):

--- a/src/hdusd/utils/__init__.py
+++ b/src/hdusd/utils/__init__.py
@@ -43,7 +43,7 @@ LIBS_DIR = PLUGIN_ROOT_DIR.parent.parent / 'libs' if DEBUG_MODE else \
 
 
 from . import logging
-log = logging.Log(tag='utils')
+log = logging.Log('utils')
 
 
 def temp_dir():

--- a/src/hdusd/utils/logging.py
+++ b/src/hdusd/utils/logging.py
@@ -14,7 +14,7 @@
 #********************************************************************
 import sys
 import logging
-from logging import *
+from logging import DEBUG, INFO, WARN, ERROR, CRITICAL
 
 from . import PLUGIN_ROOT_DIR
 
@@ -143,6 +143,45 @@ class Log:
 
     def critical(self, *args):
         critical(*args, tag=self.__tag)
+
+
+class LogOnce(Log):
+    def __init__(self, tag: str = 'default', level: str = 'debug'):
+        super().__init__(tag, level)
+
+        self._cached_logs = set()
+
+    def _cache_check(self, args):
+        s = args[0]
+        if s in self._cached_logs:
+            return False
+
+        self._cached_logs.add(s)
+        return True
+
+    def __call__(self, *args):
+        if self._cache_check(args):
+            super().__call__(*args)
+
+    def info(self, *args):
+        if self._cache_check(args):
+            super().info(*args)
+
+    def debug(self, *args):
+        if self._cache_check(args):
+            super().debug(*args)
+
+    def warn(self, *args):
+        if self._cache_check(args):
+            super().warn(*args)
+
+    def error(self, *args):
+        if self._cache_check(args):
+            super().error(*args)
+
+    def critical(self, *args):
+        if self._cache_check(args):
+            super().critical(*args)
 
 
 def dump_args(func):

--- a/src/hdusd/utils/logging.py
+++ b/src/hdusd/utils/logging.py
@@ -14,7 +14,7 @@
 #********************************************************************
 import sys
 import logging
-from logging import DEBUG, INFO, WARN, ERROR, CRITICAL
+import logging.handlers
 
 from . import PLUGIN_ROOT_DIR
 from .. import config
@@ -24,11 +24,12 @@ FORMAT_STR = "%(asctime)s %(levelname)s %(name)s [%(thread)d]:  %(message)s"
 
 # root logger for the addon
 logger = logging.getLogger('hdusd')
-logger.setLevel(config.log_level_show_min)
+logger.setLevel(config.logging_level)
 
-# TODO: Add creation time to this log name. Could be configurable.
-file_handler = logging.FileHandler(filename=PLUGIN_ROOT_DIR / 'hdusd.log',
-                                   mode='w', encoding='utf-8')
+file_handler = logging.handlers.RotatingFileHandler(PLUGIN_ROOT_DIR / 'hdusd.log',
+                                                    mode='w', encoding='utf-8', delay=True,
+                                                    backupCount=config.logging_backups)
+file_handler.doRollover()
 file_handler.setFormatter(logging.Formatter(FORMAT_STR))
 logger.addHandler(file_handler)
 

--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -19,11 +19,10 @@ from pathlib import Path
 import zipfile
 import json
 
-from .. import config
 from . import LIBS_DIR
 
 from ..utils import logging
-log = logging.Log(tag='utils.matlib')
+log = logging.Log('utils.matlib')
 
 URL = "https://matlibapi.stvcis.com/api"
 MATLIB_DIR = LIBS_DIR.parent / "matlib"

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -23,7 +23,7 @@ from .image import cache_image_file
 from . import LIBS_DIR, title_str, code_str
 
 from . import logging
-log = logging.Log(tag='utils.mx')
+log = logging.Log('utils.mx')
 
 
 MX_LIBS_DIR = LIBS_DIR / "libraries"

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -17,7 +17,7 @@ import bpy
 from pxr import Sdf
 
 from ..utils import logging
-log = logging.Log(tag='usd_collection')
+log = logging.Log('usd_collection')
 
 
 COLLECTION_NAME = "USD NodeTree"

--- a/tools/usdview.py
+++ b/tools/usdview.py
@@ -40,13 +40,11 @@ if OS == 'Windows':
 
     os.environ['PATH'] = path_str + os.environ['PATH']
 
-os.environ['PXR_PLUGINPATH_NAME'] = str(LIBS_DIR / 'plugins')
+os.environ['PXR_PLUGINPATH_NAME'] = str(LIBS_DIR / 'plugin')
 os.environ['RPR'] = str(LIBS_DIR)
-os.environ['MATERIALX_SEARCH_PATH'] = str(LIBS_DIR / 'libraries')
 
-sys.path.append(str(LIBS_DIR / 'usd/python'))
-sys.path.append(str(LIBS_DIR / 'hdrpr/lib/python'))
-sys.path.append(str(LIBS_DIR / 'materialx/python'))
+sys.path.append(str(LIBS_DIR / 'lib/python'))
+sys.path.append(str(LIBS_DIR / 'python'))
 
 from pxr import Usdviewq
 


### PR DESCRIPTION
### PURPOSE
In some places of the code, like in bl_nodes, we want one log warning to be printed once per export.
Also utils/logging.py has low quality code which is hard to maintain.

### EFFECT OF CHANGE
1. Improved log warnings: now some warnings are printed once.
2. Implemented logging backups

### TECHNICAL STEPS
1. Simplified/cleaned up utils/logging.py
2. Implemented class LogOnce. Made it used in bl_nodes.
3. Implemented logging backups.
4. Removed unnecessary `tag=` from log creations
---
5. Additionally fixed paths in tools/usdview.py