### PR TITLE
Fixed possible issue during importing usd file in USD nodetree.

### DIFF
--- a/src/hdusd/export/world/__init__.py
+++ b/src/hdusd/export/world/__init__.py
@@ -172,9 +172,16 @@ class WorldData:
         light_prim = next((prim for prim in stage.TraverseAll() if
                            prim.GetTypeName() == 'DomeLight'), None)
         if light_prim:
-            data.color = light_prim.GetAttribute('inputs:color').Get()
-            data.intensity = light_prim.GetAttribute('inputs:intensity').Get()
-            data.transparency = light_prim.GetAttribute('inputs:transparency').Get()
+            color = light_prim.GetAttribute('inputs:color').Get()
+            intensity = light_prim.GetAttribute('inputs:intensity').Get()
+            transparency = light_prim.GetAttribute('inputs:transparency').Get()
+
+            if color is not None:
+                data.color = color
+            if intensity is not None:
+                data.intensity = intensity
+            if transparency is not None:
+                data.transparency = transparency
 
         return data
 


### PR DESCRIPTION
### PURPOSE
Possible issue during importing usd file in USD nodetree
```
  File "D:\amd-gpuopen\BlenderUSDHydraAddon\src\hdusd\engine\viewport_engine.py", line 521, in _sync
    self.render_params.clearColor = world_data.clear_color
Boost.Python.ArgumentError: Python argument types in
    None.None(RenderParams, tuple)
```

### EFFECT OF CHANGE
Fixed possible issue during importing usd file in USD nodetree.

### TECHNICAL STEPS
Added check `is not None` in WorldData.init_from_stage()