### PR TITLE
BLEN-13: add USD animation support for Final render

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -78,7 +78,7 @@ class FinalEngine(Engine):
         root = self.stage.GetPseudoRoot()
         params = UsdImagingGL.RenderParams()
         params.renderResolution = (self.width, self.height)
-        params.frame = Usd.TimeCode.Default()
+        params.frame = Usd.TimeCode(scene.frame_current)
 
         if scene.hdusd.final.data_source:
             world_data = world.WorldData.init_from_stage(self.stage)
@@ -115,6 +115,8 @@ class FinalEngine(Engine):
         self._set_scene_camera(renderer, scene)
 
         params = UsdImagingLite.RenderParams()
+        params.frame = Usd.TimeCode(scene.frame_current)
+
         render_images = {
             'Combined': np.empty((self.width, self.height, 4), dtype=np.float32)
         }


### PR DESCRIPTION
### PURPOSE
Add USD animation support for Final render.

### EFFECT OF CHANGE
Added support of animation for final render and USD node tree.

### TECHNICAL STEPS
Passed current frame to 'frame' parameter for final render RPR and GL delegates.
