### PR TITLE
Fix crash with Undo operation if data source is NodeTree

### DIFF
--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -52,6 +52,11 @@ def update(context):
             clear(context)
             return
 
+        # workaround for Undo operation - Blender doesn't send bpy.data.scenes and bpy.data.collections
+        # so we need to do nothing to prevent Blender crash
+        if len(bpy.data.scenes) == 0:
+            return
+
         collection = bpy.data.collections.get(COLLECTION_NAME)
         if not collection:
             collection = bpy.data.collections.new(COLLECTION_NAME)


### PR DESCRIPTION
### PURPOSE
Fix crash with Undo operation if data source is NodeTree

### EFFECT OF CHANGE
Blender doesn't crash after Undo operation if data source is NodeTree

### TECHNICAL STEPS
Added check for Undo operation.