### PR TITLE
BLEN-58: Error with Country-Kitchen Cycles scene

### DIFF
--- a/src/hdusd/properties/material.py
+++ b/src/hdusd/properties/material.py
@@ -38,6 +38,10 @@ class MaterialProperties(HdUSDProperties):
     @property
     def output_node(self):
         material = self.id_data
+
+        if not material.node_tree:
+            return None
+
         return next((node for node in material.node_tree.nodes if
                      node.bl_idname == ShaderNodeOutputMaterial.__name__ and
                      node.is_active_output), None)


### PR DESCRIPTION
### PURPOSE
Fix exception if nodetree isn't exist for material.

### EFFECT OF CHANGE
Render and material UI panel works fine if nodetree isn't exist for material.

### TECHNICAL STEPS
Added check for nodetree existence.