### PR TITLE
RPRBLND-2048: Frame node causes an error in USD nodetree

### DIFF
--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -60,7 +60,7 @@ class USDTree(bpy.types.ShaderNodeTree):
         self._is_resetting = True
 
         try:
-            nodes = tuple(node for node in nodes if not isinstance(node, bpy.types.NodeReroute)
+            nodes = tuple(node for node in nodes if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame))
                           and (is_hard or node.use_hard_reset))
 
             for node in nodes:
@@ -87,7 +87,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, bpy.types.NodeReroute):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
                 node.depsgraph_update(depsgraph)
 
     def frame_change(self, depsgraph):
@@ -102,7 +102,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, bpy.types.NodeReroute):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
                 node.material_update(depsgraph)
 
     def no_update_call(self, op, *args, **kwargs):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -95,7 +95,8 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            node.frame_change(depsgraph)
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
+                node.frame_change(depsgraph)
 
     def material_update(self, depsgraph):
         if self._is_resetting:


### PR DESCRIPTION
### PURPOSE
Frame node causes an error in USD nodetree.

### EFFECT OF CHANGE
Frame node works as expected in USD nodetree.

### TECHNICAL STEPS
In USDTree fixed condition in methods: _reset_nodes, depsgraph_update, frame_change, material_update
