### PR TITLE
RPRBLND-2042: Update HdRPR with Core 2.2.10.

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -230,8 +230,6 @@ class FinalEngine(Engine):
             quality = hdrpr.quality
             denoise = hdrpr.denoise
 
-            # renderer.SetRendererSetting('renderMode', 'batch')
-            # renderer.SetRendererSetting('progressive', True)
             renderer.SetRendererSetting('rpr:alpha:enable', False)
 
             # renderer.SetRendererSetting('renderDevice', hdrpr.device)
@@ -252,7 +250,6 @@ class FinalEngine(Engine):
                                         quality.max_ray_depth_glossy_refraction)
             renderer.SetRendererSetting('rpr:quality:rayDepthShadow', quality.max_ray_depth_shadow)
             renderer.SetRendererSetting('rpr:quality:raycastEpsilon', quality.raycast_epsilon)
-            # renderer.SetRendererSetting('enableRadianceClamping', quality.enable_radiance_clamping)
             renderer.SetRendererSetting('rpr:quality:radianceClamping', quality.radiance_clamping)
 
             renderer.SetRendererSetting('rpr:denoising:enable', denoise.enable)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -230,34 +230,34 @@ class FinalEngine(Engine):
             quality = hdrpr.quality
             denoise = hdrpr.denoise
 
-            renderer.SetRendererSetting('renderMode', 'batch')
-            renderer.SetRendererSetting('progressive', True)
-            renderer.SetRendererSetting('enableAlpha', False)
+            # renderer.SetRendererSetting('renderMode', 'batch')
+            # renderer.SetRendererSetting('progressive', True)
+            renderer.SetRendererSetting('rpr:alpha:enable', False)
 
-            renderer.SetRendererSetting('renderDevice', hdrpr.device)
-            renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
-            renderer.SetRendererSetting('coreRenderMode', hdrpr.render_mode)
+            # renderer.SetRendererSetting('renderDevice', hdrpr.device)
+            renderer.SetRendererSetting('rpr:core:renderQuality', hdrpr.render_quality)
+            renderer.SetRendererSetting('rpr:core:renderMode', hdrpr.render_mode)
 
-            renderer.SetRendererSetting('aoRadius', hdrpr.ao_radius)
+            renderer.SetRendererSetting('rpr:ambientOcclusion:radius', hdrpr.ao_radius)
 
-            renderer.SetRendererSetting('maxSamples', hdrpr.max_samples)
-            renderer.SetRendererSetting('minAdaptiveSamples', hdrpr.min_adaptive_samples)
-            renderer.SetRendererSetting('varianceThreshold', hdrpr.variance_threshold)
+            renderer.SetRendererSetting('rpr:maxSamples', hdrpr.max_samples)
+            renderer.SetRendererSetting('rpr:adaptiveSampling:minSamples', hdrpr.min_adaptive_samples)
+            renderer.SetRendererSetting('rpr:adaptiveSampling:noiseTreshold', hdrpr.variance_threshold)
 
-            renderer.SetRendererSetting('maxRayDepth', quality.max_ray_depth)
-            renderer.SetRendererSetting('maxRayDepthDiffuse', quality.max_ray_depth_diffuse)
-            renderer.SetRendererSetting('maxRayDepthGlossy', quality.max_ray_depth_glossy)
-            renderer.SetRendererSetting('maxRayDepthRefraction', quality.max_ray_depth_refraction)
-            renderer.SetRendererSetting('maxRayDepthGlossyRefraction',
+            renderer.SetRendererSetting('rpr:quality:rayDepth', quality.max_ray_depth)
+            renderer.SetRendererSetting('rpr:quality:rayDepthDiffuse', quality.max_ray_depth_diffuse)
+            renderer.SetRendererSetting('rpr:quality:rayDepthGlossy', quality.max_ray_depth_glossy)
+            renderer.SetRendererSetting('rpr:quality:rayDepthRefraction', quality.max_ray_depth_refraction)
+            renderer.SetRendererSetting('rpr:quality:rayDepthGlossyRefraction',
                                         quality.max_ray_depth_glossy_refraction)
-            renderer.SetRendererSetting('maxRayDepthShadow', quality.max_ray_depth_shadow)
-            renderer.SetRendererSetting('raycastEpsilon', quality.raycast_epsilon)
-            renderer.SetRendererSetting('enableRadianceClamping', quality.enable_radiance_clamping)
-            renderer.SetRendererSetting('radianceClamping', quality.radiance_clamping)
+            renderer.SetRendererSetting('rpr:quality:rayDepthShadow', quality.max_ray_depth_shadow)
+            renderer.SetRendererSetting('rpr:quality:raycastEpsilon', quality.raycast_epsilon)
+            # renderer.SetRendererSetting('enableRadianceClamping', quality.enable_radiance_clamping)
+            renderer.SetRendererSetting('rpr:quality:radianceClamping', quality.radiance_clamping)
 
-            renderer.SetRendererSetting('enableDenoising', denoise.enable)
-            renderer.SetRendererSetting('denoiseMinIter', denoise.min_iter)
-            renderer.SetRendererSetting('denoiseIterStep', denoise.iter_step)
+            renderer.SetRendererSetting('rpr:denoising:enable', denoise.enable)
+            renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
+            renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
 
 
 class FinalEngineScene(FinalEngine):

--- a/src/hdusd/engine/preview_engine.py
+++ b/src/hdusd/engine/preview_engine.py
@@ -74,8 +74,11 @@ class PreviewEngine(Engine):
 
         renderer = UsdImagingLite.Engine()
         renderer.SetRendererPlugin('HdRprPlugin')
-        renderer.SetRendererSetting('maxSamples', self.SAMPLES_NUMBER)
-        renderer.SetRendererSetting('renderQuality', 'Northstar')
+        renderer.SetRendererSetting('rpr:maxSamples', self.SAMPLES_NUMBER)
+        renderer.SetRendererSetting('rpr:core:renderQuality', 'Northstar')
+        renderer.SetRendererSetting('rpr:alpha:enable', False)
+        renderer.SetRendererSetting('rpr:adaptiveSampling:minSamples', 16)
+        renderer.SetRendererSetting('rpr:adaptiveSampling:noiseTreshold', 0.05)
 
         renderer.SetRenderViewport((0, 0, width, height))
         renderer.SetRendererAov('color')

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -313,8 +313,6 @@ class ViewportEngine(Engine):
             quality = hdrpr.interactive_quality
             denoise = hdrpr.denoise
 
-            # self.renderer.SetRendererSetting('renderMode', 'interactive')
-            # self.renderer.SetRendererSetting('rpr:interactive', True)
             self.renderer.SetRendererSetting('rpr:alpha:enable', False)
 
             # self.renderer.SetRendererSetting('renderDevice', hdrpr.device)

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -306,21 +306,20 @@ class ViewportEngine(Engine):
         settings = self.get_settings(scene)
 
         self.is_gl_delegate = settings.is_gl_delegate
+        self.renderer.SetRendererPlugin(settings.delegate)
+
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
             quality = hdrpr.interactive_quality
             denoise = hdrpr.denoise
 
-            # self.renderer.SetRendererPlugin(f"{settings.delegate}:{hdrpr.render_quality}")
-            self.renderer.SetRendererPlugin(settings.delegate)
-
-            self.renderer.SetRendererSetting('renderMode', 'interactive')
+            # self.renderer.SetRendererSetting('renderMode', 'interactive')
             # self.renderer.SetRendererSetting('rpr:interactive', True)
             self.renderer.SetRendererSetting('rpr:alpha:enable', False)
 
             # self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
-            # self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
-            self.renderer.SetRendererSetting('coreRenderMode', hdrpr.render_mode)
+            self.renderer.SetRendererSetting('rpr:core:renderQuality', hdrpr.render_quality)
+            self.renderer.SetRendererSetting('rpr:core:renderMode', hdrpr.render_mode)
 
             self.renderer.SetRendererSetting('rpr:ambientOcclusion:radius', hdrpr.ao_radius)
 
@@ -335,9 +334,6 @@ class ViewportEngine(Engine):
             self.renderer.SetRendererSetting('rpr:denoising:enable', denoise.enable)
             self.renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
             self.renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
-
-        else:
-            self.renderer.SetRendererPlugin(settings.delegate)
 
     def _check_restart_renderer(self, scene):
         restart = False

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -306,33 +306,38 @@ class ViewportEngine(Engine):
         settings = self.get_settings(scene)
 
         self.is_gl_delegate = settings.is_gl_delegate
-        self.renderer.SetRendererPlugin(settings.delegate)
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
             quality = hdrpr.interactive_quality
             denoise = hdrpr.denoise
 
+            # self.renderer.SetRendererPlugin(f"{settings.delegate}:{hdrpr.render_quality}")
+            self.renderer.SetRendererPlugin(settings.delegate)
+
             self.renderer.SetRendererSetting('renderMode', 'interactive')
             # self.renderer.SetRendererSetting('rpr:interactive', True)
-            self.renderer.SetRendererSetting('enableAlpha', False)
+            self.renderer.SetRendererSetting('rpr:alpha:enable', False)
 
-            self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
-            self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
+            # self.renderer.SetRendererSetting('renderDevice', hdrpr.device)
+            # self.renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)
             self.renderer.SetRendererSetting('coreRenderMode', hdrpr.render_mode)
 
-            self.renderer.SetRendererSetting('aoRadius', hdrpr.ao_radius)
+            self.renderer.SetRendererSetting('rpr:ambientOcclusion:radius', hdrpr.ao_radius)
 
-            self.renderer.SetRendererSetting('maxSamples', hdrpr.max_samples)
-            self.renderer.SetRendererSetting('minAdaptiveSamples', hdrpr.min_adaptive_samples)
-            self.renderer.SetRendererSetting('varianceThreshold', hdrpr.variance_threshold)
+            self.renderer.SetRendererSetting('rpr:maxSamples', hdrpr.max_samples)
+            self.renderer.SetRendererSetting('rpr:adaptiveSampling:minSamples', hdrpr.min_adaptive_samples)
+            self.renderer.SetRendererSetting('rpr:adaptiveSampling:noiseTreshold', hdrpr.variance_threshold)
 
-            self.renderer.SetRendererSetting('interactiveMaxRayDepth', quality.max_ray_depth)
-            self.renderer.SetRendererSetting('interactiveEnableDownscale', quality.enable_downscale)
-            self.renderer.SetRendererSetting('interactiveResolutionDownscale', quality.resolution_downscale)
+            self.renderer.SetRendererSetting('rpr:quality:interactive:rayDepth', quality.max_ray_depth)
+            self.renderer.SetRendererSetting('rpr:quality:interactive:downscale:enable', quality.enable_downscale)
+            self.renderer.SetRendererSetting('rpr:quality:interactive:downscale:resolution', quality.resolution_downscale)
 
-            self.renderer.SetRendererSetting('enableDenoising', denoise.enable)
-            self.renderer.SetRendererSetting('denoiseMinIter', denoise.min_iter)
-            self.renderer.SetRendererSetting('denoiseIterStep', denoise.iter_step)
+            self.renderer.SetRendererSetting('rpr:denoising:enable', denoise.enable)
+            self.renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
+            self.renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
+
+        else:
+            self.renderer.SetRendererPlugin(settings.delegate)
 
     def _check_restart_renderer(self, scene):
         restart = False

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -77,6 +77,7 @@ class QualitySettings(bpy.types.PropertyGroup):
         name="Ray Cast Epsilon",
         description="Determines an offset used to move light rays away from the geometry for\n"
                     "ray-surface intersection calculations",
+        subtype='DISTANCE',
         min=1e-6, max=1.0,
         default=2e-3,
     )
@@ -87,8 +88,8 @@ class QualitySettings(bpy.types.PropertyGroup):
     )
     radiance_clamping: FloatProperty(
         name="Max Radiance",
-        description="Limits the intensity, or the maximum brightness, of samples in the scene.\n"
-                    "Greater clamp radiance values produce more brightness",
+        description="Limits the intensity or the maximum brightness of samples in the scene.\n"
+                    "Greater clamp radiance values produce more brightness. Set to 0 ot disable clamping",
         min=0.0, max=1e6,
         default=0.0,
     )

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -212,7 +212,7 @@ class RenderSettings(bpy.types.PropertyGroup):
         description="Render Quality",
         items=(
             ('Northstar', "Full", "Full render quality"),
-            ('HybridPro', "Hybrid Pro", "Hybrid Pro render quality"),
+            ('HybridPro', "Interactive", "Interactive render quality"),
         ),
         default='Northstar',
     )

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -34,7 +34,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_final(HdUSD_Panel):
         layout.use_property_decorate = False
 
         col = layout.column()
-        col.prop(hdrpr, "device")
+        # col.prop(hdrpr, "device")
         col.prop(hdrpr, "render_quality")
         col.prop(hdrpr, "render_mode")
 
@@ -82,12 +82,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_quality_final(HdUSD_Panel):
         col.prop(quality, "max_ray_depth_glossy_refraction")
 
         layout.prop(quality, "raycast_epsilon")
-
-        col = layout.column(align=True)
-        col.prop(quality, "enable_radiance_clamping")
-        row = col.row()
-        row.enabled = quality.enable_radiance_clamping
-        row.prop(quality, "radiance_clamping")
+        layout.prop(quality, "radiance_clamping")
 
 
 class HDUSD_RENDER_PT_hdrpr_settings_denoise_final(HdUSD_Panel):
@@ -130,7 +125,7 @@ class HDUSD_RENDER_PT_hdrpr_settings_viewport(HdUSD_Panel):
         layout.use_property_decorate = False
 
         layout = layout.column()
-        layout.prop(hdrpr, "device")
+        # layout.prop(hdrpr, "device")
         layout.prop(hdrpr, "render_quality")
         layout.prop(hdrpr, "render_mode")
 

--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -79,8 +79,6 @@ def main(bin_dir):
     print(f"Clearing {rpr_usd_init_py}")
     rpr_usd_init_py.write_text("")
 
-    print("Done.")
-
 
 def copy_usd_debug_files(bin_dir):
     repo_dir = Path(__file__).parent.parent


### PR DESCRIPTION
### PURPOSE
RPR Core to 2.2.10 is available.

### EFFECT OF CHANGE
Updated RPR Core to 2.2.10.

### TECHNICAL STEPS
Updated HdRPR submodule to branch with Core 2.2.10.
Improved build script.

### NOTES FOR REVIEWERS
Waiting for https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/515 be merged.

CIS:REBUILD_DEPS