### PR TITLE
RPRBLND-2069: Blender 3.0 MaterialX editor error while link nodes and open Material Properies

### DIFF
--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -16,7 +16,7 @@ import MaterialX as mx
 
 import bpy
 
-from ...utils import title_str, code_str, LIBS_DIR, pass_node_reroute
+from ...utils import title_str, code_str, LIBS_DIR, pass_node_reroute, BLENDER_VERSION
 from ...utils import mx as mx_utils
 from . import log
 
@@ -234,7 +234,7 @@ class MxNode(bpy.types.ShaderNode):
                 box = row.box()
                 box.scale_x = 0.7
                 box.scale_y = 0.5
-                box.emboss = 'UI_EMBOSS_NONE_OR_STATUS'
+                box.emboss = 'NONE_OR_STATUS' if BLENDER_VERSION >= "3.0" else 'UI_EMBOSS_NONE_OR_STATUS'
 
                 op = box.operator(HDUSD_MATERIAL_OP_invoke_popup_input_nodes.bl_idname, icon='HANDLETYPE_AUTO_CLAMP_VEC')
                 op.input_num = i


### PR DESCRIPTION
### PURPOSE
Replace UI_EMBOSS_NONE_OR_STATUS with NONE_OR_STATUS in UILayout.emboss for Blender3.0.

### EFFECT OF CHANGE
Fixed issue when linking two nodes in MaterialX editor in Blender 3.0.

### TECHNICAL STEPS
Added condition for blender 3.0 and higher versions.
