### PR TITLE
BLEN-105: Add RenderMan delegate samples option

### DIFF
--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -285,6 +285,11 @@ class FinalEngine(Engine):
             renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
             renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
 
+        if settings.delegate == 'HdPrmanLoaderRendererPlugin':
+            hdprman = settings.hdprman
+            renderer.SetRendererSetting('convergedSamplesPerPixel', hdprman.samples)
+            renderer.SetRendererSetting('convergedVariance', hdprman.variance_threshold)
+
         return True
 
 

--- a/src/hdusd/engine/final_engine.py
+++ b/src/hdusd/engine/final_engine.py
@@ -289,6 +289,7 @@ class FinalEngine(Engine):
             hdprman = settings.hdprman
             renderer.SetRendererSetting('convergedSamplesPerPixel', hdprman.samples)
             renderer.SetRendererSetting('convergedVariance', hdprman.variance_threshold)
+            renderer.SetRendererSetting('interactiveIntegratorTimeout', hdprman.timeout)
 
         return True
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -350,6 +350,11 @@ class ViewportEngine(Engine):
             self.renderer.SetRendererSetting('rpr:denoising:minIter', denoise.min_iter)
             self.renderer.SetRendererSetting('rpr:denoising:iterStep', denoise.iter_step)
 
+        if settings.delegate == 'HdPrmanLoaderRendererPlugin':
+            hdprman = settings.hdprman
+            self.renderer.SetRendererSetting('convergedSamplesPerPixel', hdprman.samples)
+            self.renderer.SetRendererSetting('convergedVariance', hdprman.variance_threshold)
+
     def _check_restart_renderer(self, scene):
         restart = False
 

--- a/src/hdusd/engine/viewport_engine.py
+++ b/src/hdusd/engine/viewport_engine.py
@@ -354,6 +354,7 @@ class ViewportEngine(Engine):
             hdprman = settings.hdprman
             self.renderer.SetRendererSetting('convergedSamplesPerPixel', hdprman.samples)
             self.renderer.SetRendererSetting('convergedVariance', hdprman.variance_threshold)
+            self.renderer.SetRendererSetting('interactiveIntegratorTimeout', hdprman.timeout)
 
     def _check_restart_renderer(self, scene):
         restart = False

--- a/src/hdusd/properties/__init__.py
+++ b/src/hdusd/properties/__init__.py
@@ -51,6 +51,7 @@ from . import (
     usd_list,
     material,
     hdrpr_render,
+    hdprman_render,
     matlib
 )
 register, unregister = bpy.utils.register_classes_factory((
@@ -61,6 +62,8 @@ register, unregister = bpy.utils.register_classes_factory((
     hdrpr_render.ContourSettings,
     hdrpr_render.DenoiseSettings,
     hdrpr_render.RenderSettings,
+
+    hdprman_render.RenderSettings,
 
     usd_list.PrimPropertyItem,
     usd_list.UsdListItem,

--- a/src/hdusd/properties/hdprman_render.py
+++ b/src/hdusd/properties/hdprman_render.py
@@ -30,3 +30,9 @@ class RenderSettings(bpy.types.PropertyGroup):
         min=0.001, soft_max=0.5,
         default=0.15,
     )
+    timeout: IntProperty(
+        name="Timeout",
+        description="If >0, the time in ms that renders quick output before switching to path tracing",
+        min=0, max=2 ** 16,
+        default=200,
+    )

--- a/src/hdusd/properties/hdprman_render.py
+++ b/src/hdusd/properties/hdprman_render.py
@@ -1,0 +1,32 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+import bpy
+from bpy.props import IntProperty, FloatProperty
+
+
+class RenderSettings(bpy.types.PropertyGroup):
+    samples: IntProperty(
+        name="Samples",
+        description="Number of samples to render for each pixel",
+        min=1, max=2 ** 16,
+        default=64,
+    )
+    variance_threshold: FloatProperty(
+        name="Pixel Variance",
+        description="Once pixels are below this amount of noise,\n"
+                    "no more samples are added. Set to 0 for no cutoff",
+        min=0.001, soft_max=0.5,
+        default=0.15,
+    )

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -19,7 +19,7 @@ from pxr import UsdImagingGL, UsdGeom
 from ..viewport import usd_collection
 from ..export.camera import CameraData
 from ..viewport.usd_collection import USD_CAMERA
-from . import HdUSDProperties, hdrpr_render, log
+from . import HdUSDProperties, hdrpr_render, hdprman_render, log
 
 
 _render_delegates = {name: UsdImagingGL.Engine.GetRendererDisplayName(name)
@@ -44,6 +44,7 @@ class RenderSettings(bpy.types.PropertyGroup):
         return _render_delegates[self.delegate]
 
     hdrpr: bpy.props.PointerProperty(type=hdrpr_render.RenderSettings)
+    hdprman: bpy.props.PointerProperty(type=hdprman_render.RenderSettings)
 
     def nodetree_update(self, context):
         if not self.data_source:

--- a/src/hdusd/ui/__init__.py
+++ b/src/hdusd/ui/__init__.py
@@ -44,6 +44,7 @@ from . import (
     panels,
     render,
     hdrpr_render,
+    hdprman_render,
     light,
     material,
     matlib,
@@ -73,6 +74,11 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_samples_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_quality_viewport,
     hdrpr_render.HDUSD_RENDER_PT_hdrpr_settings_denoise_viewport,
+
+    hdprman_render.HDUSD_RENDER_PT_hdprman_settings_final,
+    hdprman_render.HDUSD_RENDER_PT_hdprman_settings_samples_final,
+    hdprman_render.HDUSD_RENDER_PT_hdprman_settings_viewport,
+    hdprman_render.HDUSD_RENDER_PT_hdprman_settings_samples_viewport,
 
     light.HDUSD_LIGHT_PT_light,
 

--- a/src/hdusd/ui/hdprman_render.py
+++ b/src/hdusd/ui/hdprman_render.py
@@ -45,6 +45,7 @@ class HDUSD_RENDER_PT_hdprman_settings_samples_final(HdUSD_Panel):
         col = layout.column(align=True)
         col.prop(hdprman, "samples")
         col.prop(hdprman, "variance_threshold")
+        col.prop(hdprman, "timeout")
 
 
 #
@@ -77,3 +78,4 @@ class HDUSD_RENDER_PT_hdprman_settings_samples_viewport(HdUSD_Panel):
         col = layout.column(align=True)
         col.prop(hdprman, "samples")
         col.prop(hdprman, "variance_threshold")
+        col.prop(hdprman, "timeout")

--- a/src/hdusd/ui/hdprman_render.py
+++ b/src/hdusd/ui/hdprman_render.py
@@ -19,7 +19,7 @@ from . import HdUSD_Panel
 # FINAL RENDER SETTINGS
 #
 class HDUSD_RENDER_PT_hdprman_settings_final(HdUSD_Panel):
-    bl_label = "Prman Settings"
+    bl_label = "RenderMan Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_final'
 
     @classmethod
@@ -52,7 +52,7 @@ class HDUSD_RENDER_PT_hdprman_settings_samples_final(HdUSD_Panel):
 # VIEWPORT RENDER SETTINGS
 #
 class HDUSD_RENDER_PT_hdprman_settings_viewport(HdUSD_Panel):
-    bl_label = "Prman Settings"
+    bl_label = "RenderMan Settings"
     bl_parent_id = 'HDUSD_RENDER_PT_render_settings_viewport'
 
     @classmethod

--- a/src/hdusd/ui/hdprman_render.py
+++ b/src/hdusd/ui/hdprman_render.py
@@ -1,0 +1,79 @@
+#**********************************************************************
+# Copyright 2020 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#********************************************************************
+from . import HdUSD_Panel
+
+
+#
+# FINAL RENDER SETTINGS
+#
+class HDUSD_RENDER_PT_hdprman_settings_final(HdUSD_Panel):
+    bl_label = "Prman Settings"
+    bl_parent_id = 'HDUSD_RENDER_PT_render_settings_final'
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.scene.hdusd.final.delegate == 'HdPrmanLoaderRendererPlugin'
+
+    def draw(self, context):
+        pass
+
+
+class HDUSD_RENDER_PT_hdprman_settings_samples_final(HdUSD_Panel):
+    bl_label = "Samples"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdprman_settings_final'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdprman = context.scene.hdusd.final.hdprman
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        col = layout.column(align=True)
+        col.prop(hdprman, "samples")
+        col.prop(hdprman, "variance_threshold")
+
+
+#
+# VIEWPORT RENDER SETTINGS
+#
+class HDUSD_RENDER_PT_hdprman_settings_viewport(HdUSD_Panel):
+    bl_label = "Prman Settings"
+    bl_parent_id = 'HDUSD_RENDER_PT_render_settings_viewport'
+
+    @classmethod
+    def poll(cls, context):
+        return super().poll(context) and context.scene.hdusd.viewport.delegate == 'HdPrmanLoaderRendererPlugin'
+
+    def draw(self, context):
+        pass
+
+
+class HDUSD_RENDER_PT_hdprman_settings_samples_viewport(HdUSD_Panel):
+    bl_label = "Samples"
+    bl_parent_id = 'HDUSD_RENDER_PT_hdprman_settings_viewport'
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        hdprman = context.scene.hdusd.viewport.hdprman
+
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        col = layout.column(align=True)
+        col.prop(hdprman, "samples")
+        col.prop(hdprman, "variance_threshold")


### PR DESCRIPTION
### PURPOSE
Add RenderMan delegate samples option.

### EFFECT OF CHANGE
Add RenderMan delegate Samples, Pixel Variance, and Timeout parameters.

### TECHNICAL STEPS
Improved _sync_render_settings for final and viewport render as well.
Added Prman properties hdprman_render.py.
- RenderSettings
  - samples
  - variance_threshold
  - timeout

Added Prman UI hdprman_render.py.
- HDUSD_RENDER_PT_hdprman_settings_final
- HDUSD_RENDER_PT_hdprman_settings_samples_final
- HDUSD_RENDER_PT_hdprman_settings_viewport
- HDUSD_RENDER_PT_hdprman_settings_samples_viewport

### NOTES FOR REVIEWERS
Added all parameters that are currently supported by USD.