### PR TITLE
BLEN-69: Update Material X converter

### DIFF
--- a/src/hdusd/bl_nodes/nodes/output.py
+++ b/src/hdusd/bl_nodes/nodes/output.py
@@ -19,7 +19,7 @@ class ShaderNodeOutputMaterial(NodeParser):
     nodegraph_path = ""
 
     def __init__(self, doc, material, node, obj, **kwargs):
-        super().__init__(Id(), doc, material, node, obj, None, {}, **kwargs)
+        super().__init__(Id(), doc, material, node, obj, None, None, {}, **kwargs)
 
     def export(self):
         surface = self.get_input_link('Surface')

--- a/src/hdusd/bl_nodes/nodes/texture.py
+++ b/src/hdusd/bl_nodes/nodes/texture.py
@@ -35,7 +35,7 @@ class ShaderNodeTexImage(NodeParser):
         # TODO use Vector input for UV
         uv = self.create_node('texcoord', 'vector2', {})
 
-        result = self.create_node('image', 'color3', {
+        result = self.create_node('image', self.out_type, {
             'file': img_path,
             'texcoord': uv,
         })


### PR DESCRIPTION
### PURPOSE
Update Material X converter.

### EFFECT OF CHANGE
Improved Material X converter.

### TECHNICAL STEPS
Added OUTPUT_TYPE constant that maps blender and materialx output types.
Added get_output_type() method to get dynamically output type of node according to linked socket.
Improved cached_nodes keys with output_type. A unique cache key allows the creation of a specific node for every output type.
