### PR TITLE
RPRBLND-1805: Add Materials settings for USD nodetree mesh prims

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+numpy
+requests
+PyOpenGL
+PySide2

--- a/src/hdusd/config.py
+++ b/src/hdusd/config.py
@@ -20,6 +20,7 @@ logging_backups = 5
 # other settings
 matlib_enabled = False
 engine_use_preview = True
+usd_mesh_assign_material_enabled = False
 
 # dev settings
 show_dev_settings = False

--- a/src/hdusd/engine/engine.py
+++ b/src/hdusd/engine/engine.py
@@ -91,6 +91,10 @@ class HdUSDEngine(bpy.types.RenderEngine):
     # viewport render
     def view_update(self, context, depsgraph):
         """ Called when data is updated for viewport """
+        from . import handlers
+        if not handlers._do_depsgraph_update:
+            return
+
         log('view_update', self.as_pointer())
 
         try:

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -136,6 +136,11 @@ class ViewportEngine(Engine):
             if isinstance(engine, cls):
                 yield engine
 
+    @classmethod
+    def tag_redraw(cls):
+        for engine in cls.get_engines():
+            engine.render_engine.tag_redraw()
+
     def __init__(self, rpr_engine):
         super().__init__(rpr_engine)
 

--- a/src/hdusd/export/material.py
+++ b/src/hdusd/export/material.py
@@ -65,12 +65,12 @@ def sync_update(materials_prim, mat: bpy.types.Material, obj: bpy.types.Object):
     log("sync_update", mat)
 
     stage = materials_prim.GetStage()
-    mat_path = f"{materials_prim.GetPath()}/{sdf_name(mat)}"
+    mat_path = materials_prim.GetPath().AppendChild(sdf_name(mat))
     usd_mat = stage.GetPrimAtPath(mat_path)
     if usd_mat.IsValid():
         stage.RemovePrim(mat_path)
 
-    sync(materials_prim, mat, obj)
+    return sync(materials_prim, mat, obj)
 
 
 def sync_update_all(root_prim, mat: bpy.types.Material):

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -17,7 +17,7 @@ import bpy
 from pxr import UsdGeom, Gf
 
 from . import HdUSDProperties, CachedStageProp
-from ..export.object import get_transform_local
+from ..export import object, material
 from ..utils import usd as usd_utils
 
 
@@ -29,6 +29,16 @@ class ObjectProperties(HdUSDProperties):
 
     sdf_path: bpy.props.StringProperty(default="")
     cached_stage: bpy.props.PointerProperty(type=CachedStageProp)
+
+    def update_material(self, context):
+        prim = self.get_prim()
+        usd_mat = None
+        if self.material:
+            usd_mat = material.sync(prim, self.material, None)
+            
+        print(usd_mat)
+
+    material: bpy.props.PointerProperty(type=bpy.types.Material, update=update_material)
 
     @property
     def is_usd(self):
@@ -59,7 +69,7 @@ class ObjectProperties(HdUSDProperties):
 
         obj = self.id_data
         xform = UsdGeom.Xform(prim)
-        xform.MakeMatrixXform().Set(Gf.Matrix4d(get_transform_local(obj)))
+        xform.MakeMatrixXform().Set(Gf.Matrix4d(object.get_transform_local(obj)))
 
 
 def depsgraph_update(depsgraph):

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -14,7 +14,7 @@
 #********************************************************************
 import bpy
 
-from pxr import UsdGeom, Gf
+from pxr import UsdGeom, Gf, UsdShade
 
 from . import HdUSDProperties, CachedStageProp
 from ..export import object, material
@@ -35,8 +35,12 @@ class ObjectProperties(HdUSDProperties):
         usd_mat = None
         if self.material:
             usd_mat = material.sync(prim, self.material, None)
-            
-        print(usd_mat)
+
+        usd_mesh = UsdGeom.Mesh.Define(prim.GetStage()), prim.GetPath()
+        if usd_mat:
+            UsdShade.MaterialBindingAPI(usd_mesh).Bind(usd_mat)
+        else:
+            UsdShade.MaterialBindingAPI(usd_mesh).Unbind(usd_mat)
 
     material: bpy.props.PointerProperty(type=bpy.types.Material, update=update_material)
 

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -36,17 +36,17 @@ class ObjectProperties(HdUSDProperties):
         if self.material:
             usd_mat = material.sync(prim, self.material, None)
 
-        usd_mesh = UsdGeom.Mesh.Define(prim.GetStage(), prim.GetPath())
-        bindings = UsdShade.MaterialBindingAPI(usd_mesh)
-        bindings.UnbindAllBindings()
-        if usd_mat:
-            bindings.Bind(usd_mat)
+        usd_utils.bind_material(prim, usd_mat)
+
+    def poll_material(self, mat):
+        return bool(mat.node_tree)
 
     material: bpy.props.PointerProperty(
         name="Material",
         description="Select material for USD mesh",
         type=bpy.types.Material,
-        update=update_material
+        update=update_material,
+        poll=poll_material
     )
 
     @property

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -42,7 +42,12 @@ class ObjectProperties(HdUSDProperties):
         if usd_mat:
             bindings.Bind(usd_mat)
 
-    material: bpy.props.PointerProperty(type=bpy.types.Material, update=update_material)
+    material: bpy.props.PointerProperty(
+        name="Material",
+        description="Select material for USD mesh",
+        type=bpy.types.Material,
+        update=update_material
+    )
 
     @property
     def is_usd(self):

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -39,7 +39,7 @@ class ObjectProperties(HdUSDProperties):
         usd_utils.bind_material(prim, usd_mat)
 
     def poll_material(self, mat):
-        return bool(mat.node_tree)
+        return mat.hdusd.mx_node_tree or mat.node_tree
 
     material: bpy.props.PointerProperty(
         name="Material",

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -34,7 +34,7 @@ class ObjectProperties(HdUSDProperties):
         prim = self.get_prim()
         usd_mat = None
         if self.material:
-            usd_mat = material.sync(prim, self.material, None)
+            usd_mat = material.sync_update(prim, self.material, None)
 
         usd_utils.bind_material(prim, usd_mat)
 

--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -36,11 +36,11 @@ class ObjectProperties(HdUSDProperties):
         if self.material:
             usd_mat = material.sync(prim, self.material, None)
 
-        usd_mesh = UsdGeom.Mesh.Define(prim.GetStage()), prim.GetPath()
+        usd_mesh = UsdGeom.Mesh.Define(prim.GetStage(), prim.GetPath())
+        bindings = UsdShade.MaterialBindingAPI(usd_mesh)
+        bindings.UnbindAllBindings()
         if usd_mat:
-            UsdShade.MaterialBindingAPI(usd_mesh).Bind(usd_mat)
-        else:
-            UsdShade.MaterialBindingAPI(usd_mesh).Unbind(usd_mat)
+            bindings.Bind(usd_mat)
 
     material: bpy.props.PointerProperty(type=bpy.types.Material, update=update_material)
 

--- a/src/hdusd/properties/usd_list.py
+++ b/src/hdusd/properties/usd_list.py
@@ -100,3 +100,8 @@ class UsdList(PropertyGroup):
     def get_prim(self, item):
         stage = self.cached_stage()
         return stage.GetPrimAtPath(item.sdf_path) if stage else None
+
+    @property
+    def selected_prim(self):
+        item = self.items[self.item_index]
+        return self.get_prim(item)

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -118,6 +118,8 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     usd_list.HDUSD_NODE_PT_usd_nodetree_tools,
     usd_list.HDUSD_NODE_PT_usd_nodetree_dev,
     usd_list.HDUSD_NODE_OP_export_usd_file,
+    usd_list.HDUSD_NODE_MT_material_select,
+    usd_list.HDUSD_NODE_OP_material_select,
 
     mx_nodes.HDUSD_MX_OP_import_file,
     mx_nodes.HDUSD_MX_OP_export_file,

--- a/src/hdusd/ui/object.py
+++ b/src/hdusd/ui/object.py
@@ -78,3 +78,6 @@ class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
                           text="Hide" if visible else 'Show',
                           icon='HIDE_OFF' if visible else 'HIDE_ON',
                           emboss=True, depress=False)
+
+        if prim.GetTypeName() in 'Mesh':
+            layout.prop(obj.hdusd, 'material')

--- a/src/hdusd/ui/object.py
+++ b/src/hdusd/ui/object.py
@@ -18,6 +18,7 @@ from pxr import UsdGeom
 
 from . import HdUSD_Panel
 from ..properties.object import GEOM_TYPES
+from .. import config
 
 
 class HDUSD_OP_usd_object_show_hide(bpy.types.Operator):
@@ -78,6 +79,9 @@ class HDUSD_OBJECT_PT_usd_settings(HdUSD_Panel):
                           text="Hide" if visible else 'Show',
                           icon='HIDE_OFF' if visible else 'HIDE_ON',
                           emboss=True, depress=False)
+
+        if not config.usd_mesh_assign_material_enabled:
+            return
 
         if prim.GetTypeName() in 'Mesh':
             layout.prop(obj.hdusd, 'material')

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -218,7 +218,7 @@ class HDUSD_NODE_MT_material_select(bpy.types.Menu):
         op.material_name = ""
 
         for mat in materials:
-            if not mat.node_tree:
+            if not mat.node_tree and not mat.hdusd.mx_node_tree:
                 continue
 
             op = layout.operator(HDUSD_NODE_OP_material_select.bl_idname, text=mat.name, icon='MATERIAL')

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -200,10 +200,10 @@ class HDUSD_NODE_PT_usd_list(HdUSD_Panel):
             bind_path = str(bind_paths[0]) if bind_paths else ""
 
             prop_layout.separator()
-            prop_layout.label(text="Assign material")
-            row = prop_layout.row()
-            row.menu(HDUSD_NODE_MT_material_select.bl_idname, text="", icon='MATERIAL')
-            row.label(text=bind_path)
+            col = prop_layout.column(align=True)
+            col.menu(HDUSD_NODE_MT_material_select.bl_idname, text="Assign material", icon='MATERIAL')
+            if bind_path:
+                col.label(text=bind_path)
 
 
 class HDUSD_NODE_MT_material_select(bpy.types.Menu):
@@ -214,7 +214,7 @@ class HDUSD_NODE_MT_material_select(bpy.types.Menu):
         layout = self.layout
         materials = bpy.data.materials
 
-        op = layout.operator(HDUSD_NODE_OP_material_select.bl_idname, text="Unbind Material")
+        op = layout.operator(HDUSD_NODE_OP_material_select.bl_idname, text="Unbind", icon='X')
         op.material_name = ""
 
         for mat in materials:

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -193,6 +193,9 @@ class HDUSD_NODE_PT_usd_list(HdUSD_Panel):
             elif prop.type == 'FLOAT':
                 prop_layout.prop(prop, 'value_float', text=prop.name)
 
+        if not config.usd_mesh_assign_material_enabled:
+            return
+
         prim = usd_list.selected_prim
         if prim.GetTypeName() == 'Mesh':
             bindings = UsdShade.MaterialBindingAPI(prim)

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -201,7 +201,9 @@ class HDUSD_NODE_PT_usd_list(HdUSD_Panel):
 
             prop_layout.separator()
             prop_layout.label(text="Assign material")
-            prop_layout.menu(HDUSD_NODE_MT_material_select.bl_idname, text=bind_path, icon='MATERIAL')
+            row = prop_layout.row()
+            row.menu(HDUSD_NODE_MT_material_select.bl_idname, text="", icon='MATERIAL')
+            row.label(text=bind_path)
 
 
 class HDUSD_NODE_MT_material_select(bpy.types.Menu):
@@ -211,12 +213,15 @@ class HDUSD_NODE_MT_material_select(bpy.types.Menu):
     def draw(self, context):
         layout = self.layout
         materials = bpy.data.materials
+
+        op = layout.operator(HDUSD_NODE_OP_material_select.bl_idname, text="Unbind Material")
+        op.material_name = ""
+
         for mat in materials:
             if not mat.node_tree:
                 continue
 
-            row = layout.row()
-            op = row.operator(HDUSD_NODE_OP_material_select.bl_idname, text=mat.name, icon='MATERIAL')
+            op = layout.operator(HDUSD_NODE_OP_material_select.bl_idname, text=mat.name, icon='MATERIAL')
             op.material_name = mat.name
 
 

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -176,10 +176,12 @@ def depsgraph_update(depsgraph):
         if isinstance(nodetree, USDTree):
             nodetree.depsgraph_update(depsgraph)
 
+
 def frame_change(depsgraph):
     for nodetree in bpy.data.node_groups:
         if isinstance(nodetree, USDTree):
             nodetree.frame_change(depsgraph)
+
 
 def material_update(material):
     for nodetree in bpy.data.node_groups:

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -304,8 +304,7 @@ class BlenderDataNode(USDNode):
                             continue
                             
                         root_prim.GetStage().RemovePrim(root_prim.GetPath().AppendChild(key))
-
-                    is_updated = True
+                        is_updated = True
 
                 if keys_to_add:
                     for obj_data in ObjectData.depsgraph_objects(depsgraph):
@@ -313,8 +312,7 @@ class BlenderDataNode(USDNode):
                             continue
 
                         object.sync(root_prim, obj_data, **kwargs)
-
-                    is_updated = True
+                        is_updated = True
 
                 continue
 

--- a/src/hdusd/utils/stage_cache.py
+++ b/src/hdusd/utils/stage_cache.py
@@ -12,8 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ********************************************************************
-import tempfile
-
 from pxr import Usd
 
 from . import get_temp_file

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -17,6 +17,8 @@ import math
 import mathutils
 import bpy
 
+from pxr import UsdShade
+
 
 def get_xform_transform(xform):
     transform = mathutils.Matrix(xform.GetLocalTransformation())
@@ -69,3 +71,10 @@ def traverse_stage(stage, *, ignore=None):
             yield from traverse(child)
 
     yield from traverse(stage.GetPseudoRoot())
+
+
+def bind_material(mesh_prim, usd_mat):
+    bindings = UsdShade.MaterialBindingAPI(mesh_prim)
+    bindings.UnbindAllBindings()
+    if usd_mat:
+        bindings.Bind(usd_mat)

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -59,7 +59,7 @@ def get_renderer_percent_done(renderer):
     return percent
 
 
-def traverse_stage(stage, ignore=None):
+def traverse_stage(stage, *, ignore=None):
     def traverse(prim):
         for child in prim.GetAllChildren():
             if ignore and ignore(child):

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -57,3 +57,15 @@ def get_renderer_percent_done(renderer):
         percent = 0.0
 
     return percent
+
+
+def traverse_stage(stage, ignore=None):
+    def traverse(prim):
+        for child in prim.GetAllChildren():
+            if ignore and ignore(child):
+                continue
+
+            yield child
+            yield from traverse(child)
+
+    yield from traverse(stage.GetPseudoRoot())

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -17,12 +17,19 @@ import bpy
 from pxr import Sdf
 
 from ..engine import handlers
+from ..utils import usd as usd_utils
+from ..properties.object import GEOM_TYPES
 
 from ..utils import logging
 log = logging.Log('usd_collection')
 
 
 COLLECTION_NAME = "USD NodeTree"
+
+
+def ignore_prim(prim):
+    prim_type = prim.GetTypeName()
+    return not (prim_type in GEOM_TYPES or prim_type in ('Mesh', 'Camera') or prim_type.endswith('Light'))
 
 
 def update(context):
@@ -55,7 +62,7 @@ def update(context):
         obj_paths = set(objects.keys())
 
         prim_paths = set()
-        for prim in stage.TraverseAll():
+        for prim in usd_utils.traverse_stage(stage, ignore=ignore_prim):
             prim_paths.add(str(prim.GetPath()))
 
         paths_to_remove = obj_paths - prim_paths


### PR DESCRIPTION
### PURPOSE
Now in Blender user can not change any materials in imported USD files, need to add support assigning material for USD nodetree mesh prims.

### EFFECT OF CHANGE
Added possibility to assign material for selected USD NodeTree collection object. 
Added possibility to assign material for selected mesh prim in USD list in USD NodeTree.
Fixed some updating bugs with USD NodeTree collection objects.

### TECHNICAL STEPS
1. Added material property to ObjectProperties and update_material() function to assign material.
2. Fixed updating bugs with USD NodeTree collections objects:
    - added no_depsgraph_update_call() function into handlers which prevents for calling depsgraph_update for some calls.
    - adjusted functions in viewport/usd_collection.py to use no_depsgraph_update_call()
3. Added traverse_stage in utils/usd.py for more flexible stage traverse comparing to TraveseAll(). Adjusted usd_collection.py to use it.
4. Added possibility to assign material for selected mesh prim in USD list in USD NodeTree.
5. Improvement: added requirements.txt with list of required python modules for development.

### NOTES FOR REVIEWERS
This is initial implementation in this area. This feature will be improved in future but propose to do it in separate task.