### PR TITLE
RPRBLND-1970: Bug with GL delegate in viewport with Enviroment texture

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -186,7 +186,7 @@ class FinalEngine(Engine):
 
         self._sync(depsgraph)
 
-        usd_utils.set_variant_delegate(self.stage, settings.is_gl_delegate)
+        usd_utils.set_delegate_variant_stage(self.stage, settings.delegate_name)
 
         if self.render_engine.test_break():
             log.warn("Syncing stopped by user termination")

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -14,13 +14,14 @@
 #********************************************************************
 from dataclasses import dataclass
 import textwrap
-
-import bpy
-from bpy_extras import view3d_utils
 import weakref
 import time
 
-from pxr import Usd, UsdGeom, Tf
+import bpy
+import bgl
+from bpy_extras import view3d_utils
+
+from pxr import Usd, UsdGeom, Tf, Gf
 from pxr import UsdImagingGL
 
 from .engine import Engine
@@ -256,10 +257,17 @@ class ViewportEngine(Engine):
         self.renderer.SetRenderViewport((*view_settings.border[0], *view_settings.border[1]))
         self.renderer.SetRendererAov('color')
         self.render_params.renderResolution = (view_settings.width, view_settings.height)
+        # self.render_params.forceRefresh = True
+        # self.render_params.overrideColor = (1, 0, 0, 1)
+
         self.render_engine.bind_display_space_shader(context.scene)
 
         if usd_utils.get_renderer_percent_done(self.renderer) == 0.0:
             self.time_begin = time.perf_counter()
+
+        # bgl.glEnable(bgl.GL_DEPTH_TEST)
+        # bgl.glDepthFunc(bgl.GL_L)
+        # bgl.glClear(bgl.GL_DEPTH_BUFFER_BIT)
 
         try:
             self.renderer.Render(stage.GetPseudoRoot(), self.render_params)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -194,7 +194,7 @@ class ViewportEngine(Engine):
 
         self._sync(context, depsgraph)
 
-        usd_utils.set_variant_delegate(self.stage, self.is_gl_delegate)
+        usd_utils.set_delegate_variant_stage(self.stage, settings.delegate_name)
 
         self.is_synced = True
         log('Finish sync')
@@ -219,7 +219,7 @@ class ViewportEngine(Engine):
         self._sync_update(context, depsgraph)
 
         if gl_delegate_changed:
-            usd_utils.set_variant_delegate(self.cached_stage(), self.is_gl_delegate)
+            usd_utils.set_delegate_variant_stage(self.cached_stage(), settings.delegate_name)
 
         if self.renderer.IsPauseRendererSupported():
             self.renderer.ResumeRenderer()

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -128,11 +128,10 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
         color_attr.Set(tuple(power))
 
     else:
-        usd_utils.add_delegate_variants(obj_prim,
-            {
-                'GL': lambda: color_attr.Set(tuple(power / 1000)),
-                'RPR': lambda: color_attr.Set(tuple(power))
-            })
+        usd_utils.add_delegate_variants(obj_prim, {
+            'GL': lambda: color_attr.Set(tuple(power / 1000)),
+            'RPR': lambda: color_attr.Set(tuple(power))
+        })
 
 
 def sync_update(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -118,30 +118,12 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
 
     power = get_radiant_power(light)
 
-    colorAttr = usd_light.CreateColorAttr()
-
     if is_preview_render:
         # Material Previews are overly bright, that's why
         # decreasing light intensity for material preview by 10 times
         power *= 0.1
-        colorAttr.Set(tuple(power))
 
-    else:
-        # setting light color through variants for GL and RPR renderers
-        vset = obj_prim.GetVariantSets().AddVariantSet('delegate')
-        vset.AddVariant('GL')
-        vset.AddVariant('RPR')
-
-        vset.SetVariantSelection('GL')
-        with vset.GetVariantEditContext():
-            colorAttr.Set(tuple(power / 1000))
-
-        vset.SetVariantSelection('RPR')
-        with vset.GetVariantEditContext():
-            colorAttr.Set(tuple(power))
-
-        # setting default variant
-        vset.SetVariantSelection('GL' if context.scene.hdusd.viewport.is_gl_delegate else 'RPR')
+    usd_light.CreateColorAttr().Set(tuple(power))
 
 
 def sync_update(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/export/light.py
+++ b/src/hdusd/export/light.py
@@ -18,6 +18,7 @@ import numpy as np
 from pxr import UsdLux, Tf, Sdf
 import bpy
 
+from ..utils import usd as usd_utils
 
 from ..utils import logging
 log = logging.Log('export.light')
@@ -118,12 +119,20 @@ def sync(obj_prim, obj: bpy.types.Object, **kwargs):
 
     power = get_radiant_power(light)
 
+    color_attr = usd_light.CreateColorAttr()
+
     if is_preview_render:
         # Material Previews are overly bright, that's why
         # decreasing light intensity for material preview by 10 times
         power *= 0.1
+        color_attr.Set(tuple(power))
 
-    usd_light.CreateColorAttr().Set(tuple(power))
+    else:
+        usd_utils.add_delegate_variants(obj_prim,
+            {
+                'GL': lambda: color_attr.Set(tuple(power / 1000)),
+                'RPR': lambda: color_attr.Set(tuple(power))
+            })
 
 
 def sync_update(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -206,9 +206,11 @@ def sync(root_prim, world: bpy.types.World, shading: ShadingData = None):
 
     # setting visibility through variant for delegates
     visibility_attr = light_prim.CreateAttribute("visibility", Sdf.ValueTypeNames.Token)
-    usd_utils.set_delegate_variants(obj_prim,
-                                    lambda: visibility_attr.Set('invisible'),
-                                    lambda: visibility_attr.Set('inherited'))
+    usd_utils.add_delegate_variants(obj_prim,
+        {
+            'GL': lambda: visibility_attr.Set('invisible'),
+            'RPR': lambda: visibility_attr.Set('inherited')
+        })
 
 
 def sync_update(root_prim, world: bpy.types.World, shading: ShadingData = None):
@@ -234,5 +236,5 @@ def get_clear_color(root_prim):
     intensity = light_prim.GetAttribute('inputs:intensity').Get()
     transparency = light_prim.GetAttribute('inputs:transparency').Get()
     clear_color = [c * intensity for c in color]
-    clear_color.append(1.0)
+    clear_color.append(transparency)
     return tuple(clear_color)

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -193,8 +193,12 @@ def sync(root_prim, world: bpy.types.World, shading: ShadingData = None):
     usd_light.OrientToStageUpAxis()
 
     if data.image:
-        usd_light.CreateTextureFileAttr(str(data.image))
-        
+        tex_attr = usd_light.CreateTextureFileAttr()
+        usd_utils.add_delegate_variants(obj_prim, {
+            'GL': lambda: tex_attr.Set(""),
+            'RPR': lambda: tex_attr.Set(str(data.image))
+        })
+
     usd_light.CreateColorAttr(data.color)
 
     usd_light.CreateIntensityAttr(data.intensity)
@@ -203,14 +207,6 @@ def sync(root_prim, world: bpy.types.World, shading: ShadingData = None):
     # set correct Dome light rotation
     usd_light.AddRotateXOp().Set(180.0)
     usd_light.AddRotateYOp().Set(-90.0 + math.degrees(data.rotation[2]))
-
-    # setting visibility through variant for delegates
-    visibility_attr = light_prim.CreateAttribute("visibility", Sdf.ValueTypeNames.Token)
-    usd_utils.add_delegate_variants(obj_prim,
-        {
-            'GL': lambda: visibility_attr.Set('invisible'),
-            'RPR': lambda: visibility_attr.Set('inherited')
-        })
 
 
 def sync_update(root_prim, world: bpy.types.World, shading: ShadingData = None):

--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -196,7 +196,7 @@ def sync(root_prim, world: bpy.types.World, shading: ShadingData = None):
         usd_light.CreateColorAttr(data.color)
 
     usd_light.CreateIntensityAttr(data.intensity)
-    usd_light.CreateInput("transparency", Sdf.ValueTypeNames.Float).Set(data.transparency)
+    # usd_light.CreateInput("transparency", Sdf.ValueTypeNames.Float).Set(data.transparency)
 
     # set correct Dome light rotation
     usd_light.AddRotateXOp().Set(180.0)
@@ -224,7 +224,7 @@ def get_clear_color(root_prim):
     light_prim = root_prim.GetChild(OBJ_PRIM_NAME).GetChild(LIGHT_PRIM_NAME)
     color = light_prim.GetAttribute('inputs:color').Get()
     intensity = light_prim.GetAttribute('inputs:intensity').Get()
-    transparency = light_prim.GetAttribute('inputs:transparency').Get()
+    # transparency = light_prim.GetAttribute('inputs:transparency').Get()
     clear_color = [c * intensity for c in color]
-    clear_color.append(transparency)
+    clear_color.append(1.0)
     return tuple(clear_color)

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -32,6 +32,10 @@ class RenderSettings(bpy.types.PropertyGroup):
     def is_gl_delegate(self):
         return self.delegate == 'HdStormRendererPlugin'
 
+    @property
+    def delegate_name(self):
+        return _render_delegates[self.delegate]
+
     hdrpr: bpy.props.PointerProperty(type=hdrpr_render.RenderSettings)
 
 

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -19,6 +19,7 @@ from pxr import UsdGeom
 from .base_node import USDNode
 from ...export import object, material, world
 from ...export.object import ObjectData, SUPPORTED_TYPES
+from ...utils import usd as usd_utils
 
 
 #
@@ -226,13 +227,8 @@ class BlenderDataNode(USDNode):
             if isinstance(update.id, bpy.types.Scene):
                 scene = update.id
                 world.sync_update(root_prim, scene.world)
-                for prim in root_prim.GetAllChildren():
-                    vsets = prim.GetVariantSets()
-                    if 'delegate' not in vsets.GetNames():
-                        continue
-
-                    vset = vsets.GetVariantSet('delegate')
-                    vset.SetVariantSelection('GL' if scene.hdusd.viewport.is_gl_delegate else 'RPR')
+                usd_utils.set_delegate_variant(root_prim.GetAllChildren(),
+                                               scene.hdusd.viewport.delegate_name)
 
                 continue
 

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -15,6 +15,7 @@
 import math
 
 import mathutils
+import bpy
 
 
 def get_xform_transform(xform):
@@ -39,3 +40,20 @@ def get_renderer_percent_done(renderer):
         percent = 0.0
 
     return percent
+
+
+def set_delegate_variants(obj_prim, gl_func, rpr_func):
+    vset = obj_prim.GetVariantSets().AddVariantSet('delegate')
+    vset.AddVariant('GL')
+    vset.AddVariant('RPR')
+
+    vset.SetVariantSelection('GL')
+    with vset.GetVariantEditContext():
+        gl_func()
+
+    vset.SetVariantSelection('RPR')
+    with vset.GetVariantEditContext():
+        rpr_func()
+
+    # setting default variant
+    vset.SetVariantSelection('GL' if bpy.context.scene.hdusd.viewport.is_gl_delegate else 'RPR')

--- a/tools/build_usd.py
+++ b/tools/build_usd.py
@@ -61,7 +61,7 @@ add_subdirectory("{usd_imaging_lite_path.absolute().as_posix()}" usdImagingLite)
                      '--openvdb',
                      '--build-args', 'MATERIALX,"-DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_INSTALL_PYTHON=OFF"',
                      '--python',
-                     '--build-release',
+                     '--build-variant', 'release',
                      str(bin_usd_dir / "install"),
                      *args)
 

--- a/tools/build_usd.py
+++ b/tools/build_usd.py
@@ -61,7 +61,7 @@ add_subdirectory("{usd_imaging_lite_path.absolute().as_posix()}" usdImagingLite)
                      '--openvdb',
                      '--build-args', 'MATERIALX,"-DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_INSTALL_PYTHON=OFF"',
                      '--python',
-                     '--build-variant', 'release',
+                     '--build-release',
                      str(bin_usd_dir / "install"),
                      *args)
 


### PR DESCRIPTION
### PURPOSE
GL delegate doesn't work good when environment texture is set in Blender.

### EFFECT OF CHANGE
Fixed GL delegate rendering with environment texture: made workaround by disabling it for GL delegate.

### TECHNICAL STEPS
1. Created add_delegate_variants() in utils/usd.py. Made some renamings and code improvements.
2. Set dome light texture via add_delegate_variants() with setting empty path for GL delegate. Adjusted othe code with add_delegate_variants().
3. Applied additional light in camera position in viewport for GL delegate and MATERIAL shading type.
4. Added additional buffer clearing in ViewportEngine.draw().

### NOTES FOR REVIEWERS
I didn't find the way how to fully fix that, therefore I made workaround by providing empty path to environment texture for GL delegate.