### PR TITLE
RPRBLND-2035: Fail rendering Bistro scene

### DIFF
--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -23,6 +23,7 @@ from . import log
 SUPPORTED_FORMATS = {".png", ".jpeg", ".jpg", ".hdr", ".tga", ".bmp"}
 DEFAULT_FORMAT = ".hdr"
 BLENDER_DEFAULT_FORMAT = "HDR"
+READONLY_IMAGE_FORMATS = {".dds"}  # blender can read these formats, but can't write
 
 
 def cache_image_file(image: bpy.types.Image, cache_check=True):
@@ -32,8 +33,12 @@ def cache_image_file(image: bpy.types.Image, cache_check=True):
             log.warn("Image is missing", image, image_path)
             return None
 
-        if Path(image.filepath).suffix.lower() in SUPPORTED_FORMATS and \
-                f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
+        image_suffix = Path(image.filepath).suffix.lower()
+
+        if image_suffix in SUPPORTED_FORMATS and f".{image.file_format.lower()}" in SUPPORTED_FORMATS:
+            return image_path
+
+        if image_suffix in READONLY_IMAGE_FORMATS:
             return image_path
 
     old_filepath = image.filepath_raw


### PR DESCRIPTION
### PURPOSE
Add support of ".dds" image format.

### EFFECT OF CHANGE
Added support of ".dds" image format.

### TECHNICAL STEPS
Added constant READONLY_IMAGE_FORMATS and check for it for image formats, which blender can read, but can't write.