### PR TITLE
Improving HdRPR render performance for some cards

### DIFF
--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import math
+import os
 
 import bpy
 from bpy.props import (
@@ -22,6 +23,11 @@ from bpy.props import (
     BoolProperty,
     IntProperty,
 )
+
+
+# Temporary force enabling of Lighting Compiler until it'll be by default enabled on RPR side
+# Required for some cards
+os.environ['GPU_ENABLE_LC'] = "1"
 
 
 class QualitySettings(bpy.types.PropertyGroup):
@@ -250,7 +256,7 @@ class RenderSettings(bpy.types.PropertyGroup):
         description="Cutoff for adaptive sampling. Once pixels are below this amount of noise,\n"
                     "no more samples are added. Set to 0 for no cutoff",
         min=0.0, max=1.0,
-        default=0.0,
+        default=0.05,
     )
     enable_alpha: BoolProperty(
         name="Enable Color Alpha",


### PR DESCRIPTION
### PURPOSE
Rendering speed on some cards like Vega 56/64 is significant slower comparing to RX6800 and comparing to RPR plugin.

### EFFECT OF CHANGE
Increased overall HdRPR rendering speed by setting variance_threshold=0.05 by default.
Increased speed on some video cards like Vega 56/64.

### TECHNICAL STEPS
Made forcing enabling of Lighting Compiler.
Set variance_threshold=0.05 by default.