### PR TITLE
BLEN-44: PRman render delegate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ With Pixar's USD system emerging as a powerful tool for 3D graphics pipelines an
 - Rendering in Blender via the USD Hydra Framework. This is a middle layer for renderers, meaning that once a renderer is adapted to Hydra, it can work in many places including this addon for rendering. Known Hydra render delegates are:
   - AMD's Radeon ProRender (included)
   - Hydra's default Storm delegate (included)
+  - Pixar RenderMan delegate (included)  
   - Intel Embree (cpu) delegate
-  - Pixar RenderMan delegate.
   - Autodesk Arnold
   - Otoy Octane
   - Redshift
@@ -138,6 +138,10 @@ You can build project using `tools/build.py` with different flag combinations. I
 - `-mx-classes` - generates classes for MaterialX nodes
 - `-G "Visual Studio 16 2019"` - set builder, passing with `-all` and `-hdrpr` _(Windows only)_ 
 - `-addon` - generates zip archive with plugin to `/install` folder. Resulted build writes python version to zipped file (i.e., {archive_name}-3.10.zip);
+- `--prman` - build with RenderMan delegate
+- `--prman-location` - path to RenderMan directory (e.g. 'C:/Program Files/Pixar/RenderManProServer-24.3')
+
+To build addon with RenderMan you need to install RenderMan first (https://renderman.pixar.com/install) and then set environment variables according to instruction [Running hdPrman](https://graphics.pixar.com/usd/release/plugins_renderman.html#running-hdprman)  
 
 Arguments are mostly used to skip build unneeded binaries. For example, you want switch to prebuild binary folder `bin/dir_01`:
 ```commandline

--- a/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
+++ b/deps/UsdImagingLite/pxr/usdImaging/usdImagingLite/engine.h
@@ -209,7 +209,7 @@ private:
     // the task controller, and the usd imaging delegate.
     void _DeleteHydraResources();
 
-
+    SdfPath _GetRendererAovPath(TfToken const &aov) const;
 };
 
 PXR_NAMESPACE_CLOSE_SCOPE

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -67,7 +67,9 @@ class FinalEngine(Engine):
 
         # creating renderer
         renderer = UsdImagingGL.Engine()
-        self._sync_render_settings(renderer, scene)
+        if not self._sync_render_settings(renderer, scene):
+            renderer = None
+            return
 
         # setting camera
         self._set_scene_camera(renderer, scene)
@@ -106,7 +108,9 @@ class FinalEngine(Engine):
     def _render(self, scene):
         # creating renderer
         renderer = UsdImagingLite.Engine()
-        self._sync_render_settings(renderer, scene)
+        if not self._sync_render_settings(renderer, scene):
+            renderer = None
+            return
 
         renderer.SetRenderViewport((0, 0, self.width, self.height))
         renderer.SetRendererAov('color')
@@ -121,12 +125,20 @@ class FinalEngine(Engine):
             'Combined': np.empty((self.width, self.height, 4), dtype=np.float32)
         }
 
-        renderer.Render(self.stage.GetPseudoRoot(), params)
-
         time_begin = time.perf_counter()
         while True:
             if self.render_engine.test_break():
                 break
+
+            try:
+                renderer.Render(self.stage.GetPseudoRoot(), params)
+
+            except Exception as e:
+                # known RenderMan issue https://github.com/PixarAnimationStudios/USD/issues/1415
+                if isinstance(e, Tf.ErrorException) and "Failed to load plugin 'rmanOslParser'" in str(e):
+                    pass  # we won't log error "GL error: invalid operation"
+                else:
+                    log.error(e)
 
             percent_done = usd_utils.get_renderer_percent_done(renderer)
             self.notify_status(percent_done / 100,
@@ -232,7 +244,18 @@ class FinalEngine(Engine):
     def _sync_render_settings(self, renderer, scene):
         settings = scene.hdusd.final
 
-        renderer.SetRendererPlugin(settings.delegate)
+        try:
+            renderer.SetRendererPlugin(settings.delegate)
+        except Exception as e:
+            # RenderMan is not available for final and viewport render at the same time
+            if isinstance(e, Tf.ErrorException) and "Could not initialize riley API" in str(e):
+                self.render_engine.error_set('Cannot start final render when viewport render is running')
+            else
+                self.render_engine.error_set(str(e)):
+                log.error(e)
+
+            return False
+
         if settings.delegate == 'HdRprPlugin':
             hdrpr = settings.hdrpr
             quality = hdrpr.quality
@@ -261,6 +284,8 @@ class FinalEngine(Engine):
             renderer.SetRendererSetting('rpr:denoising:enable', denoise.enable)
             renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
             renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
+
+        return True
 
 
 class FinalEngineScene(FinalEngine):
@@ -316,7 +341,6 @@ class FinalEngineScene(FinalEngine):
                     object.sync(obj_prim, obj_data, objects_stage)
 
             stage.SetDefaultPrim(obj_prim)
-
 
         with futures.ThreadPoolExecutor() as executor:
             chunk_sync = []

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -250,8 +250,8 @@ class FinalEngine(Engine):
             # RenderMan is not available for final and viewport render at the same time
             if isinstance(e, Tf.ErrorException) and "Could not initialize riley API" in str(e):
                 self.render_engine.error_set('Cannot start final render when viewport render is running')
-            else
-                self.render_engine.error_set(str(e)):
+            else:
+                self.render_engine.error_set(str(e))
                 log.error(e)
 
             return False

--- a/src/hdusd/engine/preview_engine.py
+++ b/src/hdusd/engine/preview_engine.py
@@ -137,11 +137,19 @@ class PreviewEngine(Engine):
             render_passes.foreach_set('rect', image.flatten())
             self.render_engine.end_result(result)
 
-        self.renderer.Render(self.stage.GetPseudoRoot(), params)
-
         while True:
             if self.render_engine.test_break():
                 break
+
+            try:
+                self.renderer.Render(self.stage.GetPseudoRoot(), params)
+
+            except Exception as e:
+                # known RenderMan issue https://github.com/PixarAnimationStudios/USD/issues/1415
+                if isinstance(e, Tf.ErrorException) and "Failed to load plugin 'rmanOslParser'" in str(e):
+                    pass  # we won't log error "GL error: invalid operation"
+                else:
+                    log.error(e)
 
             if self.renderer.IsConverged():
                 break

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -288,7 +288,9 @@ class ViewportEngine(Engine):
             self.renderer.Render(stage.GetPseudoRoot(), self.render_params)
 
         except Exception as e:
-            if isinstance(e, Tf.ErrorException) and "GL error: invalid operation" in str(e):
+            if isinstance(e, Tf.ErrorException) and ("GL error: invalid operation" in str(e)
+                                                     # known RenderMan issue https://github.com/PixarAnimationStudios/USD/issues/1415
+                                                     or "Failed to load plugin 'rmanOslParser'" in str(e)):
                 pass    # we won't log error "GL error: invalid operation"
             else:
                 log.error(e)

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 #********************************************************************
 import bpy
+import os
 from pxr import UsdImagingGL
 
 from ..viewport import usd_collection
@@ -21,6 +22,10 @@ from . import HdUSDProperties, hdrpr_render, log
 
 _render_delegates = {name: UsdImagingGL.Engine.GetRendererDisplayName(name)
                      for name in UsdImagingGL.Engine.GetRendererPlugins()}
+
+if not os.path.isdir(os.environ.get('RMANTREE', "")):
+    _render_delegates.pop('HdPrmanLoaderRendererPlugin', None)
+
 log("Render Delegates", _render_delegates)
 
 

--- a/tools/build.py
+++ b/tools/build.py
@@ -59,7 +59,7 @@ def print_start(msg):
 -------------------------------------------------------------""")
 
 
-def usd(bin_dir, jobs, clean, build_var):
+def usd(bin_dir, jobs, clean, build_var, prman, prman_location):
     print_start("Building USD")
 
     import build_usd
@@ -67,6 +67,10 @@ def usd(bin_dir, jobs, clean, build_var):
     if jobs > 0:
         args += ['-j', str(jobs)]
 
+    if prman:
+        args += ['--prman']
+        args += ['--prman-location', prman_location]
+    
     build_usd.main(bin_dir, clean, build_var, *args)
 
 
@@ -171,6 +175,10 @@ def main():
                     help="Build variant for USD, HdRPR and dependencies. (default: release)")
     ap.add_argument("-clean", required=False, action="store_true",
                     help="Clean build dirs before start USD or HdRPR build")
+    ap.add_argument("--prman", required=False, action="store_true",
+                    help="Build with RenderMan render delegate")
+    ap.add_argument("--prman-location", required=False, type=str, default="",
+                    help="Path to RenderMan directory")
 
     args = ap.parse_args()
 
@@ -179,7 +187,7 @@ def main():
     bin_dir.mkdir(parents=True, exist_ok=True)
 
     if args.all or args.usd:
-        usd(bin_dir, args.j, args.clean, args.build_var)
+        usd(bin_dir, args.j, args.clean, args.build_var, args.prman, args.prman_location)
 
     if args.all or args.hdrpr:
         hdrpr(bin_dir, args.G, args.j, args.clean, args.build_var)


### PR DESCRIPTION
### PURPOSE
Add support for RenderMan render delegate

### EFFECT OF CHANGE
Added RenderMan render delegate

### TECHNICAL STEPS
- Added flags for build script
- UsdImagingLite fixed for correctly setting clearColor
- Added try ... except for Render method due to known RenderMan issue
- Render method in preview and final renders moved under while(true) loop
- _sync_render_settings now returns bool to indicate if it finished ok

### NOTES FOR REVIEWERS
Known issue: https://github.com/PixarAnimationStudios/USD/issues/1415
USD doesn't have implementation for RenderMan rendering progress (renderer.GetRenderStats() doesn't have 'percentDone')
Material with image as texture doesn't work (likely because RenderMan has its own nodes for this)

To make RenderMan works you need to set environment variables https://graphics.pixar.com/usd/release/plugins_renderman.html#running-hdprman

CIS:REBUILD_DEPS