### PR TITLE
Enabling matlib by default in config.py

### DIFF
--- a/src/hdusd/config.py
+++ b/src/hdusd/config.py
@@ -18,7 +18,7 @@ logging_level = 'INFO'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR',
 logging_backups = 5
 
 # other settings
-matlib_enabled = False
+matlib_enabled = True
 engine_use_preview = True
 usd_mesh_assign_material_enabled = False
 


### PR DESCRIPTION
### PURPOSE
Online matlib is ready to be open for users.

### EFFECT OF CHANGE
Enabling Matlib panel in Materials tab.

### TECHNICAL STEPS
Set config.matlib_enabled = True