### PR TITLE
RPRBLND-2042: Update HdRPR with Core 2.2.10.

### DIFF
--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -211,7 +211,7 @@ class RenderSettings(bpy.types.PropertyGroup):
         description="Render Quality",
         items=(
             ('Northstar', "Full", "Full render quality"),
-            ('HybridPro', "Hybrid Pro", "Hybrid Pro render quality"),
+            ('HybridPro', "Interactive", "Interactive render quality"),
         ),
         default='Northstar',
     )

--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -60,19 +60,19 @@ def main(bin_dir):
              "IlmImf-2_3.dll", libs_dir / "lib/IlmImf-2_3.dll")
 
     if OS == 'Linux':
-        rif_bin_dir = Path("deps/HdRPR/deps/RIF/Ubuntu20/Dynamic")
+        rif_bin_dir = repo_dir / "deps/HdRPR/deps/RIF/Ubuntu20/Dynamic"
         sdk_bin_dir = libs_dir / "lib"
 
-        shutil.copy(str(find_file(rif_bin_dir, "libRadeonImageFilters.so*")),
-                    str(sdk_bin_dir / "libRadeonImageFilters.so"))
-        shutil.copy(str(find_file(rif_bin_dir, "libRadeonML_MIOpen.so*")),
-                    str(sdk_bin_dir / "libRadeonML_MIOpen.so"))
-        shutil.copy(str(find_file(rif_bin_dir, "libOpenImageDenoise.so*")),
-                    str(sdk_bin_dir / "libOpenImageDenoise.so"))
-        shutil.copy(str(find_file(rif_bin_dir, "libMIOpen.so.2*")),
-                    str(sdk_bin_dir / "libMIOpen.so.2"))
-        shutil.copy(str(find_file(rif_bin_dir, "libRadeonML.so.0*")),
-                    str(sdk_bin_dir / "libRadeonML.so.0"))
+        copy(find_file(rif_bin_dir, "libRadeonImageFilters.so*"),
+             sdk_bin_dir / "libRadeonImageFilters.so")
+        copy(find_file(rif_bin_dir, "libRadeonML_MIOpen.so*"),
+             sdk_bin_dir / "libRadeonML_MIOpen.so")
+        copy(find_file(rif_bin_dir, "libOpenImageDenoise.so*"),
+             sdk_bin_dir / "libOpenImageDenoise.so")
+        copy(find_file(rif_bin_dir, "libMIOpen.so.2*"),
+             sdk_bin_dir / "libMIOpen.so.2")
+        copy(find_file(rif_bin_dir, "libRadeonML.so.0*"),
+             sdk_bin_dir / "libRadeonML.so.0")
 
         print("Configuring rpath")
         patchelf_args = ['patchelf', '--remove-rpath', str(libs_dir / 'plugin/usd/hdRpr.so')]

--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -33,6 +33,10 @@ def iterate_files(path, glob, *, ignore_parts=(), ignore_suffix=()):
         yield f
 
 
+def find_file(path, glob):
+    return next(f for f in path.glob(glob) if not f.is_symlink())
+
+
 def main(bin_dir):
     repo_dir = Path(__file__).parent.parent
     libs_dir = repo_dir / "libs"
@@ -56,8 +60,19 @@ def main(bin_dir):
              "IlmImf-2_3.dll", libs_dir / "lib/IlmImf-2_3.dll")
 
     if OS == 'Linux':
-        for f in iterate_files(repo_dir / "deps/HdRPR/deps/RIF/Ubuntu20/Dynamic", "libRadeonML.so*"):
-            copy(f, libs_dir / "lib")
+        rif_bin_dir = Path("deps/HdRPR/deps/RIF/Ubuntu20/Dynamic")
+        sdk_bin_dir = libs_dir / "lib"
+
+        shutil.copy(str(find_file(rif_bin_dir, "libRadeonImageFilters.so*")),
+                    str(sdk_bin_dir / "libRadeonImageFilters.so"))
+        shutil.copy(str(find_file(rif_bin_dir, "libRadeonML_MIOpen.so*")),
+                    str(sdk_bin_dir / "libRadeonML_MIOpen.so"))
+        shutil.copy(str(find_file(rif_bin_dir, "libOpenImageDenoise.so*")),
+                    str(sdk_bin_dir / "libOpenImageDenoise.so"))
+        shutil.copy(str(find_file(rif_bin_dir, "libMIOpen.so.2*")),
+                    str(sdk_bin_dir / "libMIOpen.so.2"))
+        shutil.copy(str(find_file(rif_bin_dir, "libRadeonML.so.0*")),
+                    str(sdk_bin_dir / "libRadeonML.so.0"))
 
         print("Configuring rpath")
         patchelf_args = ['patchelf', '--remove-rpath', str(libs_dir / 'plugin/usd/hdRpr.so')]

--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -33,10 +33,6 @@ def iterate_files(path, glob, *, ignore_parts=(), ignore_suffix=()):
         yield f
 
 
-def find_file(path, glob):
-    return next(f for f in path.glob(glob) if not f.is_symlink())
-
-
 def main(bin_dir):
     repo_dir = Path(__file__).parent.parent
     libs_dir = repo_dir / "libs"
@@ -60,20 +56,6 @@ def main(bin_dir):
              "IlmImf-2_3.dll", libs_dir / "lib/IlmImf-2_3.dll")
 
     if OS == 'Linux':
-        rif_bin_dir = repo_dir / "deps/HdRPR/deps/RIF/Ubuntu20/Dynamic"
-        sdk_bin_dir = libs_dir / "lib"
-
-        copy(find_file(rif_bin_dir, "libRadeonImageFilters.so*"),
-             sdk_bin_dir / "libRadeonImageFilters.so")
-        copy(find_file(rif_bin_dir, "libRadeonML_MIOpen.so*"),
-             sdk_bin_dir / "libRadeonML_MIOpen.so")
-        copy(find_file(rif_bin_dir, "libOpenImageDenoise.so*"),
-             sdk_bin_dir / "libOpenImageDenoise.so")
-        copy(find_file(rif_bin_dir, "libMIOpen.so.2*"),
-             sdk_bin_dir / "libMIOpen.so.2")
-        copy(find_file(rif_bin_dir, "libRadeonML.so.0*"),
-             sdk_bin_dir / "libRadeonML.so.0")
-
         print("Configuring rpath")
         patchelf_args = ['patchelf', '--remove-rpath', str(libs_dir / 'plugin/usd/hdRpr.so')]
         print(patchelf_args)


### PR DESCRIPTION
CIS:REBUILD_DEPS

### PURPOSE
RPR Core to 2.2.10 is available.

### EFFECT OF CHANGE
Updated RPR Core to 2.2.10.

### TECHNICAL STEPS
Set deps\HdRPR submodule to origin:core-2.2.10_no-usd-schema
Improved build script.

### NOTES FOR REVIEWERS
We can't use latest HdRPR currently because of https://github.com/GPUOpen-LibrariesAndSDKs/RadeonProRenderUSD/pull/508. 
To use USD schema for HdRPR will be done in separate task.