### PR TITLE
RPRBLND-2071: Blender Data USD nodes issue.

### DIFF
--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -303,8 +303,8 @@ class BlenderDataNode(USDNode):
                     if object.sdf_name(self.object) in depsgraph_keys:
                         required_keys = {object.sdf_name(self.object)}
 
-                keys_to_remove = (current_keys - required_keys) | parents_keys
-                keys_to_add = required_keys - current_keys - parents_keys
+                keys_to_remove = current_keys - required_keys
+                keys_to_add = required_keys - current_keys
 
                 if keys_to_remove:
                     for key in keys_to_remove:

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -280,7 +280,6 @@ class BlenderDataNode(USDNode):
                 required_keys = set()
                 depsgraph_keys = set(obj_data.sdf_name for obj_data in ObjectData.depsgraph_objects(depsgraph))
                 instances_keys = set(obj_data.sdf_name for obj_data in ObjectData.depsgraph_objects_inst(depsgraph))
-                parents_keys = set(obj_data.sdf_name for obj_data in ObjectData.parent_objects(depsgraph))
 
                 if self.data == 'SCENE':
                     required_keys = depsgraph_keys


### PR DESCRIPTION
### PURPOSE
Fix issue with not rendered objects if Data Source is NodeTree and parent of object is Empty object.

### EFFECT OF CHANGE
Fixed issue with not rendered objects if Data Source is NodeTree and parent of object is Empty object.

### TECHNICAL STEPS
Fix wrong getting add/remove keys in blender_data node