### PR TITLE
BLEN-65: Scene Instances transform not update with active viewport render

### DIFF
--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -421,7 +421,10 @@ class ViewportEngineScene(ViewportEngine):
                                    is_gl_delegate=self.is_gl_delegate)
 
                 for inst_obj_data in object.ObjectData.depsgraph_objects_inst(depsgraph):
-                    if obj_data.sdf_name == object.sdf_name(inst_obj_data.object):
+
+                    if obj_data.sdf_name == object.sdf_name(inst_obj_data.parent) \
+                            or obj_data.sdf_name == object.sdf_name(inst_obj_data.object):
+
                         object.sync_update(root_prim, inst_obj_data, update.is_updated_geometry,
                                            update.is_updated_transform)
 


### PR DESCRIPTION
### PURPOSE
Fix instances transform is not updated with active viewport render

### EFFECT OF CHANGE
Fixed instances transform is not updated with active viewport render

### TECHNICAL STEPS
Added check for parent object name