### PR TITLE
RPRBLND-2016: Improve Material X editor workflow

### DIFF
--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -725,7 +725,7 @@ def depsgraph_update(depsgraph):
     if hasattr(context, 'object') and context.object and context.object.active_material:
         mx_node_tree = context.object.active_material.hdusd.mx_node_tree
 
-    bpy.types.NODE_HT_header.remove(update_material_iu)
+    bpy.types.NODE_HT_header.remove(update_material_ui)
     for window in context.window_manager.windows:
         if not hasattr(window.screen, 'areas'):
             continue
@@ -747,11 +747,11 @@ def depsgraph_update(depsgraph):
 
             area.ui_type = 'ShaderNodeTree'
 
-    bpy.types.NODE_HT_header.append(update_material_iu)
+    bpy.types.NODE_HT_header.append(update_material_ui)
 
 
 # update for material ui according to MaterialX nodetree header changes
-def update_material_iu(self, context):
+def update_material_ui(self, context):
     if BLENDER_VERSION >= '3.0':
         return
 

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -725,28 +725,26 @@ def depsgraph_update(depsgraph):
     if hasattr(context, 'object') and context.object and context.object.active_material:
         mx_node_tree = context.object.active_material.hdusd.mx_node_tree
 
-    # trying to show MaterialX area with node tree or Shader area
-    screen = context.screen
-    if not hasattr(screen, 'areas'):
-        return
-
-    if mx_node_tree:
-        for area in screen.areas:
+    bpy.types.NODE_HT_header.remove(mx_utils.update_material_iu)
+    for window in context.window_manager.windows:
+        if not hasattr(window.screen, 'areas'):
+            continue
+        for area in window.screen.areas:
             if area.ui_type not in ('hdusd.MxNodeTree', 'ShaderNodeTree'):
                 continue
 
             space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
-            if not space.pin:
-                bpy.types.NODE_HT_header.remove(mx_utils.update_material_iu)
+            if space.pin:
+                continue
+
+            if mx_node_tree:
                 area.ui_type = 'hdusd.MxNodeTree'
                 space.node_tree = mx_node_tree
-                bpy.types.NODE_HT_header.append(mx_utils.update_material_iu)
+                continue
 
-    else:
-        for area in screen.areas:
             if area.ui_type != 'hdusd.MxNodeTree':
                 continue
 
-            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
-            if not space.pin:
-                area.ui_type = 'ShaderNodeTree'
+            area.ui_type = 'ShaderNodeTree'
+
+    bpy.types.NODE_HT_header.append(mx_utils.update_material_iu)

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -735,13 +735,18 @@ def depsgraph_update(depsgraph):
             if area.ui_type not in ('hdusd.MxNodeTree', 'ShaderNodeTree'):
                 continue
 
-            area.ui_type = 'hdusd.MxNodeTree'
             space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
-            space.node_tree = mx_node_tree
+            if not space.pin:
+                bpy.types.NODE_HT_header.remove(mx_utils.update_material_iu)
+                area.ui_type = 'hdusd.MxNodeTree'
+                space.node_tree = mx_node_tree
+                bpy.types.NODE_HT_header.append(mx_utils.update_material_iu)
 
     else:
         for area in screen.areas:
             if area.ui_type != 'hdusd.MxNodeTree':
                 continue
 
-            area.ui_type = 'ShaderNodeTree'
+            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
+            if not space.pin:
+                area.ui_type = 'ShaderNodeTree'

--- a/src/hdusd/ui/panels.py
+++ b/src/hdusd/ui/panels.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import bpy
+from ..utils import mx as mx_utils
 
 
 def get_panels():
@@ -81,9 +82,15 @@ def register():
     for panel in get_panels():
         panel.COMPAT_ENGINES.add('HdUSD')
 
+    # set update for material ui according to MaterialX nodetree header changes
+    bpy.types.NODE_HT_header.append(mx_utils.update_material_iu)
+
 
 def unregister():
     # remove HdUSD panels filter
     for panel in get_panels():
         if 'HdUSD' in panel.COMPAT_ENGINES:
             panel.COMPAT_ENGINES.remove('HdUSD')
+
+    # remove update for material ui according to MaterialX nodetree header changes
+    bpy.types.NODE_HT_header.remove(mx_utils.update_material_iu)

--- a/src/hdusd/ui/panels.py
+++ b/src/hdusd/ui/panels.py
@@ -14,6 +14,7 @@
 #********************************************************************
 import bpy
 from ..utils import mx as mx_utils
+from .material import update_material_iu
 
 
 def get_panels():
@@ -83,7 +84,7 @@ def register():
         panel.COMPAT_ENGINES.add('HdUSD')
 
     # set update for material ui according to MaterialX nodetree header changes
-    bpy.types.NODE_HT_header.append(mx_utils.update_material_iu)
+    bpy.types.NODE_HT_header.append(update_material_iu)
 
 
 def unregister():
@@ -93,4 +94,4 @@ def unregister():
             panel.COMPAT_ENGINES.remove('HdUSD')
 
     # remove update for material ui according to MaterialX nodetree header changes
-    bpy.types.NODE_HT_header.remove(mx_utils.update_material_iu)
+    bpy.types.NODE_HT_header.remove(update_material_iu)

--- a/src/hdusd/ui/panels.py
+++ b/src/hdusd/ui/panels.py
@@ -14,7 +14,7 @@
 #********************************************************************
 import bpy
 from ..utils import mx as mx_utils
-from .material import update_material_iu
+from .material import update_material_ui
 
 
 def get_panels():
@@ -84,7 +84,7 @@ def register():
         panel.COMPAT_ENGINES.add('HdUSD')
 
     # set update for material ui according to MaterialX nodetree header changes
-    bpy.types.NODE_HT_header.append(update_material_iu)
+    bpy.types.NODE_HT_header.append(update_material_ui)
 
 
 def unregister():
@@ -94,4 +94,4 @@ def unregister():
             panel.COMPAT_ENGINES.remove('HdUSD')
 
     # remove update for material ui according to MaterialX nodetree header changes
-    bpy.types.NODE_HT_header.remove(update_material_iu)
+    bpy.types.NODE_HT_header.remove(update_material_ui)

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -19,7 +19,7 @@ import shutil
 
 from pathlib import Path
 
-from . import LIBS_DIR, title_str, code_str, BLENDER_VERSION
+from . import LIBS_DIR, title_str, code_str
 from .image import cache_image_file
 
 from . import logging
@@ -289,26 +289,3 @@ def export_mx_to_file(doc, filepath, *, mx_node_tree=None, is_export_deps=False,
 
     mx.writeToXmlFile(doc, filepath)
     log(f"Export MaterialX to {filepath}: completed successfuly")
-
-
-# update for material ui according to MaterialX nodetree header changes
-def update_material_iu(self, context):
-    if BLENDER_VERSION >= '3.0':
-        return
-
-    space = context.space_data
-    mat = context.object.active_material
-    if space.tree_type == 'ShaderNodeTree':
-        if space.node_tree != mat.node_tree:
-            space.node_tree = mat.node_tree
-            mat.hdusd.mx_node_tree = None
-            return
-
-    if space.tree_type != 'hdusd.MxNodeTree':
-        return
-
-    ui_mx_node_tree = mat.hdusd.mx_node_tree
-    editor_node_tree = space.node_tree
-
-    if editor_node_tree != ui_mx_node_tree and not space.pin:
-        mat.hdusd.mx_node_tree = editor_node_tree

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -289,3 +289,17 @@ def export_mx_to_file(doc, filepath, *, mx_node_tree=None, is_export_deps=False,
 
     mx.writeToXmlFile(doc, filepath)
     log(f"Export MaterialX to {filepath}: completed successfuly")
+
+
+# update for material ui according to MaterialX nodetree header changes
+def update_material_iu(self, context):
+    space = context.space_data
+    if space.tree_type != 'hdusd.MxNodeTree':
+        return
+
+    mat = context.object.active_material
+    ui_mx_node_tree = mat.hdusd.mx_node_tree
+    editor_node_tree = space.node_tree
+
+    if editor_node_tree != ui_mx_node_tree:
+        mat.hdusd.mx_node_tree = editor_node_tree

--- a/src/hdusd/utils/mx.py
+++ b/src/hdusd/utils/mx.py
@@ -19,7 +19,7 @@ import shutil
 
 from pathlib import Path
 
-from . import LIBS_DIR, title_str, code_str
+from . import LIBS_DIR, title_str, code_str, BLENDER_VERSION
 from .image import cache_image_file
 
 from . import logging
@@ -293,13 +293,22 @@ def export_mx_to_file(doc, filepath, *, mx_node_tree=None, is_export_deps=False,
 
 # update for material ui according to MaterialX nodetree header changes
 def update_material_iu(self, context):
+    if BLENDER_VERSION >= '3.0':
+        return
+
     space = context.space_data
+    mat = context.object.active_material
+    if space.tree_type == 'ShaderNodeTree':
+        if space.node_tree != mat.node_tree:
+            space.node_tree = mat.node_tree
+            mat.hdusd.mx_node_tree = None
+            return
+
     if space.tree_type != 'hdusd.MxNodeTree':
         return
 
-    mat = context.object.active_material
     ui_mx_node_tree = mat.hdusd.mx_node_tree
     editor_node_tree = space.node_tree
 
-    if editor_node_tree != ui_mx_node_tree:
+    if editor_node_tree != ui_mx_node_tree and not space.pin:
         mat.hdusd.mx_node_tree = editor_node_tree


### PR DESCRIPTION
### PURPOSE
Need to fix material X Editor workflow, because now MaterialX selection doesn't work as expected.

### EFFECT OF CHANGE
Improved MaterialX nodetree editor behavior when selecting MaterialX through Material Properties.

### TECHNICAL STEPS
Added update_material_iu function.
Added turn on/off for bpy.types.NODE_HT_header updates.
Added condition for nodetree pin option.

### NOTES FOR REVIEWERS
There's a workaround for Blender 3.0 because of changing logic. For Blender 3.0 implemented only the pin option.
