### PR TITLE
RPRBLND-1950: KeyError: 'BSDF' with USD_Hydra

### DIFF
--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -16,8 +16,7 @@ import math
 
 from ..node_parser import NodeParser
 
-from ...utils import logging
-log = logging.LogOnce("bl_nodes.nodes.shader")
+from . import log
 
 
 SSS_MIN_RADIUS = 0.0001
@@ -245,7 +244,7 @@ class ShaderNodeMixShader(NodeParser):
             'mix': factor
         })
 
-        log.warn(f"Known issue: node doesn't work correctly now: {result.nodedef.getName()}", self.material, self.node)
+        log.warn(f"Known issue: node doesn't work correctly with {result.nodedef.getName()}", self.material, self.node)
 
         return result
 
@@ -271,6 +270,6 @@ class ShaderNodeAddShader(NodeParser):
             'in2': shader2
         })
 
-        log.warn(f"Known issue: node doesn't work correctly now: {result.nodedef.getName()}", self.material, self.node)
+        log.warn(f"Known issue: node doesn't work correctly with {result.nodedef.getName()}", self.material, self.node)
 
         return result

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -237,8 +237,8 @@ class ShaderNodeMixShader(NodeParser):
             return shader1
 
         result = self.create_node('STD_mix', 'surfaceshader', {
-            'fg' : shader1,
-            'bg' : shader2,
+            'fg': shader1,
+            'bg': shader2,
             'mix': factor
         })
 

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -16,6 +16,9 @@ import math
 
 from ..node_parser import NodeParser
 
+from ...utils import logging
+log = logging.LogOnce("bl_nodes.nodes.shader")
+
 
 SSS_MIN_RADIUS = 0.0001
 
@@ -242,6 +245,7 @@ class ShaderNodeMixShader(NodeParser):
             'mix': factor
         })
 
+        log.warn(f"Known issue: node doesn't work correctly now: {result.nodedef.getName()}", self.material, self.node)
         return result
 
 

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -246,10 +246,13 @@ class ShaderNodeMixShader(NodeParser):
         })
 
         log.warn(f"Known issue: node doesn't work correctly now: {result.nodedef.getName()}", self.material, self.node)
+
         return result
 
 
 class ShaderNodeAddShader(NodeParser):
+    nodegraph_path = ""
+
     def export(self):
         shader1 = self.get_input_link(0)
         shader2 = self.get_input_link(1)
@@ -263,8 +266,11 @@ class ShaderNodeAddShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('add', 'BSDF', {
+        result = self.create_node('STD_add', 'surfaceshader', {
             'in1': shader1,
             'in2': shader2
         })
+
+        log.warn(f"Known issue: node doesn't work correctly now: {result.nodedef.getName()}", self.material, self.node)
+
         return result

--- a/src/hdusd/bl_nodes/nodes/shader.py
+++ b/src/hdusd/bl_nodes/nodes/shader.py
@@ -220,6 +220,8 @@ class ShaderNodeEmission(NodeParser):
 
 
 class ShaderNodeMixShader(NodeParser):
+    nodegraph_path = ""
+
     def export(self):
         factor = self.get_input_value(0)
         shader1 = self.get_input_link(1)
@@ -234,11 +236,12 @@ class ShaderNodeMixShader(NodeParser):
         if shader2 is None:
             return shader1
 
-        result = self.create_node('mix', 'BSDF', {
-            'fg': shader1,
-            'bg': shader2,
+        result = self.create_node('STD_mix', 'surfaceshader', {
+            'fg' : shader1,
+            'bg' : shader2,
             'mix': factor
         })
+
         return result
 
 


### PR DESCRIPTION
### PURPOSE
Fix KeyError: 'BSDF' with Mix and Add shader nodes.

### EFFECT OF CHANGE
- Add support for Mix shader node.
- Add support for Add shader node.

### TECHNICAL STEPS
- Changed implementation for Mix shader node.
- Changed implementation for Add shader node.
- Added logging.

### NOTES FOR REVIEWERS
For now RPR can't render materials with Mix and Add shader node possibly due to its own issues. To approve correctness of resulted material with Mix shader node you need to build your own MaterialX from sources (with viewer) and open exported mtlx file with MaterialX viewer.

You can open material with Add shader node with MaterialX viewer.

**Attention: latest MaterialX binaries (8 Oct) also can't open materials with Mix shader node.**