### PR TITLE
BLEN-64: USD import scenes without packed textures to USD

### DIFF
--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -12,13 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #********************************************************************
+import os
+import shutil
 import traceback
 from pathlib import Path
 
 import bpy
 import MaterialX as mx
 
-from pxr import UsdGeom, Usd, Sdf, UsdShade
+from pxr import UsdGeom, Usd, Sdf, UsdShade, UsdLux
 from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
@@ -420,8 +422,79 @@ class HDUSD_NODE_OP_export_usd_file(HdUSD_Operator, ExportHelper):
             log.warn(f"Unable to export USD node '{node_tree.name}':'{output_node.name}' stage: write correct file name")
             return {'CANCELLED'}
 
+        # important to save stage to export all packed textures and flatten the stage to one file
         if self.is_pack_into_one_file:
-            input_stage.Export(self.filepath)
+            tempfile = str(get_temp_file(".usda"))
+            input_stage.Export(tempfile, False)
+            input_stage = Usd.Stage.Open(tempfile)
+
+        # default primitive is considered as camera object while importing to external software
+        scene_camera = context.scene.camera
+        if scene_camera:
+            camera = input_stage.GetPrimAtPath(f'/{context.scene.camera.data.name}')
+            if camera:
+                input_stage.SetDefaultPrim(camera)
+
+        dest_path_root_dir = Path(self.filepath).parent
+        texture_dir_abs = dest_path_root_dir / "textures"
+        texture_dir_rel = texture_dir_abs.relative_to(dest_path_root_dir)
+        image_paths = set()
+        index = 0
+
+        def _resolve_texture_filepath(tex_attr):
+            global index
+            src_filepath = tex_attr.Get()
+            if not src_filepath:
+                return
+
+            src_filepath = Path(src_filepath.path)
+
+            if not os.path.exists(texture_dir_abs):
+                Path(texture_dir_abs).mkdir(parents=True, exist_ok=True)
+
+            dest_filepath = texture_dir_abs / src_filepath.name
+            if src_filepath not in image_paths:
+                image_paths.update([src_filepath])
+                if os.path.isfile(dest_filepath):
+                    index += 1
+                    dest_filepath = texture_dir_abs / f"{src_filepath.stem}_{index}{src_filepath.suffix}"
+
+                shutil.copy(str(src_filepath), str(dest_filepath))
+            tex_attr.Set(str(texture_dir_rel / dest_filepath.name))
+
+        for prim in input_stage.TraverseAll():
+            # perform world texture paths to be relative
+            if prim.GetTypeName() == 'DomeLight':
+                world_prim = prim.GetParent()
+                if not world_prim.IsValid():
+                    continue
+
+                light_obj = UsdLux.DomeLight.Get(input_stage, prim.GetPath())
+                if 'delegate' in world_prim.GetVariantSets().GetNames():
+                    vset = world_prim.GetVariantSet('delegate')
+                    for name in vset.GetVariantNames():
+                        vset.SetVariantSelection(name)
+                        with vset.GetVariantEditContext():
+                            tex_attr = light_obj.GetTextureFileAttr()
+                            _resolve_texture_filepath(tex_attr)
+
+                        if self.is_pack_into_one_file:
+                            vset.ClearVariantSelection()
+                else:
+                    tex_attr = light_obj.GetTextureFileAttr()
+                    _resolve_texture_filepath(tex_attr)
+                continue
+
+            if self.is_pack_into_one_file:
+                # perform all texture paths in MaterialX to be relative
+                if not prim.GetTypeName() == 'Shader':
+                    continue
+
+                tex_attr = prim.GetAttribute('inputs:file')
+                _resolve_texture_filepath(tex_attr)
+
+        if self.is_pack_into_one_file:
+            input_stage.Export(self.filepath, False)
             log.info(f"Export of '{node_tree.name}':'{output_node.name}' stage to {self.filepath}: completed successfuly")
             return {'FINISHED'}
 
@@ -454,10 +527,12 @@ class HDUSD_NODE_OP_export_usd_file(HdUSD_Operator, ExportHelper):
                     mx_node_tree = next((mat.hdusd.mx_node_tree for mat in bpy.data.materials
                                          if mat.hdusd.mx_node_tree
                                          and source_path.stem.startswith(mat.name_full)
-                                         and source_path.stem.endswith(mat.hdusd.mx_node_tree.name_full)), None)
+                                         and mat.hdusd.mx_node_tree.name_full in source_path.stem), None)
 
                     if not mx_node_tree:
-                        mat = bpy.data.materials.get(source_path.stem, None)
+                        material_name = max([mat.name_full for mat in bpy.data.materials
+                                                if source_path.stem.startswith(mat.name_full)], key=len)
+                        mat = bpy.data.materials.get(material_name, None)
                         if not mat:
                             continue
 

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -16,10 +16,11 @@ import os
 import re
 
 import bpy
-from pxr import Usd, UsdGeom, Sdf, Gf
+from pxr import Usd, UsdGeom, Sdf, Gf, UsdLux, UsdShade
 
 from .base_node import USDNode
 from . import log
+from ...utils import get_temp_file
 
 
 class UsdFileNode(USDNode):
@@ -65,6 +66,35 @@ class UsdFileNode(USDNode):
             return None
 
         input_stage = Usd.Stage.Open(file_path)
+
+        def _resolve_world_path(light_obj):
+            tex_attr = light_obj.GetTextureFileAttr()
+            src_filepath = tex_attr.Get()
+            if src_filepath:
+                tex_attr.Set(src_filepath.resolvedPath)
+
+        for prim in input_stage.TraverseAll():
+            # perform world texture paths to be absolute
+            if prim.GetTypeName() == 'DomeLight':
+                world_prim = prim.GetParent()
+                if not world_prim.IsValid():
+                    continue
+
+                light_obj = UsdLux.DomeLight.Get(input_stage, prim.GetPath())
+                if 'delegate' in world_prim.GetVariantSets().GetNames():
+                    vset = world_prim.GetVariantSet('delegate')
+                    for name in world_prim.GetVariantSet('delegate').GetVariantNames():
+                        vset.SetVariantSelection(name)
+                        with vset.GetVariantEditContext():
+                            _resolve_world_path(light_obj)
+
+                else:
+                    _resolve_world_path(light_obj)
+
+        # perform all texture paths in MaterialX to be absolute
+        tempfile = str(get_temp_file(".usda"))
+        input_stage.Export(tempfile, False)
+        input_stage = Usd.Stage.Open(tempfile)
 
         if self.filter_path == '/*':
             self.cached_stage.insert(input_stage)


### PR DESCRIPTION
### PURPOSE
What this PR is made for.

### EFFECT OF CHANGE
Fixed missing textures.
Camera object now sets a default primitive of the stage while exporting to USD file.

### TECHNICAL STEPS
Fixed search of materialx while exporting to USD file.
Improved HDUSD_NODE_OP_export_usd_file execute method so world and shader export converts texture paths to relative.
Improved UsdFileNode resolving all texture paths to absolute so HDRPR now uses correct paths in the scope of its temp directory.
Camera object now sets a default primitive of the stage while exporting to USD file.
Added comments.