### PR TITLE
Improvements in build process: added build variant option.

### DIFF
--- a/tools/build.py
+++ b/tools/build.py
@@ -58,7 +58,7 @@ def print_start(msg):
 -------------------------------------------------------------""")
 
 
-def usd(bin_dir, jobs, clean):
+def usd(bin_dir, jobs, clean, build_var):
     print_start("Building USD")
 
     import build_usd
@@ -66,10 +66,10 @@ def usd(bin_dir, jobs, clean):
     if jobs > 0:
         args += ['-j', str(jobs)]
 
-    build_usd.main(bin_dir, clean, *args)
+    build_usd.main(bin_dir, clean, build_var, *args)
 
 
-def _cmake(d, compiler, jobs, args):
+def _cmake(d, compiler, jobs, build_var, args):
     cur_dir = os.getcwd()
     ch_dir(d)
 
@@ -77,9 +77,13 @@ def _cmake(d, compiler, jobs, args):
     if compiler:
         build_args += ['-G', compiler]
 
+    build_name = {'release': 'Release',
+                  'debug': 'Debug',
+                  'relwithdebuginfo': 'RelWithDebInfo'}[build_var]
+
     compile_args = [
         '--build', 'build',
-        '--config', 'Release',
+        '--config', build_name,
         '--target', 'install'
     ]
     if jobs > 0:
@@ -93,7 +97,7 @@ def _cmake(d, compiler, jobs, args):
         ch_dir(cur_dir)
 
 
-def hdrpr(bin_dir, compiler, jobs, clean):
+def hdrpr(bin_dir, compiler, jobs, clean, build_var):
     print_start("Building HdRPR")
 
     hdrpr_dir = repo_dir / "deps/HdRPR"
@@ -104,18 +108,18 @@ def hdrpr(bin_dir, compiler, jobs, clean):
 
     os.environ['PXR_PLUGINPATH_NAME'] = str(usd_dir / "lib/usd")
 
-    _cmake(hdrpr_dir, compiler, jobs, [
+    _cmake(hdrpr_dir, compiler, jobs, build_var, [
         f'-Dpxr_DIR={usd_dir}',
         f'-DCMAKE_INSTALL_PREFIX={bin_dir / "USD/install"}',
         '-DRPR_BUILD_AS_HOUDINI_PLUGIN=FALSE',
     ])
 
 
-def libs(bin_dir):
+def libs(bin_dir, build_var):
     print_start("Copying binaries to libs")
 
     import create_libs
-    create_libs.main(bin_dir)
+    create_libs.main(bin_dir, build_var)
 
 
 def mx_classes():
@@ -130,11 +134,6 @@ def zip_addon():
 
     import create_zip_addon
     create_zip_addon.main()
-
-
-def usd_debug_libs(bin_dir):
-    import create_libs
-    create_libs.copy_usd_debug_files(bin_dir)
 
 
 def main():
@@ -161,33 +160,32 @@ def main():
                     default="Visual Studio 16 2019" if OS == 'Windows' else "")
     ap.add_argument("-j", required=False, type=int, default=0,
                     help="Number of jobs run in parallel")
-    ap.add_argument("-usd-debug-libs", required=False, action="store_true",
-                    help="Copy RelWithDebInfo USD libs")
+    ap.add_argument("-build-var", required=False, type=str, default="release",
+                    choices=('release', 'relwithdebuginfo'),    # TODO: add 'debug' build variant
+                    help="Build variant for USD, HdRPR and dependencies. (default: release)")
     ap.add_argument("-clean", required=False, action="store_true",
-                    help="Clean build dirs before start USD, HdRPR or MaterialX build")
+                    help="Clean build dirs before start USD or HdRPR build")
 
     args = ap.parse_args()
 
     bin_dir = Path(args.bin_dir).resolve() if args.bin_dir else (repo_dir / "bin")
+    bin_dir = bin_dir.absolute()
     bin_dir.mkdir(parents=True, exist_ok=True)
 
     if args.all or args.usd:
-        usd(bin_dir, args.j, args.clean)
+        usd(bin_dir, args.j, args.clean, args.build_var)
 
     if args.all or args.hdrpr:
-        hdrpr(bin_dir, args.G, args.j, args.clean)
+        hdrpr(bin_dir, args.G, args.j, args.clean, args.build_var)
 
     if args.all or args.libs:
-        libs(bin_dir)
+        libs(bin_dir, args.build_var)
 
     if args.all or args.mx_classes:
         mx_classes()
 
     if args.all or args.addon:
         zip_addon()
-
-    if args.usd_debug_libs:
-        usd_debug_libs(bin_dir)
 
     print_start("Finished")
 

--- a/tools/build_usd.py
+++ b/tools/build_usd.py
@@ -19,7 +19,7 @@ from pathlib import Path
 from build import rm_dir, check_call
 
 
-def main(bin_dir, clean, *args):
+def main(bin_dir, clean, build_var, *args):
     if len(args) == 1 and args[0] in ("--help", "-h"):
         print("""
 Usage
@@ -67,7 +67,7 @@ add_subdirectory("{usd_imaging_lite_path.absolute().as_posix()}" usdImagingLite)
                      '--build-args', f'MATERIALX,-DMATERIALX_BUILD_PYTHON=ON -DMATERIALX_INSTALL_PYTHON=OFF '
                                      f'-DMATERIALX_PYTHON_EXECUTABLE="{sys.executable}"',
                      '--python',
-                     '--build-variant', 'release',
+                     '--build-variant', build_var,
                      str(bin_usd_dir / "install"),
                      *args)
 

--- a/tools/create_libs.py
+++ b/tools/create_libs.py
@@ -33,7 +33,7 @@ def iterate_files(path, glob, *, ignore_parts=(), ignore_suffix=()):
         yield f
 
 
-def main(bin_dir):
+def main(bin_dir, build_var):
     repo_dir = Path(__file__).parent.parent
     libs_dir = repo_dir / "libs"
 
@@ -44,16 +44,30 @@ def main(bin_dir):
     usd_dir = bin_dir / "USD/install"
     libs_dir.mkdir(parents=True)
 
-    copy(usd_dir / "bin", libs_dir / "bin", ('*.pdb',))
-    copy(usd_dir / "lib", libs_dir / "lib", ("*.pdb", "*.lib", "*.def", "cmake", "__pycache__"))
-    copy(usd_dir / "plugin", libs_dir / "plugin", ("*.pdb", "*.lib"))
+    ignore_base = ("*.pdb",) if build_var == 'release' else ()
+    build_name = {'release': 'Release',
+                  'debug': 'Debug',
+                  'relwithdebuginfo': 'RelWithDebInfo'}[build_var]
+
+    copy(usd_dir / "bin", libs_dir / "bin", ignore_base)
+    copy(usd_dir / "lib", libs_dir / "lib",
+         ignore_base + ("*.lib", "*.def", "cmake", "__pycache__"))
+    copy(usd_dir / "plugin", libs_dir / "plugin", ignore_base + ("*.lib",))
     copy(usd_dir / "python", libs_dir / "python", ("*.lib", "build"))
     copy(usd_dir / "libraries", libs_dir / "libraries")
     copy(repo_dir / "deps/mx_libs/alglib", libs_dir / "libraries/alglib")
 
     if OS == 'Windows':
-        copy(bin_dir / "USD/build/openexr-2.3.0/OpenEXR/IlmImf/Release/"
-             "IlmImf-2_3.dll", libs_dir / "lib/IlmImf-2_3.dll")
+        copy(bin_dir / f"USD/build/openexr-2.3.0/OpenEXR/IlmImf/{build_name}/IlmImf-2_3.dll",
+             libs_dir / "lib/IlmImf-2_3.dll")
+
+        if build_var != 'release':
+            copy(bin_dir / f"USD/build/openexr-2.3.0/OpenEXR/IlmImf/{build_name}/IlmImf-2_3.pdb",
+                 libs_dir / "lib/IlmImf-2_3.pdb")
+            copy(repo_dir / f"deps/HdRPR/build/pxr/imaging/rprUsd/{build_name}/rprUsd.pdb",
+                 libs_dir / "lib/rprUsd.pdb")
+            copy(repo_dir / f"deps/HdRPR/build/pxr/imaging/plugin/hdRpr/{build_name}/hdRpr.pdb",
+                 libs_dir / "plugin/usd/hdRpr.pdb")
 
     if OS == 'Linux':
         print("Configuring rpath")


### PR DESCRIPTION
### PURPOSE
For debugging purposes in USD, UsdImagingLite, HdRPR projects we need ability to compile in Debug or RelWithDebInfo build variant.

### EFFECT OF CHANGE
Added 'release' (default) and 'relwithdebuginfo' build variants to the plugin build process.

### TECHNICAL STEPS
Added 'release' and 'relwithdebuginfo' build variants to build.py script. With 'relwithdebuginfo' varint it also copies *.pdb files to the libs folder.

### NOTES FOR REVIEWERS
Added only 'release' and 'relwithdebuginfo' variants, 'debug' variant doesn't work properly.

CIS:REBUID_DEPS