### PR TITLE
RPRBLND-2060: Fix updating materials in viewport after HdRPR update

### DIFF
--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -340,7 +340,7 @@ class ViewportEngine(Engine):
         settings = self.get_settings(scene)
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
-            restart = self.renderer.GetRendererSetting('renderQuality') != hdrpr.render_quality
+            restart = self.renderer.GetRendererSetting('rpr:core:renderQuality') != hdrpr.render_quality
 
         return restart
 


### PR DESCRIPTION
### PURPOSE
Fix updating materials in viewport after HdRPR update

### EFFECT OF CHANGE
Fixed updating materials during active viewport render.

### TECHNICAL STEPS
Actualized name of render setting for identifying do we need to restart renderer.