### PR TITLE
RPRBLND-1994: Exclude MatX unsupported render qualities fro HdRPR.

### DIFF
--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -205,11 +205,7 @@ class RenderSettings(bpy.types.PropertyGroup):
         description="Render Quality",
         items=(
             ('Northstar', "Full", "Full render quality"),
-            ('Full', "Legacy", "Legacy render quality"),
-            ('HybridPro', "HybridPro", "HybridPro render quality"),
-            ('High', "High", "High render quality"),
-            ('Medium', "Medium", "Medium render quality"),
-            ('Low', "Low", "Low render quality")
+            ('HybridPro', "Hybrid Pro", "Hybrid Pro render quality"),
         ),
         default='Northstar',
     )


### PR DESCRIPTION
### PURPOSE
Only Northstar and HybridPro render qualities support MatX. Other can be excluded.

### EFFECT OF CHANGE
Excluded Legacy, High, Medium, Low render qualities from RPR render delegates, as they aren't support MaterialX.

### TECHNICAL STEPS
Excluded mentioned items from render_quality.