### PR TITLE
BLEN-173: Empty Render Delegate on systems without Render man delegate

### DIFF
--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ********************************************************************
 import bpy
+from hdusd.properties.scene import FinalRenderSettings, ViewportRenderSettings
 
 from .. import utils
 from .engine import log
@@ -32,6 +33,12 @@ def on_load_post(*args):
     from ..usd_nodes import node_tree
     node_tree.reset()
 
+    for scene in bpy.data.scenes:
+        if not scene.hdusd.final.delegate:
+            scene.hdusd.final.delegate = FinalRenderSettings.delegate_items[0][0]
+            
+        if not scene.hdusd.viewport.delegate:
+            scene.hdusd.viewport.delegate = ViewportRenderSettings.delegate_items[0][0]
 
 _do_depsgraph_update = True
 

--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -13,8 +13,8 @@
 # limitations under the License.
 # ********************************************************************
 import bpy
-from hdusd.properties.scene import DEFAULT_DELEGATE
 
+from ..properties.scene import DEFAULT_DELEGATE
 from .. import utils
 from .engine import log
 

--- a/src/hdusd/engine/handlers.py
+++ b/src/hdusd/engine/handlers.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ********************************************************************
 import bpy
-from hdusd.properties.scene import FinalRenderSettings, ViewportRenderSettings
+from hdusd.properties.scene import DEFAULT_DELEGATE
 
 from .. import utils
 from .engine import log
@@ -35,10 +35,10 @@ def on_load_post(*args):
 
     for scene in bpy.data.scenes:
         if not scene.hdusd.final.delegate:
-            scene.hdusd.final.delegate = FinalRenderSettings.delegate_items[0][0]
-            
+            scene.hdusd.final.delegate = DEFAULT_DELEGATE
+
         if not scene.hdusd.viewport.delegate:
-            scene.hdusd.viewport.delegate = ViewportRenderSettings.delegate_items[0][0]
+            scene.hdusd.viewport.delegate = DEFAULT_DELEGATE
 
 _do_depsgraph_update = True
 

--- a/src/hdusd/properties/scene.py
+++ b/src/hdusd/properties/scene.py
@@ -22,6 +22,9 @@ from ..viewport.usd_collection import USD_CAMERA
 from . import HdUSDProperties, hdrpr_render, hdprman_render, log
 
 
+DEFAULT_DELEGATE = 'HdRprPlugin'
+
+
 _render_delegates = {name: UsdImagingGL.Engine.GetRendererDisplayName(name)
                      if name != 'HdPrmanLoaderRendererPlugin' else "RenderMan"
                      for name in UsdImagingGL.Engine.GetRendererPlugins()}
@@ -79,7 +82,7 @@ class FinalRenderSettings(RenderSettings):
         name="Renderer",
         items=RenderSettings.delegate_items,
         description="Render delegate for final render",
-        default='HdRprPlugin',
+        default=DEFAULT_DELEGATE,
     )
     data_source: bpy.props.StringProperty(
         name="Data Source",
@@ -97,7 +100,7 @@ class ViewportRenderSettings(RenderSettings):
     delegate: bpy.props.EnumProperty(
         name="Renderer",
         items=RenderSettings.delegate_items,
-        default='HdRprPlugin',
+        default=DEFAULT_DELEGATE,
     )
 
     def data_source_update(self, context):


### PR DESCRIPTION
### PURPOSE
Fix issue when scene was saved with render delegate which doesn't exist on current Blender.

### EFFECT OF CHANGE
Fixed issue when scene was saved with render delegate which doesn't exist on current Blender.

### TECHNICAL STEPS
Added check in handler for chosen render delegate.