### PR TITLE
RPRBLND-1949: USD Transform node doesn't update empty objects in USD NodeTree outliner

### DIFF
--- a/src/hdusd/properties/object.py
+++ b/src/hdusd/properties/object.py
@@ -71,6 +71,10 @@ class ObjectProperties(HdUSDProperties):
         prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
         prim_obj.hide_viewport = prim.GetTypeName() not in GEOM_TYPES
 
+    def sync_transform_from_prim(self, prim):
+        prim_obj = self.id_data
+        prim_obj.matrix_local = usd_utils.get_xform_transform(UsdGeom.Xform(prim))
+
     def sync_to_prim(self):
         prim = self.get_prim()
         if not prim:

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -181,6 +181,9 @@ class HDUSD_NODE_PT_usd_list(HdUSD_Panel):
             sort_lock=True
         )
 
+        if usd_list.item_index < 0:
+            return
+
         prop_layout = layout.column()
         prop_layout.use_property_split = True
         prop_layout.use_property_decorate = True

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -234,7 +234,7 @@ class BlenderDataNode(USDNode):
 
             if isinstance(update.id, bpy.types.Object):
                 obj = update.id
-                if obj.hdusd.is_usd:
+                if obj.hdusd.is_usd or obj.type == 'EMPTY':
                     continue
 
                 obj_data = ObjectData.from_object(obj)
@@ -302,7 +302,7 @@ class BlenderDataNode(USDNode):
                     for key in keys_to_remove:
                         if key == world.OBJ_PRIM_NAME:
                             continue
-                            
+
                         root_prim.GetStage().RemovePrim(root_prim.GetPath().AppendChild(key))
                         is_updated = True
 

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -67,11 +67,18 @@ def update(context):
 
         paths_to_remove = obj_paths - prim_paths
         paths_to_add = prim_paths - obj_paths
+        path_to_update = obj_paths.intersection(prim_paths)
 
         log(f"Removing {len(paths_to_remove)} objects")
         for path in paths_to_remove:
             obj = objects.pop(path)
             bpy.data.objects.remove(obj)
+
+        log(f"Updated {len(path_to_update)} objects")
+        for path in path_to_update:
+            prim = stage.GetPrimAtPath(path)
+            if prim.GetTypeName() in GEOM_TYPES:
+                objects[path].hdusd.sync_transform_from_prim(prim)
 
         log(f"Adding {len(paths_to_add)} objects")
         for path in sorted(paths_to_add):


### PR DESCRIPTION
### PURPOSE
USD Transform, TransformByEmptyNode, InstancingNode nodes don't update empty objects in USD NodeTree outliner and viewport.

### EFFECT OF CHANGE
Now empty updates immediately.

### TECHNICAL STEPS
Added method sync_transform_from_prim to ObjectProperties.
Excluded empty object from depsgraph_update method for BlenderDataNode.

### NOTES FOR REVIEWERS
 Recursion issues found while handing the task were fixed. It's good to test various nodetree cases.
 