### PR TITLE
BLEN-70: add animation Import-Export option for USD nodes

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -163,7 +163,7 @@ class FinalEngine(Engine):
         else:
             usd_camera = UsdAppUtils.GetCameraAtPath(self.stage, Tf.MakeValidIdentifier(scene.camera.data.name))
        
-        gf_camera = usd_camera.GetCamera()
+        gf_camera = usd_camera.GetCamera(scene.frame_current)
         renderer.SetCameraState(gf_camera.frustum.ComputeViewMatrix(),
                                 gf_camera.frustum.ComputeProjectionMatrix())
 

--- a/src/hdusd/export/object.py
+++ b/src/hdusd/export/object.py
@@ -233,10 +233,7 @@ def sync_update(root_prim, obj_data: ObjectData, is_updated_geometry, is_updated
 
     if is_updated_transform:
         xform = UsdGeom.Xform(obj_prim)
-        transform_matrix = xform.MakeMatrixXform()
-
-        set_matrix_xform(kwargs.get('scene'), kwargs.get('is_use_animation'), kwargs.get('is_restrict_frames'),
-                         kwargs.get('start_frame'), kwargs.get('end_frame'), obj_data, transform_matrix)
+        xform.MakeMatrixXform().Set(Gf.Matrix4d(obj_data.transform))
 
     if is_updated_geometry:
         obj = obj_data.object

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -451,8 +451,9 @@ class HDUSD_NODE_OP_export_usd_file(HdUSD_Operator, ExportHelper):
             self.layout.prop(self, 'is_restrict_frames')
 
         if self.is_export_animation and self.is_restrict_frames:
-            self.layout.prop(self, 'start_frame')
-            self.layout.prop(self, 'end_frame')
+            row = self.layout.row(align=True)
+            row.prop(self, 'start_frame')
+            row.prop(self, 'end_frame')
 
         self.layout.prop(self, 'export_format')
 

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -24,6 +24,7 @@ from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
 from ..usd_nodes.nodes.base_node import USDNode
+from ..usd_nodes.nodes.blender_data import BlenderDataNode
 from ..mx_nodes.node_tree import MxNodeTree
 from ..engine.viewport_engine import ViewportEngineNodetree
 
@@ -283,6 +284,10 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
 
     def execute(self, context):
         tree = context.space_data.edit_tree
+        blender_data_node = next((node for node in tree.nodes if isinstance(node, BlenderDataNode) and node.is_use_animation), None)
+        if blender_data_node:
+            blender_data_node.reset(True)
+
         node = context.active_node
         if not node:
             log(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")
@@ -296,7 +301,7 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
 
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
         print(stage.ExportToString())
-
+        
         return {'FINISHED'}
 
 
@@ -312,6 +317,10 @@ class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
 
     def execute(self, context):
         tree = context.space_data.edit_tree
+        blender_data_node = next((node for node in tree.nodes if isinstance(node, BlenderDataNode) and node.is_use_animation), None)
+        if blender_data_node:
+            blender_data_node.reset(True)
+
         node = context.active_node
         if not node:
             log(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -284,9 +284,6 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
 
     def execute(self, context):
         tree = context.space_data.edit_tree
-        blender_data_node = next((node for node in tree.nodes if isinstance(node, BlenderDataNode) and node.is_use_animation), None)
-        if blender_data_node:
-            blender_data_node.reset(True)
 
         node = context.active_node
         if not node:
@@ -317,9 +314,6 @@ class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
 
     def execute(self, context):
         tree = context.space_data.edit_tree
-        blender_data_node = next((node for node in tree.nodes if isinstance(node, BlenderDataNode) and node.is_use_animation), None)
-        if blender_data_node:
-            blender_data_node.reset(True)
 
         node = context.active_node
         if not node:

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -24,7 +24,6 @@ from bpy_extras.io_utils import ExportHelper
 
 from . import HdUSD_Panel, HdUSD_ChildPanel, HdUSD_Operator
 from ..usd_nodes.nodes.base_node import USDNode
-from ..usd_nodes.nodes.blender_data import BlenderDataNode
 from ..mx_nodes.node_tree import MxNodeTree
 from ..engine.viewport_engine import ViewportEngineNodetree
 

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -30,8 +30,9 @@ from ..engine.viewport_engine import ViewportEngineNodetree
 from .. import config
 from ..utils import get_temp_file, temp_pid_dir
 from ..utils import mx as mx_utils
-from ..export import material
 from ..utils import usd as usd_utils
+from ..export import material
+
 
 from ..utils import logging
 log = logging.Log('ui.usd_list')
@@ -394,7 +395,6 @@ class HDUSD_NODE_OP_export_usd_file(HdUSD_Operator, ExportHelper):
     is_pack_into_one_file: bpy.props.BoolProperty(name="Pack into one file",
                                                   description="Pack all references into one file",
                                                   default=True)
-
     export_format: bpy.props.EnumProperty(
         name="Format",
         items=(('.usda', "Text (.usda)",
@@ -408,26 +408,22 @@ class HDUSD_NODE_OP_export_usd_file(HdUSD_Operator, ExportHelper):
         default='.usdc',
         update=on_export_format_changed,
     )
-
     is_export_animation: bpy.props.BoolProperty(
         name="Export animation",
         description="Export animation",
         default=True,
     )
-
     is_restrict_frames: bpy.props.BoolProperty(
         name="Set frames",
         description="Set frames to export",
         default=False,
     )
-
     start_frame: bpy.props.IntProperty(
         name="Start frame",
         description="Start frame to export",
         default=0,
         update=update_start_frame
     )
-
     end_frame: bpy.props.IntProperty(
         name="End frame",
         description="End frame to export",

--- a/src/hdusd/ui/usd_list.py
+++ b/src/hdusd/ui/usd_list.py
@@ -298,7 +298,7 @@ class HDUSD_OP_usd_tree_node_print_stage(HdUSD_Operator):
 
         print(f"Node \"{tree.name}\":\"{node.name}\" USD stage is:")
         print(stage.ExportToString())
-        
+
         return {'FINISHED'}
 
 
@@ -314,7 +314,6 @@ class HDUSD_OP_usd_tree_node_print_root_layer(HdUSD_Operator):
 
     def execute(self, context):
         tree = context.space_data.edit_tree
-
         node = context.active_node
         if not node:
             log(f"Unable to print USD nodetree \"{tree.name}\" stage: no USD node selected")

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -17,6 +17,7 @@ import bpy
 from .nodes.hydra_render import HydraRenderNode
 from .nodes.print_file import PrintFileNode
 from .nodes.write_file import WriteFileNode
+from .nodes.blender_data import BlenderDataNode
 from ..viewport import usd_collection
 from ..engine.viewport_engine import ViewportEngineNodetree
 
@@ -87,7 +88,8 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)) \
+                    and not (isinstance(node, BlenderDataNode) and node.is_use_animation):
                 node.depsgraph_update(depsgraph)
 
     def frame_change(self, depsgraph):
@@ -95,7 +97,8 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)) \
+                    and not (isinstance(node, BlenderDataNode) and node.is_use_animation):
                 node.frame_change(depsgraph)
 
     def material_update(self, depsgraph):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -88,8 +88,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)) \
-                    and not (isinstance(node, BlenderDataNode) and node.is_use_animation):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
                 node.depsgraph_update(depsgraph)
 
     def frame_change(self, depsgraph):
@@ -97,8 +96,7 @@ class USDTree(bpy.types.ShaderNodeTree):
             return
 
         for node in self.nodes:
-            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)) \
-                    and not (isinstance(node, BlenderDataNode) and node.is_use_animation):
+            if not isinstance(node, (bpy.types.NodeReroute, bpy.types.NodeFrame)):
                 node.frame_change(depsgraph)
 
     def material_update(self, depsgraph):

--- a/src/hdusd/usd_nodes/node_tree.py
+++ b/src/hdusd/usd_nodes/node_tree.py
@@ -17,7 +17,6 @@ import bpy
 from .nodes.hydra_render import HydraRenderNode
 from .nodes.print_file import PrintFileNode
 from .nodes.write_file import WriteFileNode
-from .nodes.blender_data import BlenderDataNode
 from ..viewport import usd_collection
 from ..engine.viewport_engine import ViewportEngineNodetree
 

--- a/src/hdusd/usd_nodes/nodes/__init__.py
+++ b/src/hdusd/usd_nodes/nodes/__init__.py
@@ -64,6 +64,7 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     blender_data.HDUSD_USD_NODETREE_OP_blender_data_link_object,
     blender_data.HDUSD_USD_NODETREE_OP_blender_data_unlink_object,
     blender_data.HDUSD_USD_NODETREE_MT_blender_data_object,
+    blender_data.HDUSD_USD_NODETREE_OP_blender_data_update_animation,
     blender_data.BlenderDataNode,
     instancing.HDUSD_USD_NODETREE_MT_instancing_object,
 

--- a/src/hdusd/usd_nodes/nodes/blender_data.py
+++ b/src/hdusd/usd_nodes/nodes/blender_data.py
@@ -233,8 +233,9 @@ class BlenderDataNode(USDNode):
             layout.prop(self, 'is_restrict_frames')
 
         if self.is_use_animation and self.is_restrict_frames:
-            layout.prop(self, 'start_frame')
-            layout.prop(self, 'end_frame')
+            row = layout.row(align=True)
+            row.prop(self, 'start_frame')
+            row.prop(self, 'end_frame')
 
         if self.is_use_animation:
             layout.operator(HDUSD_USD_NODETREE_OP_blender_data_update_animation.bl_idname,

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -130,6 +130,8 @@ class UsdFileNode(USDNode):
             return None
 
         input_stage = Usd.Stage.Open(file_path)
+        root_layer = input_stage.GetRootLayer()
+        root_layer.TransferContent(input_stage.Flatten(False))
 
         if self.filter_path == '/*':
             set_timesamples_for_stage(input_stage,

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -101,8 +101,9 @@ class UsdFileNode(USDNode):
             layout.prop(self, 'is_restrict_frames')
 
         if self.is_import_animation and self.is_restrict_frames:
-            layout.prop(self, 'start_frame')
-            layout.prop(self, 'end_frame')
+            row = layout.row(align=True)
+            row.prop(self, 'start_frame')
+            row.prop(self, 'end_frame')
 
     def compute(self, **kwargs):
         if not self.filename:

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -115,7 +115,6 @@ class UsdFileNode(USDNode):
             return None
 
         input_stage = Usd.Stage.Open(file_path)
-        print(input_stage.ExportToString())
         root_layer = input_stage.GetRootLayer()
         root_layer.TransferContent(input_stage.Flatten(False))
 

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -51,9 +51,16 @@ class UsdFileNode(USDNode):
         update=update_data
     )
 
+    is_import_animation: bpy.props.BoolProperty(
+        name="Import animation",
+        description="Import animation",
+        default=True,
+    )
+
     def draw_buttons(self, context, layout):
         layout.prop(self, 'filename')
         layout.prop(self, 'filter_path')
+        layout.prop(self, 'is_import_animation')
 
     def compute(self, **kwargs):
         if not self.filename:
@@ -67,6 +74,12 @@ class UsdFileNode(USDNode):
         input_stage = Usd.Stage.Open(file_path)
         root_layer = input_stage.GetRootLayer()
         root_layer.TransferContent(input_stage.Flatten(False))
+
+        if self.is_import_animation:
+            scene = bpy.context.evaluated_depsgraph_get().scene
+
+            scene.frame_start = input_stage.GetStartTimeCode()
+            scene.frame_end = input_stage.GetEndTimeCode()
 
         if self.filter_path == '/*':
             self.cached_stage.insert(input_stage)

--- a/src/hdusd/usd_nodes/nodes/usd_file.py
+++ b/src/hdusd/usd_nodes/nodes/usd_file.py
@@ -48,10 +48,25 @@ class UsdFileNode(USDNode):
 
         self.update_data(context)
 
+    def update_filename(self, context):
+        if not self.filename:
+            return None
+
+        file_path = bpy.path.abspath(self.filename)
+        if not os.path.isfile(file_path):
+            return None
+
+        input_stage = Usd.Stage.Open(file_path)
+
+        self['start_frame'] = int(input_stage.GetMetadata('startTimeCode'))
+        self['end_frame'] = int(input_stage.GetMetadata('endTimeCode'))
+
+        self.update_data(context)
+
     filename: bpy.props.StringProperty(
         name="USD File",
         subtype='FILE_PATH',
-        update=update_data,
+        update=update_filename,
     )
 
     filter_path: bpy.props.StringProperty(
@@ -115,8 +130,6 @@ class UsdFileNode(USDNode):
             return None
 
         input_stage = Usd.Stage.Open(file_path)
-        root_layer = input_stage.GetRootLayer()
-        root_layer.TransferContent(input_stage.Flatten(False))
 
         if self.filter_path == '/*':
             set_timesamples_for_stage(input_stage,

--- a/src/hdusd/usd_nodes/nodes/write_file.py
+++ b/src/hdusd/usd_nodes/nodes/write_file.py
@@ -70,8 +70,9 @@ class WriteFileNode(USDNode):
             layout.prop(self, 'is_restrict_frames')
 
         if self.is_export_animation and self.is_restrict_frames:
-            layout.prop(self, 'start_frame')
-            layout.prop(self, 'end_frame')
+            row = layout.row(align=True)
+            row.prop(self, 'start_frame')
+            row.prop(self, 'end_frame')
 
     def compute(self, **kwargs):
         input_stage = self.get_input_link('Input', **kwargs)

--- a/src/hdusd/usd_nodes/nodes/write_file.py
+++ b/src/hdusd/usd_nodes/nodes/write_file.py
@@ -41,20 +41,17 @@ class WriteFileNode(USDNode):
         description="Export animation",
         default=True,
     )
-
     is_restrict_frames: bpy.props.BoolProperty(
         name="Set frames",
         description="Set frames to export",
         default=False,
     )
-
     start_frame: bpy.props.IntProperty(
         name="Start frame",
         description="Start frame to export",
         default=0,
         update=update_start_frame
     )
-
     end_frame: bpy.props.IntProperty(
         name="End frame",
         description="End frame to export",

--- a/src/hdusd/utils/usd.py
+++ b/src/hdusd/utils/usd.py
@@ -65,7 +65,7 @@ def traverse_stage(stage, *, ignore=None):
     def traverse(prim):
         for child in prim.GetAllChildren():
             if ignore and ignore(child):
-                log.warn(f'Ignoring prim {child.GetTypeName()}, {child}')
+                log(f'Ignoring prim {child.GetTypeName()}, {child}')
                 continue
 
             yield child


### PR DESCRIPTION
### PURPOSE
Add animation Import-Export support.

### EFFECT OF CHANGE
Added animation support for nodes (Blender Data, USD file, Write USD file) and exporting USD to file.

### TECHNICAL STEPS
- Corresponded UI changes for Blender Data, USD file, Write USD file nodes and exporting USD to file;
- added reading and setting endTimeCode and startTimeCode to USD;
- added setting timeSamples to object transform;
- added auxiliary methods for setting USD timecodes to utils/usd.py;