### PR TITLE
RPRBLND-1990: path_tracer_shade.h:41: '' : syntax error, unexpected IDENTIFIER

### DIFF
--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -341,7 +341,8 @@ class NodeParser:
         link = socket_in.links[0]
 
         if link.from_socket.type != link.to_socket.type:
-            log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
+            log.warn("Different input and output types", link,
+                     link.to_socket.type, link.to_socket.type, self.node, self.material)
             return None
 
         if not link.is_valid:

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -340,6 +340,10 @@ class NodeParser:
 
         link = socket_in.links[0]
 
+        if link.from_socket.type != link.to_socket.type:
+            log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
+            return None
+
         if not link.is_valid:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
             return None

--- a/src/hdusd/bl_nodes/node_parser.py
+++ b/src/hdusd/bl_nodes/node_parser.py
@@ -340,11 +340,6 @@ class NodeParser:
 
         link = socket_in.links[0]
 
-        if link.from_socket.type != link.to_socket.type:
-            log.warn("Different input and output types", link,
-                     link.to_socket.type, link.to_socket.type, self.node, self.material)
-            return None
-
         if not link.is_valid:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.material)
             return None

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -256,12 +256,7 @@ class NodeParser:
 
         link = socket_in.links[0]
 
-        if link.from_socket.type != link.to_socket.type:
-            log.warn("Different input and output types", link,
-                     link.to_socket.type, link.to_socket.type, self.node, self.world)
-            return None
-
-        # # check if linked is correct
+        # check if linked is correct
         if not link.is_valid:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.world)
             return None

--- a/src/hdusd/export/world/node_parser.py
+++ b/src/hdusd/export/world/node_parser.py
@@ -256,6 +256,11 @@ class NodeParser:
 
         link = socket_in.links[0]
 
+        if link.from_socket.type != link.to_socket.type:
+            log.warn("Different input and output types", link,
+                     link.to_socket.type, link.to_socket.type, self.node, self.world)
+            return None
+
         # # check if linked is correct
         if not link.is_valid:
             log.warn("Invalid link ignored", link, socket_in, self.node, self.world)

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -254,25 +254,17 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
             if material.hdusd.mx_node_tree and material.hdusd.mx_node_tree.name == self.name:
                 material.hdusd.update()
 
-        self.update_invalid_links()
-
         for window in bpy.context.window_manager.windows:
             for area in window.screen.areas:
                 if area.type == AREA_TO_UPDATE:
                     for region in area.regions:
                         if region.type == REGION_TO_UPDATE:
                             region.tag_redraw()
-                            break
-                    break
 
-
-    def update_invalid_links(self):
+    def update_links(self):
         for link in self.links:
-            node_from = link.from_socket.node
-            socket_from_type = node_from.nodedef.getOutput(link.from_socket.name).getType()
-
-            node_to = link.to_socket.node
-            socket_to_type = node_to.nodedef.getInput(link.to_socket.name).getType()
+            socket_from_type = link.from_socket.node.nodedef.getOutput(link.from_socket.name).getType()
+            socket_to_type = link.to_socket.node.nodedef.getInput(link.to_socket.name).getType()
 
             if socket_to_type != socket_from_type:
                 link.is_valid = False

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -250,6 +250,8 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
         self.update_()
 
     def update_(self):
+        self.update_links()
+
         for material in bpy.data.materials:
             if material.hdusd.mx_node_tree and material.hdusd.mx_node_tree.name == self.name:
                 material.hdusd.update()

--- a/src/hdusd/mx_nodes/node_tree.py
+++ b/src/hdusd/mx_nodes/node_tree.py
@@ -254,6 +254,8 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
             if material.hdusd.mx_node_tree and material.hdusd.mx_node_tree.name == self.name:
                 material.hdusd.update()
 
+        self.update_invalid_links()
+
         for window in bpy.context.window_manager.windows:
             for area in window.screen.areas:
                 if area.type == AREA_TO_UPDATE:
@@ -262,3 +264,18 @@ class MxNodeTree(bpy.types.ShaderNodeTree):
                             region.tag_redraw()
                             break
                     break
+
+
+    def update_invalid_links(self):
+        for link in self.links:
+            node_from = link.from_socket.node
+            socket_from_type = node_from.nodedef.getOutput(link.from_socket.name).getType()
+
+            node_to = link.to_socket.node
+            socket_to_type = node_to.nodedef.getInput(link.to_socket.name).getType()
+
+            if socket_to_type != socket_from_type:
+                link.is_valid = False
+                continue
+
+            link.is_valid = True

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -373,11 +373,11 @@ class MxNode(bpy.types.ShaderNode):
         socket_to_type = node_to.nodedef.getInput(link.to_socket.name).getType()
 
         if socket_to_type != socket_from_type:
-            log.error("Invalid link found", link, socket_in, self)
+            log.warn("Different input and output types", link, socket_to_type, socket_from_type, self)
             return None
 
         if not link.is_valid:
-            log.error("Invalid link found", link, socket_in, self)
+            log.warn("Invalid link found", link, socket_in, self)
             return None
 
         link = pass_node_reroute(link)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -365,13 +365,6 @@ class MxNode(bpy.types.ShaderNode):
             return None
 
         link = socket_in.links[0]
-        socket_from_type = link.from_socket.node.nodedef.getOutput(link.from_socket.name).getType()
-        socket_to_type = link.to_socket.node.nodedef.getInput(link.to_socket.name).getType()
-
-        if socket_to_type != socket_from_type:
-            log.warn("Different input and output types", link, socket_to_type, socket_from_type, self)
-            return None
-
         if not link.is_valid:
             log.warn("Invalid link found", link, socket_in, self)
             return None

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -365,12 +365,8 @@ class MxNode(bpy.types.ShaderNode):
             return None
 
         link = socket_in.links[0]
-
-        node_from = link.from_socket.node
-        socket_from_type = node_from.nodedef.getOutput(link.from_socket.name).getType()
-
-        node_to = link.to_socket.node
-        socket_to_type = node_to.nodedef.getInput(link.to_socket.name).getType()
+        socket_from_type = link.from_socket.node.nodedef.getOutput(link.from_socket.name).getType()
+        socket_to_type = link.to_socket.node.nodedef.getInput(link.to_socket.name).getType()
 
         if socket_to_type != socket_from_type:
             log.warn("Different input and output types", link, socket_to_type, socket_from_type, self)

--- a/src/hdusd/mx_nodes/nodes/base_node.py
+++ b/src/hdusd/mx_nodes/nodes/base_node.py
@@ -365,8 +365,20 @@ class MxNode(bpy.types.ShaderNode):
             return None
 
         link = socket_in.links[0]
+
+        node_from = link.from_socket.node
+        socket_from_type = node_from.nodedef.getOutput(link.from_socket.name).getType()
+
+        node_to = link.to_socket.node
+        socket_to_type = node_to.nodedef.getInput(link.to_socket.name).getType()
+
+        if socket_to_type != socket_from_type:
+            log.error("Invalid link found", link, socket_in, self)
+            return None
+
         if not link.is_valid:
             log.error("Invalid link found", link, socket_in, self)
+            return None
 
         link = pass_node_reroute(link)
         if not link:

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -748,4 +748,4 @@ def depsgraph_update(depsgraph):
                 if area.ui_type != 'hdusd.MxNodeTree':
                     continue
 
-            area.ui_type = 'ShaderNodeTree'
+                area.ui_type = 'ShaderNodeTree'

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -731,19 +731,21 @@ def depsgraph_update(depsgraph):
         return
 
     if mx_node_tree:
-        for area in screen.areas:
-            if area.ui_type not in ('hdusd.MxNodeTree', 'ShaderNodeTree'):
-                continue
+        for window in context.window_manager.windows:
+            for area in window.screen.areas:
+                if area.ui_type not in ('hdusd.MxNodeTree', 'ShaderNodeTree'):
+                    continue
 
-            area.ui_type = 'hdusd.MxNodeTree'
-            space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
-            space.node_tree = mx_node_tree
+                area.ui_type = 'hdusd.MxNodeTree'
+                space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
+                space.node_tree = mx_node_tree
 
-            mx_node_tree.update_invalid_links()
+                mx_node_tree.update_links()
 
     else:
-        for area in screen.areas:
-            if area.ui_type != 'hdusd.MxNodeTree':
-                continue
+        for window in context.window_manager.windows:
+            for area in window.screen.areas:
+                if area.ui_type != 'hdusd.MxNodeTree':
+                    continue
 
             area.ui_type = 'ShaderNodeTree'

--- a/src/hdusd/ui/material.py
+++ b/src/hdusd/ui/material.py
@@ -739,6 +739,8 @@ def depsgraph_update(depsgraph):
             space = next(s for s in area.spaces if s.type == 'NODE_EDITOR')
             space.node_tree = mx_node_tree
 
+            mx_node_tree.update_invalid_links()
+
     else:
         for area in screen.areas:
             if area.ui_type != 'hdusd.MxNodeTree':


### PR DESCRIPTION
### PURPOSE
Fix an error with parsing MaterialX when input and output types of connected node's sockets.

### EFFECT OF CHANGE
Node's link in MaterialX nodetree editor now becomes invalid when types of output and input node's sockets are different.
Fixed switch to MaterialX nodetree editor if secondary window of blender are opened.

### TECHNICAL STEPS
Added update_links() method to MxNodeTree.
It is used when Blender calls update() of MxNodeTree and depsgraph_update of ui/material.py.
In depsgraph_update now iterates throught all context.window_manager.windows.

### NOTES FOR REVIEWERS
In MaterialX node editor now links become red/invalid and nodes aren't calculated. To have the correct render result, the user needs to define all socket types properly before rendering.
