### PR TITLE
RPRBLND-2030: Selected light source showed orange with GL Delegate

### DIFF
--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -345,6 +345,11 @@ class ViewportEngine(Engine):
             hdrpr = settings.hdrpr
             restart = self.renderer.GetRendererSetting('renderQuality') != hdrpr.render_quality
 
+        # temporary solution due to "material preview red painting" issue
+        # we need to restart renderer to remove red from material after switching from material preview
+        if settings.delegate == "HdStormRendererPlugin" and self.shading_data.type == 'MATERIAL':
+            restart = True
+
         return restart
 
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -264,11 +264,14 @@ class ViewportEngine(Engine):
         self.render_params.renderResolution = (view_settings.width, view_settings.height)
         self.render_params.clipPlanes = [Gf.Vec4d(i) for i in gf_camera.clippingPlanes]
 
-        if self.shading_data.type == 'MATERIAL' and self.is_gl_delegate:
+        if self.is_gl_delegate:
             l = Glf.SimpleLight()
             l.ambient = (0, 0, 0, 0)
             l.position = (*gf_camera.frustum.position, 1)
 
+            if not self.shading_data.type == 'MATERIAL':
+                l.isDomeLight = True
+                
             mat = Glf.SimpleMaterial()
 
             self.renderer.SetLightingState((l,), mat, (0, 0, 0, 0))


### PR DESCRIPTION
### PURPOSE
Materials become orange if user clicks on scene in viewport render using GL delegate

### EFFECT OF CHANGE
Fixed issue with GL delegate in viewport render when materials become orange if user clicks in scene

### TECHNICAL STEPS
added parameter `l.isDomeLight = True` for SimpleLight. Now it's created every time for GL delegate

### NOTES FOR REVIEWERS
There is the same issue with material preview, which can't be fixed right now.
Warnings in console:
- `Dome light has no texture asset path.` 
- `Invalid texture for dome light environment map`
- `Could not open dome light texture file`

also known and can't be fixed right now