### PR TITLE
BLEN-66: add camera selection for viewport render settings

### DIFF
--- a/src/hdusd/export/camera.py
+++ b/src/hdusd/export/camera.py
@@ -51,7 +51,7 @@ class CameraData:
         data.clip_plane = (camera.clip_start, camera.clip_end)
         data.transform = tuple(transform)
         data.mode = camera.type
-        
+
         if camera.dof.use_dof:
             # calculating focus_distance
             if not camera.dof.focus_object:
@@ -175,6 +175,27 @@ class CameraData:
 
         return data
 
+    @staticmethod
+    def init_from_usd_camera(prim):
+        data = CameraData()
+
+        stage = prim.GetStage()
+        xform_camera = stage.DefinePrim(prim.GetPath().pathString, prim.GetTypeName())
+        usd_camera = UsdGeom.Camera.Get(stage, prim.GetPath())
+
+        data.transform = UsdGeom.XformCache(bpy.context.scene.frame_current).GetLocalToWorldTransform(xform_camera)
+
+        data.mode = usd_camera.GetProjectionAttr().Get()
+        data.focal_length = usd_camera.GetFocalLengthAttr().Get()
+
+        if data.mode == 'perspective':
+            data.sensor_size = (usd_camera.GetHorizontalApertureAttr().Get(),
+                                usd_camera.GetVerticalApertureAttr().Get())
+        elif data.mode == 'orthographic':
+            data.ortho_size = (usd_camera.GetHorizontalApertureAttr().Get(),
+                               usd_camera.GetVerticalApertureAttr().Get())
+        return data
+
     def export(self, usd_camera, tile=((0.0, 0.0), (1.0, 1.0))):
         tile_pos, tile_size = tile
 
@@ -238,7 +259,7 @@ class CameraData:
         # following formula is used:
         # lens_shift = lens_shift * resolution / tile_size + (center - resolution/2) / tile_size
         # where: center = tile_pos + tile_size/2
-        lens_shift = tuple((self.lens_shift[i] + tile_pos[i] + tile_size[i] * 0.5 - 0.5) / tile_size[i] for i in (0, 1))        
+        lens_shift = tuple((self.lens_shift[i] + tile_pos[i] + tile_size[i] * 0.5 - 0.5) / tile_size[i] for i in (0, 1))
 
         if self.mode == 'PERSP':
             gf_camera.projection = Gf.Camera.Perspective
@@ -284,6 +305,20 @@ class CameraData:
         gf_camera.transform = Gf.Matrix4d(np.transpose(self.transform))
 
         return gf_camera
+
+    def export_to_camera(self, camera: bpy.types.Object):
+        camera.matrix_world = self.transform
+        camera_data = camera.data
+        if self.mode == 'orthographic':
+            camera_data.type = 'ORTHO'
+            ratio = self.ortho_size[0]/self.ortho_size[1]
+            camera_data.ortho_scale = max(self.ortho_size)
+        else:
+            camera_data.type = 'PERSP'
+            ratio = self.sensor_size[0]/self.sensor_size[1]
+            camera_data.lens = self.focal_length
+
+        camera_data.sensor_fit = 'HORIZONTAL' if ratio > 1 else 'VERTICAL'
 
 
 def sync(obj_prim, obj: bpy.types.Object, **kwargs):

--- a/src/hdusd/export/camera.py
+++ b/src/hdusd/export/camera.py
@@ -188,12 +188,14 @@ class CameraData:
         data.mode = usd_camera.GetProjectionAttr().Get()
         data.focal_length = usd_camera.GetFocalLengthAttr().Get()
 
+        aperture = (usd_camera.GetHorizontalApertureAttr().Get(), usd_camera.GetVerticalApertureAttr().Get())
         if data.mode == 'perspective':
-            data.sensor_size = (usd_camera.GetHorizontalApertureAttr().Get(),
-                                usd_camera.GetVerticalApertureAttr().Get())
+            data.sensor_size = aperture
+
         elif data.mode == 'orthographic':
-            data.ortho_size = (usd_camera.GetHorizontalApertureAttr().Get(),
-                               usd_camera.GetVerticalApertureAttr().Get())
+            # Use tenths of a world unit accorging to USD docs https://graphics.pixar.com/usd/docs/api/class_gf_camera.html
+            data.ortho_size = tuple(i / 10 for i in aperture)
+
         return data
 
     def export(self, usd_camera, tile=((0.0, 0.0), (1.0, 1.0))):

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -25,6 +25,7 @@ log = logging.Log('export.object')
 
 
 SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA', 'EMPTY')
+USD_CAMERA = "USD Camera"
 
 
 @dataclass(init=False)
@@ -71,7 +72,7 @@ class ObjectData:
             if obj.type == 'LIGHT' and not use_scene_lights:
                 continue
 
-            if obj.type == 'CAMERA' and not use_scene_cameras:
+            if obj.type == 'CAMERA' and not use_scene_cameras or obj.name == USD_CAMERA:
                 continue
 
             if space_data and not instance.is_instance and not obj.visible_in_viewport_get(space_data):

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -25,7 +25,6 @@ log = logging.Log('export.object')
 
 
 SUPPORTED_TYPES = ('MESH', 'LIGHT', 'CURVE', 'FONT', 'SURFACE', 'META', 'CAMERA', 'EMPTY')
-USD_CAMERA = "USD Camera"
 
 
 @dataclass(init=False)
@@ -64,6 +63,7 @@ class ObjectData:
     @staticmethod
     def depsgraph_objects(depsgraph, *, space_data=None,
                           use_scene_lights=True, use_scene_cameras=True):
+        from ..viewport.usd_collection import USD_CAMERA
         for instance in depsgraph.object_instances:
             obj = instance.object
             if obj.type not in SUPPORTED_TYPES or instance.object.hdusd.is_usd:

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -109,7 +109,13 @@ class ViewportRenderSettings(RenderSettings):
             return
 
         output_node = bpy.data.node_groups[self.data_source].get_output_node()
+        if not output_node:
+            return
+
         stage = output_node.cached_stage()
+        if not stage:
+            return
+
         camera_prim = stage.GetPrimAtPath(self.nodetree_camera)
         if not camera_prim:
             if viewport_camera:

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -14,9 +14,11 @@
 #********************************************************************
 import bpy
 import os
-from pxr import UsdImagingGL
+from pxr import UsdImagingGL, UsdGeom
 
 from ..viewport import usd_collection
+from ..export.camera import CameraData
+from ..export.object import USD_CAMERA
 from . import HdUSDProperties, hdrpr_render, log
 
 
@@ -42,25 +44,6 @@ class RenderSettings(bpy.types.PropertyGroup):
         return _render_delegates[self.delegate]
 
     hdrpr: bpy.props.PointerProperty(type=hdrpr_render.RenderSettings)
-
-
-class FinalRenderSettings(RenderSettings):
-    delegate: bpy.props.EnumProperty(
-        name="Renderer",
-        items=RenderSettings.delegate_items,
-        description="Render delegate for final render",
-        default='HdRprPlugin',
-    )
-    data_source: bpy.props.StringProperty(
-        name="Data Source",
-        description="Data source for final render",
-        default=""
-    )
-    nodetree_camera: bpy.props.StringProperty(
-        name="Camera",
-        description="Select camera from USD for final render",
-        default=""
-    )
 
     def nodetree_update(self, context):
         if not self.data_source:
@@ -89,6 +72,25 @@ class FinalRenderSettings(RenderSettings):
                 break
 
 
+class FinalRenderSettings(RenderSettings):
+    delegate: bpy.props.EnumProperty(
+        name="Renderer",
+        items=RenderSettings.delegate_items,
+        description="Render delegate for final render",
+        default='HdRprPlugin',
+    )
+    data_source: bpy.props.StringProperty(
+        name="Data Source",
+        description="Data source for final render",
+        default=""
+    )
+    nodetree_camera: bpy.props.StringProperty(
+        name="Camera",
+        description="Select camera from USD for final render",
+        default=""
+    )
+
+
 class ViewportRenderSettings(RenderSettings):
     delegate: bpy.props.EnumProperty(
         name="Renderer",
@@ -99,11 +101,41 @@ class ViewportRenderSettings(RenderSettings):
     def data_source_update(self, context):
         usd_collection.update(context)
 
+    def nodetree_camera_update(self, context):
+        viewport_camera = context.scene.objects.get(USD_CAMERA, None)
+        if not self.data_source:
+            if viewport_camera:
+                bpy.data.objects.remove(viewport_camera)
+            return
+
+        output_node = bpy.data.node_groups[self.data_source].get_output_node()
+        stage = output_node.cached_stage()
+        camera_prim = stage.GetPrimAtPath(self.nodetree_camera)
+        if not camera_prim:
+            if viewport_camera:
+                bpy.data.objects.remove(viewport_camera)
+            return
+
+        camera_settings = CameraData.init_from_usd_camera(camera_prim)
+        if not viewport_camera:
+            camera_data = bpy.data.cameras.new(USD_CAMERA)
+            viewport_camera = bpy.data.objects.new(USD_CAMERA, camera_data)
+            context.scene.collection.objects.link(viewport_camera)
+            context.scene.camera = viewport_camera
+
+        camera_settings.export_to_camera(viewport_camera)
+
     data_source: bpy.props.StringProperty(
         name="Data Source",
         description="Data source for viewport render",
         default="",
         update=data_source_update
+    )
+    nodetree_camera: bpy.props.StringProperty(
+        name="Camera",
+        description="Select camera from USD for viewport render",
+        default="",
+        update=nodetree_camera_update
     )
 
 

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -18,7 +18,7 @@ from pxr import UsdImagingGL, UsdGeom
 
 from ..viewport import usd_collection
 from ..export.camera import CameraData
-from ..export.object import USD_CAMERA
+from ..viewport.usd_collection import USD_CAMERA
 from . import HdUSDProperties, hdrpr_render, log
 
 

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -60,6 +60,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     render.HDUSD_OP_nodetree_camera,
     render.HDUSD_MT_data_source_final,
     render.HDUSD_MT_nodetree_camera_final,
+    render.HDUSD_MT_nodetree_camera_viewport,
     render.HDUSD_MT_data_source_viewport,
     render.HDUSD_RENDER_PT_render_settings_final,
     render.HDUSD_RENDER_PT_render_settings_viewport,

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -140,6 +140,7 @@ class USDTree(bpy.types.ShaderNodeTree):
     def output_node_computed(self):
         context = bpy.context
         if context.scene.hdusd.viewport.data_source == self.name:
+            context.scene.hdusd.viewport.nodetree_update(context)
             usd_collection.update(context)
 
         if context.scene.hdusd.final.data_source == self.name:

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -19,7 +19,7 @@ from pxr import UsdGeom
 from .base_node import USDNode
 from ...export import object, material, world
 from ...utils import usd as usd_utils
-from ...export.object import ObjectData, SUPPORTED_TYPES, sdf_name
+from ...export.object import ObjectData, SUPPORTED_TYPES, sdf_name, USD_CAMERA
 
 
 #
@@ -99,7 +99,7 @@ class HDUSD_USD_NODETREE_MT_blender_data_object(bpy.types.Menu):
         objects = bpy.data.objects
 
         for obj in objects:
-            if obj.hdusd.is_usd or obj.type not in SUPPORTED_TYPES:
+            if (obj.type == 'CAMERA' and obj.name == USD_CAMERA) or obj.hdusd.is_usd or obj.type not in SUPPORTED_TYPES:
                 continue
 
             row = layout.row()
@@ -197,7 +197,7 @@ class BlenderDataNode(USDNode):
                 return
 
             for obj_col in self.collection.objects:
-                if obj_col.hdusd.is_usd:
+                if obj_col.hdusd.is_usd or (obj_col.type == 'CAMERA' and obj_col.name == USD_CAMERA ):
                     continue
 
                 object.sync(root_prim, ObjectData.from_object(
@@ -235,6 +235,9 @@ class BlenderDataNode(USDNode):
             if isinstance(update.id, bpy.types.Object):
                 obj = update.id
                 if obj.hdusd.is_usd or obj.type == 'EMPTY':
+                    continue
+
+                if obj.type == 'CAMERA' and obj.name == USD_CAMERA:
                     continue
 
                 obj_data = ObjectData.from_object(obj)

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -19,7 +19,8 @@ from pxr import UsdGeom
 from .base_node import USDNode
 from ...export import object, material, world
 from ...utils import usd as usd_utils
-from ...export.object import ObjectData, SUPPORTED_TYPES, sdf_name, USD_CAMERA
+from ...export.object import ObjectData, SUPPORTED_TYPES, sdf_name
+from ...viewport.usd_collection import USD_CAMERA
 
 
 #

--- a/src/hdusd/viewport/usd_collection.py
+++ b/src/hdusd/viewport/usd_collection.py
@@ -25,6 +25,7 @@ log = logging.Log('usd_collection')
 
 
 COLLECTION_NAME = "USD NodeTree"
+USD_CAMERA = "USD Camera"
 
 
 def ignore_prim(prim):


### PR DESCRIPTION
### PURPOSE
Add camera selection for viewport render settings.

### EFFECT OF CHANGE
Added ability to choose viewport camera from USD node tree.

### TECHNICAL STEPS
Added constant name for viewport camera 'USD Camera'.
BLEND-66: add camera selection for viewport render settings.
Excluded 'USD Camera' from export to usd collection blender_data node in usd nodetree.
Improved CameraData adding init_from_usd_camera and export_to_camera.
Added new menu class HDUSD_MT_nodetree_camera_viewport.
Improved UI in render.py adding HDUSD_MT_nodetree_camera_viewport dropdown list.
Improved camera switch update with context.scene.hdusd.viewport.nodetree_update
Moved method nodetree_update to RenderSettings as now it's used by FinalRenderSettings, ViewportRenderSettings.
Added camera icon to the dropdown menu.

### NOTES FOR REVIEWERS
Some USD camera attributes might transfer incorrectly, for example, camera shifts.
It's supposed to be done as a further task.