### PR TITLE
RPRBLND-2081: Download materials to Material Library via blender console

### DIFF
--- a/src/hdusd/utils/matlib.py
+++ b/src/hdusd/utils/matlib.py
@@ -334,7 +334,7 @@ class Manager:
         if self.materials is not None and not reset:
             return True
 
-        if reset:
+        if reset and self.pcoll:
             bpy.utils.previews.remove(self.pcoll)
 
         self.materials = {}


### PR DESCRIPTION
### PURPOSE
Download materials to Material Library via blender console.

### EFFECT OF CHANGE
Download materials to Material Library via blender console using bpy.ops.hdusd.matlib_load().

### TECHNICAL STEPS
Added condition to check self.pcolls existance.
