### PR TITLE
fix_RPRBLND-1968: Improve MatX UI panel (should be more close to Blender Shading)

### DIFF
--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -26,7 +26,7 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
     bl_label = "MX Input Socket"
 
     def draw(self, context, layout, node, text):
-        if not hasattr(node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if not is_mx_node_valid(node):
             return
 
         nd = node.nodedef
@@ -47,7 +47,7 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
 
     def draw_color(self, context, node):
         socket_type = 'undefined'
-        if hasattr(node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if is_mx_node_valid(node):
             socket_type = node.nodedef.getInput(self.name).getType()
         return mx_utils.get_socket_color(socket_type)
 
@@ -57,7 +57,7 @@ class MxNodeOutputSocket(bpy.types.NodeSocket):
     bl_label = "MX Output Socket"
 
     def draw(self, context, layout, node, text):
-        if not hasattr(node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if not is_mx_node_valid(node):
             return
 
         nd = node.nodedef
@@ -71,7 +71,7 @@ class MxNodeOutputSocket(bpy.types.NodeSocket):
 
     def draw_color(self, context, node):
         socket_type = 'undefined'
-        if hasattr(node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if is_mx_node_valid(node):
             socket_type = node.nodedef.getOutput(self.name).getType()
         return mx_utils.get_socket_color(socket_type)
 
@@ -376,7 +376,7 @@ class MxNode(bpy.types.ShaderNode):
         if not link:
             return None
 
-        if not hasattr(link.from_node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if not is_mx_node_valid(link.from_node):
             log.warn(f"Ignoring unsupported node {link.from_node.bl_idname}", link.from_node, link.from_node.id_data)
             return None
 
@@ -455,3 +455,8 @@ class MxNode(bpy.types.ShaderNode):
         output = self.outputs.new(MxNodeOutputSocket.bl_idname, f'out_{len(self.outputs)}')
         output.name = mx_output.getName()
         return output
+
+
+def is_mx_node_valid(node):
+    # handle MaterialX 1.37 nodes
+    return hasattr(node, 'nodedef')

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -46,10 +46,8 @@ class MxNodeInputSocket(bpy.types.NodeSocket):
 
 
     def draw_color(self, context, node):
-        socket_type = 'undefined'
-        if is_mx_node_valid(node):
-            socket_type = node.nodedef.getInput(self.name).getType()
-        return mx_utils.get_socket_color(socket_type)
+        return mx_utils.get_socket_color(node.nodedef.getInput(self.name).getType()
+                                         if is_mx_node_valid(node) else 'undefined')
 
 
 class MxNodeOutputSocket(bpy.types.NodeSocket):
@@ -70,10 +68,8 @@ class MxNodeOutputSocket(bpy.types.NodeSocket):
             layout.label(text=f"{uiname}: {uitype}")
 
     def draw_color(self, context, node):
-        socket_type = 'undefined'
-        if is_mx_node_valid(node):
-            socket_type = node.nodedef.getOutput(self.name).getType()
-        return mx_utils.get_socket_color(socket_type)
+        return mx_utils.get_socket_color(node.nodedef.getOutput(self.name).getType()
+                                         if is_mx_node_valid(node) else 'undefined')
 
 
 class MxNode(bpy.types.ShaderNode):

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -486,7 +486,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         box.scale_x = 0.7
         box.scale_y = 0.5
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
-        op.input_num = int(input.identifier[-1])
+        op.input_num = output_node.inputs.find(self.bl_label)
 
         if link:
             row.prop(link.from_node, 'name', text="")
@@ -540,7 +540,7 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         box.scale_x = 0.7
         box.scale_y = 0.5
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
-        op.input_num = int(input.identifier[-1])
+        op.input_num = output_node.inputs.find(self.bl_label)
 
         if link:
             row.prop(link.from_node, 'name', text="")

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -488,7 +488,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
         op.input_num = output_node.inputs.find(self.bl_label)
 
-        if link:
+        if link and hasattr(link.from_node, 'nodedef'):    # handle MaterialX 1.37 nodes
             row.prop(link.from_node, 'name', text="")
         else:
             box = row.box()
@@ -501,11 +501,15 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
             layout.label(text="No input node")
             return
 
-        layout.separator()
+        if not hasattr(link.from_node, "nodedef"):
+            layout.label(text="Unsupported node")
+            return
 
         link = pass_node_reroute(link)
         if not link:
             return
+
+        layout.separator()
 
         link.from_node.draw_node_view(context, layout)
 
@@ -542,7 +546,7 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
         op.input_num = output_node.inputs.find(self.bl_label)
 
-        if link:
+        if link and hasattr(link.from_node, 'nodedef'):    # handle MaterialX 1.37 nodes
             row.prop(link.from_node, 'name', text="")
         else:
             box = row.box()
@@ -555,11 +559,15 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
             layout.label(text="No input node")
             return
 
-        layout.separator()
+        if not hasattr(link.from_node, "nodedef"):
+            layout.label(text="Unsupported node")
+            return
 
         link = pass_node_reroute(link)
         if not link:
             return
+
+        layout.separator()
 
         link.from_node.draw_node_view(context, layout)
 

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -20,6 +20,7 @@ from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
 from ..mx_nodes.node_tree import MxNodeTree, NODE_LAYER_SEPARATION_WIDTH
+from ..mx_nodes.nodes.base_node import is_mx_node_valid
 from ..utils import get_temp_file, pass_node_reroute
 from ..utils import mx as mx_utils
 
@@ -488,7 +489,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
         op.input_num = output_node.inputs.find(self.bl_label)
 
-        if link and hasattr(link.from_node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if link and is_mx_node_valid(link.from_node):
             row.prop(link.from_node, 'name', text="")
         else:
             box = row.box()
@@ -501,7 +502,7 @@ class HDUSD_MATERIAL_PT_material_settings_surface(HdUSD_ChildPanel):
             layout.label(text="No input node")
             return
 
-        if not hasattr(link.from_node, "nodedef"):
+        if not is_mx_node_valid(link.from_node):
             layout.label(text="Unsupported node")
             return
 
@@ -546,7 +547,7 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
         op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_shader_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
         op.input_num = output_node.inputs.find(self.bl_label)
 
-        if link and hasattr(link.from_node, 'nodedef'):    # handle MaterialX 1.37 nodes
+        if link and is_mx_node_valid(link.from_node):
             row.prop(link.from_node, 'name', text="")
         else:
             box = row.box()
@@ -559,7 +560,7 @@ class HDUSD_MATERIAL_PT_material_settings_displacement(HdUSD_ChildPanel):
             layout.label(text="No input node")
             return
 
-        if not hasattr(link.from_node, "nodedef"):
+        if not is_mx_node_valid(link.from_node):
             layout.label(text="Unsupported node")
             return
 


### PR DESCRIPTION
### PURPOSE
Error with an older scene that contains uber shader.

### EFFECT OF CHANGE
Works as expected for a scene with uber shader.

### TECHNICAL STEPS
get a correct input index with output_node.inputs.find(self.bl_label).
made workaround to handle unsupported  nodes is_mx_node_valid.