### PR TITLE
BLEN-131: [Hybrid Pro] TypeError: bpy_struct: item.attr = val: enum "" not found in ('BW', 'RGB')

### DIFF
--- a/src/hdusd/utils/image.py
+++ b/src/hdusd/utils/image.py
@@ -50,6 +50,12 @@ def cache_image_file(image: bpy.types.Image, cache_check=True):
     scene = bpy.context.scene
     user_format = scene.render.image_settings.file_format
     user_color_mode = scene.render.image_settings.color_mode
+
+    # in some scenes the color_mode is undefined
+    # we can read it but unable to assign back, so switch it to 'RGB' if color_mode isn't selected
+    if not user_color_mode:
+        user_color_mode = 'RGB'
+
     scene.render.image_settings.file_format = BLENDER_DEFAULT_FORMAT
     scene.render.image_settings.color_mode = BLENDER_DEFAULT_COLOR_MODE
 


### PR DESCRIPTION
### PURPOSE
TypeError: bpy_struct: item.attr = val: enum "" not found in ('BW', 'RGB').

### EFFECT OF CHANGE
Fixed error while output color mode is undefined.

### TECHNICAL STEPS
It is used Blender tools image.save_render to create an image cache.
In case when color_mode is undefined an error occurs. It only happens in some scenes it's unavailable to make it manually.
Added condition for color_mode, now it's 'RGB' (it presents in all file formats) if none is selected.