### PR TITLE
RPRBLND-2045: add "Film Transparent Background" option

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -73,7 +73,6 @@ class FinalEngine(Engine):
         params = UsdImagingGL.RenderParams()
         params.renderResolution = (self.width, self.height)
         params.frame = Usd.TimeCode.Default()
-        params.enableSampleAlphaToCoverage = True
 
         if scene.hdusd.final.data_source:
             world_data = world.WorldData.init_from_stage(self.stage)

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -73,6 +73,7 @@ class FinalEngine(Engine):
         params = UsdImagingGL.RenderParams()
         params.renderResolution = (self.width, self.height)
         params.frame = Usd.TimeCode.Default()
+        params.enableSampleAlphaToCoverage = True
 
         if scene.hdusd.final.data_source:
             world_data = world.WorldData.init_from_stage(self.stage)
@@ -232,7 +233,7 @@ class FinalEngine(Engine):
 
             renderer.SetRendererSetting('renderMode', 'batch')
             renderer.SetRendererSetting('progressive', True)
-            renderer.SetRendererSetting('enableAlpha', False)
+            renderer.SetRendererSetting('enableAlpha', hdrpr.enable_alpha)
 
             renderer.SetRendererSetting('renderDevice', hdrpr.device)
             renderer.SetRendererSetting('renderQuality', hdrpr.render_quality)

--- a/src/hdusd/properties/hdrpr_render.py
+++ b/src/hdusd/properties/hdrpr_render.py
@@ -260,8 +260,8 @@ class RenderSettings(bpy.types.PropertyGroup):
     )
     enable_alpha: BoolProperty(
         name="Enable Color Alpha",
-        description="Enable Color Alpha",
-        default=True,
+        description="World background is transparent, for compositing the render over another background",
+        default=False,
     )
     enable_motion_blur: BoolProperty(
         name="Enable Beauty Motion Blur",

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -69,6 +69,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_final,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_final,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_denoise_final,
+    hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_film_final,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_viewport,

--- a/src/hdusd/ui/hdrpr_render.py
+++ b/src/hdusd/ui/hdrpr_render.py
@@ -111,6 +111,21 @@ class HDUSD_RENDER_PT_hdrpr_settings_denoise_final(HdUSD_Panel):
         layout.prop(denoise, "iter_step")
 
 
+class HDUSD_RENDER_PT_hdrpr_settings_film_final(HdUSD_Panel):
+    bl_label = "Film"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdrpr_settings_final'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        hdrpr = context.scene.hdusd.final.hdrpr
+
+        layout.prop(hdrpr, "enable_alpha", text="Transparent Background")
+
+
 #
 # VIEWPORT RENDER SETTINGS
 #


### PR DESCRIPTION
### PURPOSE
Add "Film Transparent Background" option for HDRPR final render.

### EFFECT OF CHANGE
Added Film subpanel with Transparent Background option for HDRPR final render.

### TECHNICAL STEPS
Added class HDUSD_RENDER_PT_hdrpr_settings_film_final.
Added description to property enable_alpha, set the default to False as in blender.
Connected render settings with enable_alpha property.
