### PR TITLE
RPRBLND-2008: Add sorting to MX nodes in material UI and nodetree UI

### DIFF
--- a/src/hdusd/bl_nodes/__init__.py
+++ b/src/hdusd/bl_nodes/__init__.py
@@ -63,8 +63,8 @@ node_categories = [
         NodeItem('ShaderNodeNormalMap'),
     ], ),
     HdUSD_CompatibleShaderNodeCategory('HDUSD_SHADER_NODE_CATEGORY_LAYOUT', "Layout", items=[
-        NodeItem('NodeReroute'),
         NodeItem('NodeFrame'),
+        NodeItem('NodeReroute'),
     ], ),
 ]
 

--- a/src/hdusd/mx_nodes/nodes/__init__.py
+++ b/src/hdusd/mx_nodes/nodes/__init__.py
@@ -28,6 +28,10 @@ mx_node_classes = []
 for mod in gen_modules:
     mx_node_classes.extend(mod.mx_node_classes)
 
+# sorting by category and label
+mx_node_classes = sorted(mx_node_classes, key=lambda cls: (cls.category.lower(), cls.bl_label.lower()))
+
+
 register_sockets, unregister_sockets = bpy.utils.register_classes_factory([
     base_node.MxNodeInputSocket,
     base_node.MxNodeOutputSocket,

--- a/src/hdusd/mx_nodes/nodes/categories.py
+++ b/src/hdusd/mx_nodes/nodes/categories.py
@@ -39,8 +39,9 @@ def get_node_categories():
                            items=[NodeItem(MxNode_cls.bl_idname)
                                   for MxNode_cls in category_classes]))
 
-    categories.append(MxNodeCategory('HdUSD_MX_NG_LAYOUT', 'Layout',
-                           items=[NodeItem("NodeReroute"),
-                                  NodeItem("NodeFrame")]))
+    categories.append(
+        MxNodeCategory('HdUSD_MX_NG_LAYOUT', 'Layout',
+                       items=[NodeItem("NodeFrame"),
+                              NodeItem("NodeReroute")]))
 
     return categories

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -316,6 +316,11 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
 
         split = self.layout.split()
 
+        def add_operator(col, op_cls, text=None):
+            row = col.row()
+            row.alignment = 'LEFT'
+            return row.operator(op_cls.bl_idname, text=text)
+
         cat = ""
         i = 0
         col = None
@@ -333,58 +338,26 @@ class HDUSD_MATERIAL_OP_invoke_popup_input_nodes(bpy.types.Operator):
                 col.label(text=title_str(cat), icon='NODE')
                 i += 1
 
-            row = col.row()
-            i += 1
-            row.alignment = 'LEFT'
-            op = row.operator(HDUSD_MATERIAL_OP_link_mx_node.bl_idname,
-                              text=cls.bl_label)
+            op = add_operator(col, HDUSD_MATERIAL_OP_link_mx_node, cls.bl_label)
             op.new_node_name = cls.bl_idname
             op.input_num = self.input_num
             op.current_node_name = self.current_node_name
+            i += 1
 
-        # col = split.column()
-        #
-        # categories = sorted(set(node.category for node in mx_node_classes) -
-        #                         NODE_SHADER_CATEGORIES - NODE_EXCLUDE_CATEGORIES,
-        #                         key=lambda x: x.lower())
-        #
-        # i = 0
-        # for category in categories:
-        #     if i % 4 == 0:
-        #         col = split.column()
-        #     col.emboss = 'PULLDOWN_MENU'
-        #     col.label(text=title_str(category), icon='NODE')
-        #     for node in mx_node_classes:
-        #         if node.category == category:
-        #             row1 = col.row()
-        #             row1.alignment = 'LEFT'
-        #             op = row1.operator(HDUSD_MATERIAL_OP_link_mx_node.bl_idname,
-        #                               text=node.bl_label)
-        #             op.new_node_name = node.bl_idname
-        #             op.input_num = self.input_num
-        #             op.current_node_name = self.current_node_name
+        input = context.material.hdusd.mx_node_tree.nodes[self.current_node_name].inputs[self.input_num]
+        if input.is_linked:
+            link = input.links[0]
 
-        node_tree = context.material.hdusd.mx_node_tree
-        node_inputs = node_tree.nodes[self.current_node_name].inputs
-        if node_inputs[self.input_num].is_linked:
             col = split.column()
             col.emboss = 'PULLDOWN_MENU'
             col.label(text=NODE_LINK_CATEGORY)
 
-            link = next((link for link in node_inputs[self.input_num].links), None)
-            
-            if link:
-                row1 = col.row()
-                row1.alignment = 'LEFT'
-                op = row1.operator(HDUSD_MATERIAL_OP_remove_node.bl_idname,
-                                  text=HDUSD_MATERIAL_OP_remove_node.bl_label)
-                op.input_node_name = link.from_node.name
-                row1 = col.row()
-                row1.alignment = 'LEFT'
-                op = row1.operator(HDUSD_MATERIAL_OP_disconnect_node.bl_idname,
-                                  text=HDUSD_MATERIAL_OP_disconnect_node.bl_label)
-                op.output_node_name = link.to_node.name
-                op.input_num = self.input_num
+            op = add_operator(col, HDUSD_MATERIAL_OP_remove_node)
+            op.input_node_name = link.from_node.name
+
+            op = add_operator(col, HDUSD_MATERIAL_OP_disconnect_node)
+            op.output_node_name = link.to_node.name
+            op.input_num = self.input_num
 
 
 class HDUSD_MATERIAL_OP_invoke_popup_shader_nodes(bpy.types.Operator):

--- a/src/hdusd/usd_nodes/nodes/__init__.py
+++ b/src/hdusd/usd_nodes/nodes/__init__.py
@@ -51,8 +51,8 @@ node_categories = [
         NodeItem('usd.TransformByEmptyNode'),
     ]),
     USDNodeCategory('HdUSD_USD_LAYOUT', 'Layout', items=[
-        NodeItem('NodeReroute'),
         NodeItem('NodeFrame'),
+        NodeItem('NodeReroute'),
     ]),
 ]
 


### PR DESCRIPTION
### PURPOSE
MX nodes aren't sorted comparing to blender's shader nodes.

### EFFECT OF CHANGE
Implemented sorting of MX nodes. Improved material UI panel with selecting MX node.

### TECHNICAL STEPS
1. Added sorting of MX nodes by category and label.
2. Improved popup panel with selecting MX node in material panel + improved algorithm.