### PR TITLE
BLEN-577: Move code from ResolverBlenderAddon to BlenderUSDHydraAddon

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /bin*
 
 .idea
+.DS_Store

--- a/.gitmodules
+++ b/.gitmodules
@@ -7,3 +7,9 @@
 [submodule "deps/USD"]
 	path = deps/USD
 	url = https://github.com/PixarAnimationStudios/USD
+[submodule "deps/RenderStudioKit"]
+	path = deps/RenderStudioKit
+	url = git@github.com:Radeon-Pro/RenderStudioKit.git
+[submodule "deps/Boost"]
+	path = deps/Boost
+	url = https://github.com/boostorg/boost.git

--- a/.gitmodules
+++ b/.gitmodules
@@ -10,6 +10,3 @@
 [submodule "deps/RenderStudioKit"]
 	path = deps/RenderStudioKit
 	url = git@github.com:Radeon-Pro/RenderStudioKit.git
-[submodule "deps/Boost"]
-	path = deps/Boost
-	url = https://github.com/boostorg/boost.git

--- a/build.py
+++ b/build.py
@@ -20,11 +20,16 @@ import shutil
 import zipfile
 import zlib
 import os
+import sys
+import sysconfig
+from urllib.request import urlopen
+
 
 OS = platform.system()
 POSTFIX = ""
 EXT = ".exe" if OS == 'Windows' else ""
-LIBEXT = ".lib" if OS == 'Windows' else ".so"
+LIBEXT = ".lib" if OS == 'Windows' else ".dylib" if OS == 'Darwin' else ".so"
+DLLEXT = ".dll" if OS == 'Windows' else ".dylib" if OS == 'Darwin' else ".so"
 LIBPREFIX = "" if OS == 'Windows' else "lib"
 
 repo_dir = Path(__file__).parent.resolve()
@@ -86,6 +91,45 @@ def uninstall_requirements(py_executable, installed_modules):
             print("Error:", e)
 
 
+def get_version():
+    # getting build version
+    build_ver = subprocess.getoutput("git rev-parse --short HEAD")
+
+    # # getting plugin version
+    # text = (repo_dir / "src/hdusd/__init__.py").read_text()
+    # m = re.search(r'"version": \((\d+), (\d+), (\d+)\)', text)
+    # plugin_ver = m.group(1), m.group(2), m.group(3)
+    #
+    # return (*plugin_ver, build_ver)
+    return build_ver
+
+
+def create_zip_addon(install_dir, bin_dir, name, package_name, enumerate_addon_data, ver):
+    """ Pack addon files to zip archive """
+    zip_addon = install_dir / name
+    if zip_addon.is_file():
+        os.remove(zip_addon)
+
+    print(f"Compressing addon files to: {zip_addon}")
+    with zipfile.ZipFile(zip_addon, 'w', compression=zipfile.ZIP_DEFLATED,
+                         compresslevel=zlib.Z_BEST_COMPRESSION) as myzip:
+        for src, package_path in enumerate_addon_data(bin_dir):
+            print(f"adding {src} --> {package_path}")
+
+            arcname = str(Path(package_name) / package_path)
+
+            if str(package_path) == "__init__.py":
+                print(f"    set version_build={ver[3]}")
+                text = src.read_text(encoding='utf-8')
+                text = text.replace('version_build = ""', f'version_build = "{ver[3]}"')
+                myzip.writestr(arcname, text)
+                continue
+
+            myzip.write(str(src), arcname=arcname)
+
+    return zip_addon
+
+
 def print_start(msg):
     print(f"""
 -------------------------------------------------------------
@@ -127,13 +171,16 @@ def _cmake(src_dir, bin_dir, compiler, jobs, build_var, clean, args):
 
 
 def materialx(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
+    print_start("Building MaterialX")
+
     libdir = bl_libs_dir.as_posix()
-    py_exe = f"{libdir}/python/310/bin/python{POSTFIX}{EXT}" if OS == 'Windows' \
-        else f"{libdir}/python/bin/python3.10{POSTFIX}{EXT}"
+    py_exe = f"{libdir}/python/310/bin/python.exe" if OS == 'Windows' else\
+             f"{libdir}/python/bin/python3.10"
 
     _cmake(deps_dir / "MaterialX", bin_dir / "materialx", compiler, jobs, build_var, clean, [
         '-DMATERIALX_BUILD_PYTHON=ON',
         '-DMATERIALX_BUILD_RENDER=ON',
+        # '-DMATERIALX_BUILD_VIEWER=ON',
         '-DMATERIALX_INSTALL_PYTHON=OFF',
         f'-DMATERIALX_PYTHON_EXECUTABLE={py_exe}',
         f'-DMATERIALX_PYTHON_VERSION=3.10',
@@ -149,10 +196,9 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
     print_start("Building USD")
 
     usd_dir = deps_dir / "USD"
-
     libdir = bl_libs_dir.as_posix()
-    py_exe = f"{libdir}/python/310/bin/python{POSTFIX}{EXT}" if OS == 'Windows' \
-        else f"{libdir}/python/bin/python3.10{POSTFIX}{EXT}"
+    py_exe = f"{libdir}/python/310/bin/python.exe" if OS == 'Windows' else\
+             f"{libdir}/python/bin/python3.10"
 
     # USD_PLATFORM_FLAGS
     args = [
@@ -166,6 +212,16 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
             "-DPXR_USE_DEBUG_PYTHON=ON",
             f"-DOPENVDB_LIBRARY={libdir}/openvdb/lib/openvdb_d.lib",
         ]
+    if OS != 'Windows':
+        args += [
+            f"-DPython3_ROOT_DIR={libdir}/python/",
+            f"-DPYTHON_INCLUDE_DIR={libdir}/python/include/python3.10/",
+            f"-DPYTHON_LIBRARY={libdir}/tbb/lib/{LIBPREFIX}tbb{LIBEXT}",
+        ]
+        if OS == 'Darwin':
+            args += [
+                f'-DCMAKE_SHARED_LINKER_FLAGS=-Xlinker -undefined -Xlinker dynamic_lookup',
+            ]
 
     # DEFAULT_BOOST_FLAGS
     args += [
@@ -185,7 +241,6 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
     args += [
         f"-DOPENSUBDIV_ROOT_DIR={libdir}/opensubdiv",
         f"-DOpenImageIO_ROOT={libdir}/openimageio",
-        #f"-DMaterialX_ROOT={libdir}/materialx",
         f"-DMaterialX_DIR={bin_dir / 'materialx/install/lib/cmake/MaterialX'}",
         f"-DOPENEXR_LIBRARIES={libdir}/imath/lib/{LIBPREFIX}Imath{POSTFIX}{LIBEXT}",
         f"-DOPENEXR_INCLUDE_DIR={libdir}/imath/include",
@@ -253,6 +308,56 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
         os.chdir(cur_dir)
 
 
+def boost(bin_dir, clean):
+    print_start("Building Boost")
+
+    boost_dir = bin_dir / "boost"
+    install_dir = boost_dir / "install"
+    build_dir = boost_dir / "build"
+
+    if clean:
+        rm_dir(boost_dir)
+
+    cur_dir = os.getcwd()
+    os.chdir(str(deps_dir / "Boost"))
+
+    # python-config.jam is required for boost::python
+    project_path = 'python-config.jam'
+    with open(project_path, 'w') as project_file:
+        project_file.write("\n".join([
+            f'using python : {sysconfig.get_config_var("py_version_short")}',
+            f'  : "{Path(sys.executable).as_posix()}"',
+            f'  : "{Path(sysconfig.get_path("include")).as_posix()}"',
+            f'  : "{(Path(sysconfig.get_config_var("base")) / "libs").as_posix()}"',
+            '  ;\n'
+        ]))
+
+    args = [
+        "b2",
+        f"--prefix={install_dir}",
+        f"--build-dir={build_dir}",
+        "address-model=64",
+        "link=shared",
+        "runtime-link=shared",
+        "threading=multi",
+        "variant=release",
+        "--with-log",
+        "--with-python",
+        f"--user-config={project_path}",
+        "-sNO_BZIP2=1",
+        "toolset=msvc-14.2",
+        "install"
+    ]
+
+    try:
+        check_call("bootstrap.bat", f'--prefix="{install_dir}"')
+        check_call(*args)
+    finally:
+        check_call('git', 'checkout', '--', '*')
+        check_call('git', 'clean', '-f')
+        os.chdir(cur_dir)
+
+
 def hdrpr(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
     print_start("Building HdRPR")
 
@@ -263,8 +368,8 @@ def hdrpr(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
 
     os.environ['PXR_PLUGINPATH_NAME'] = str(usd_dir / "lib/usd")
 
-    py_exe = f"{libdir}/python/310/bin/python{POSTFIX}{EXT}" if OS == 'Windows' \
-        else f"{libdir}/python/bin/python3.10{POSTFIX}{EXT}"
+    py_exe = f"{libdir}/python/310/bin/python.exe" if OS == 'Windows' else\
+             f"{libdir}/python/bin/python3.10"
 
     # Boost flags
     args = [
@@ -301,39 +406,54 @@ def hdrpr(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
         f"-DOPENVDB_LOCATION={libdir}/openvdb",
     ]
 
+    lib_name = "bin" if OS == 'Windows' else "lib"
+    paths = [
+        usd_dir / 'lib',
+        bl_libs_dir / 'boost/lib',
+        bl_libs_dir / f'tbb/{lib_name}',
+        bl_libs_dir / f'openimageio/{lib_name}',
+        bl_libs_dir / f'openvdb/{lib_name}',
+        bin_dir / f'materialx/install/{lib_name}',
+        bl_libs_dir / f'imath/{lib_name}',
+        bl_libs_dir / f'openexr/{lib_name}',
+    ]
+    pxr_init_py = usd_dir / "lib/python/pxr/__init__.py"
+    pxr_init_py_text = None
+
     if OS == 'Windows':
-        # Adding required paths and preloading usd_ms.dll
-        pxr_init_py = usd_dir / "lib/python/pxr/__init__.py"
         print(f"Modifying {pxr_init_py}")
         pxr_init_py_text = pxr_init_py.read_text()
-        pxr_init_py.write_text(
-            pxr_init_py_text +
-f"""
+        text_new = pxr_init_py_text
+        text_new += f"""
 
 import os
 import ctypes
 
-os.add_dll_directory(r"{usd_dir / 'lib'}")
-os.add_dll_directory(r"{bl_libs_dir / 'boost/lib'}")
-os.add_dll_directory(r"{bl_libs_dir / 'tbb/bin'}")
-os.add_dll_directory(r"{bl_libs_dir / 'OpenImageIO/bin'}")
-os.add_dll_directory(r"{bl_libs_dir / 'openvdb/bin'}")
-os.add_dll_directory(r"{bin_dir / 'materialx/install/bin'}")
-os.add_dll_directory(r"{bl_libs_dir / 'imath/bin'}")
-os.add_dll_directory(r"{bl_libs_dir / 'openexr/bin'}")
+"""
+        # Adding required paths and preloading usd_ms.dll
+        for p in paths:
+            text_new += f'os.add_dll_directory(r"{p}")\n'
+        text_new += f'\nctypes.CDLL(r"{usd_dir / "lib/usd_ms.dll"}")\n'
+        pxr_init_py.write_text(text_new)
+        print(text_new)
 
-ctypes.CDLL(r"{usd_dir / 'lib/usd_ms.dll'}")
-""")
-    else:
-        os.environ['LD_LIBRARY_PATH'] = ':'.join([os.environ.get('LD_LIBRARY_PATH', ''),
-                                                  f":{usd_dir / 'lib'}",
-                                                  f":{bl_libs_dir / 'boost/lib'}",
-                                                  f":{bl_libs_dir / 'tbb/lib'}",
-                                                  f":{bl_libs_dir / 'OpenImageIO/lib'}",
-                                                  f":{bl_libs_dir / 'openvdb/lib'}",
-                                                  f":{bin_dir / 'materialx/install/bin'}",
-                                                  f":{bl_libs_dir / 'imath/lib'}",
-                                                  f":{bl_libs_dir / 'openexr/lib'}"])
+    elif OS == 'Darwin':
+        print(f"Modifying {pxr_init_py}")
+        pxr_init_py_text = pxr_init_py.read_text()
+        text_new = pxr_init_py_text
+        text_new += f"""
+
+import ctypes
+
+ctypes.CDLL(r"{bl_libs_dir / 'imath/lib/libImath.dylib'}")
+ctypes.CDLL(r"{bl_libs_dir / 'openexr/lib/libOpenEXR.dylib'}")
+ctypes.CDLL(r"{bl_libs_dir / 'openexr/lib/libOpenEXRCore.dylib'}")
+"""
+        pxr_init_py.write_text(text_new)
+        print(text_new)
+
+    else:   # OS == 'Linux':
+        os.environ['LD_LIBRARY_PATH'] = ':'.join(str(p) for p in paths)
 
     cur_dir = os.getcwd()
     ch_dir(hdrpr_dir)
@@ -351,9 +471,138 @@ ctypes.CDLL(r"{usd_dir / 'lib/usd_ms.dll'}")
 
     finally:
         ch_dir(cur_dir)
-        if OS == 'Windows':
+        if pxr_init_py_text:
             print(f"Reverting {pxr_init_py}")
             pxr_init_py.write_text(pxr_init_py_text)
+
+    rif_ver = "1.7.3"
+    ml_ver = "0.9.12"
+    mi_ver = "2.0.5"
+    if OS == 'Darwin':
+        lib_dir = bin_dir / "hdrpr/install/lib"
+        # removing and renaming
+        (lib_dir / "libRadeonImageFilters.dylib").unlink()
+        (lib_dir / f"libRadeonImageFilters.{rif_ver[0]}.dylib").unlink()
+        (lib_dir / f"libRadeonImageFilters.{rif_ver}.dylib").rename(lib_dir / "libRadeonImageFilters.dylib")
+        check_call('install_name_tool', '-change',
+                   f"@rpath/libRadeonImageFilters.{rif_ver[0]}.dylib", "@rpath/libRadeonImageFilters.dylib",
+                   str(lib_dir / "libRadeonImageFilters.dylib"))
+        check_call('install_name_tool', '-change',
+                   f"@rpath/libRadeonML.{ml_ver[0]}.dylib", "@rpath/libRadeonML.dylib",
+                   str(lib_dir / "libRadeonImageFilters.dylib"))
+
+        (lib_dir / "libRadeonML.dylib").unlink()
+        (lib_dir / f"libRadeonML.{ml_ver[0]}.dylib").unlink()
+        (lib_dir / f"libRadeonML.{ml_ver}.dylib").rename(lib_dir / "libRadeonML.dylib")
+        check_call('install_name_tool', '-change',
+                   f"@rpath/libRadeonML.{ml_ver[0]}.dylib", "@rpath/libRadeonML.dylib",
+                   str(lib_dir / "libRadeonML.dylib"))
+
+        (lib_dir / "libRadeonML_MPS.dylib").unlink()
+        (lib_dir / f"libRadeonML_MPS.{ml_ver[0]}.dylib").unlink()
+        (lib_dir / f"libRadeonML_MPS.{ml_ver}.dylib").rename(lib_dir / "libRadeonML_MPS.dylib")
+        check_call('install_name_tool', '-change',
+                   f"@rpath/libRadeonML_MPS.{ml_ver[0]}.dylib", "@rpath/libRadeonML_MPS.dylib",
+                   str(lib_dir / "libRadeonML_MPS.dylib"))
+
+        # fixing @rpath
+        rprusd_lib = bin_dir / "hdrpr/install/lib/librprUsd.dylib"
+        assert rprusd_lib.exists()
+        check_call('install_name_tool', '-change',
+                   "@rpath/libMaterialXFormat.1.dylib", "@rpath/libMaterialXFormat.dylib", str(rprusd_lib))
+        check_call('install_name_tool', '-change',
+                   "@rpath/libMaterialXCore.1.dylib", "@rpath/libMaterialXCore.dylib", str(rprusd_lib))
+
+        hdrpr_lib = bin_dir / "hdrpr/install/plugin/usd/hdRpr.dylib"
+        assert hdrpr_lib.exists()
+        check_call('install_name_tool', '-change',
+                   "@rpath/libMaterialXFormat.1.dylib", "@rpath/libMaterialXFormat.dylib", str(hdrpr_lib))
+        check_call('install_name_tool', '-change',
+                   "@rpath/libMaterialXCore.1.dylib", "@rpath/libMaterialXCore.dylib", str(hdrpr_lib))
+        check_call('install_name_tool', '-change',
+                   "@rpath/libRadeonImageFilters.1.dylib", "@rpath/libRadeonImageFilters.dylib", str(hdrpr_lib))
+
+    elif OS == 'Linux':
+        lib_dir = bin_dir / "hdrpr/install/lib"
+
+        # removing and renaming
+        (lib_dir / "libRadeonImageFilters.so").unlink()
+        (lib_dir / f"libRadeonImageFilters.so.{rif_ver[0]}").unlink()
+        (lib_dir / f"libRadeonImageFilters.so.{rif_ver}").rename(lib_dir / "libRadeonImageFilters.so")
+        check_call('patchelf', '--replace-needed',
+                   f"libRadeonML.so.{ml_ver[0]}", "libRadeonML.so",
+                   str(lib_dir / "libRadeonImageFilters.so"))
+
+        (lib_dir / f"libRadeonML.so.{ml_ver[0]}").unlink()
+        (lib_dir / f"libRadeonML.so.{ml_ver}").rename(lib_dir / "libRadeonML.so")
+
+        (lib_dir / "libRadeonML_MIOpen.so").unlink()
+        (lib_dir / f"libRadeonML_MIOpen.so.{ml_ver[0]}").unlink()
+        (lib_dir / f"libRadeonML_MIOpen.so.{ml_ver}").rename(lib_dir / "libRadeonML_MIOpen.so")
+
+        (lib_dir / "libMIOpen.so").unlink()
+        (lib_dir / f"libMIOpen.so.{mi_ver[0]}").unlink()
+        (lib_dir / f"libMIOpen.so.{mi_ver}").rename(lib_dir / "libMIOpen.so")
+
+        hdrpr_lib = bin_dir / "hdrpr/install/plugin/usd/hdRpr.so"
+        assert hdrpr_lib.exists()
+        check_call('patchelf', '--replace-needed',
+                   "libRadeonImageFilters.so.1", "libRadeonImageFilters.so", str(hdrpr_lib))
+
+
+def resolver(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
+    print_start("Building RenderStudioResolver")
+
+    deps_dir = repo_dir / "deps"
+    resolver_dir = deps_dir / "RenderStudioKit"
+    openssl_dir = Path(os.environ["ProgramFiles"]) / "OpenSSL-Win64"
+    boost_dir = bin_dir / "boost"
+    usd_dir = bin_dir / "USD/install"
+
+    libdir = bl_libs_dir.as_posix()
+
+    os.environ['PXR_PLUGINPATH_NAME'] = str(usd_dir / "lib/usd")
+
+    # Boost flags
+    args = [
+        "-DCMAKE_CXX_FLAGS=/Zc:inline- /EHsc /bigobj /DBOOST_ALL_NO_LIB",
+        f"-DBoost_COMPILER:STRING=-vc142",
+        "-DBLENDER_SUPPORT=ON",
+        "-DBoost_USE_MULTITHREADED=ON",
+        "-DBoost_USE_STATIC_LIBS=OFF",
+        "-DBoost_USE_STATIC_RUNTIME=OFF",
+        f"-DBOOST_ROOT={boost_dir}/install",
+        "-DBoost_NO_SYSTEM_PATHS=OFF",
+        "-DBoost_NO_BOOST_CMAKE=OFF",
+        f"-DBoost_INCLUDE_DIR={boost_dir}/install/include",
+        f"-DOPENSSL_ROOT_DIR={openssl_dir}",
+        f"-DTBB_INCLUDE_DIRS={libdir}/tbb/include",
+        f"-DUSD_INCLUDE_DIRS={libdir}/usd/include",
+        "-DPXR_ENABLE_PYTHON_SUPPORT=ON",
+        f'-Dpxr_DIR={usd_dir}',
+        f"-DMaterialX_DIR={bin_dir / 'materialx/install/lib/cmake/MaterialX'}",
+    ]
+
+    def generate_files():
+        info_json = Path(bin_dir / "resolver/install/plugin/plugInfo.json")
+        info_json.touch()
+        info_json.write_text(
+        """
+{
+    "Includes": [ "usd/*/resources/" ]
+}
+        """
+    )
+        init = Path(bin_dir / "resolver/install/lib/python/__init__.py")
+        init.touch()
+
+    cur_dir = os.getcwd()
+    ch_dir(resolver_dir)
+
+    _cmake(resolver_dir, bin_dir / "resolver", compiler, jobs, build_var, clean, args)
+    generate_files()
+
+    os.chdir(cur_dir)
 
 
 def zip_addon(bin_dir):
@@ -369,6 +618,7 @@ def zip_addon(bin_dir):
 
         # copy addon scripts
         hydrarpr_plugin_dir = repo_dir / 'src/hydrarpr'
+        assert hydrarpr_plugin_dir.exists()
         for f in hydrarpr_plugin_dir.glob("**/*"):
             if f.is_dir():
                 continue
@@ -381,38 +631,27 @@ def zip_addon(bin_dir):
 
             yield f, rel_path
 
-        hydrarpr_repo_dir = deps_dir / 'RadeonProRenderUSD'
-        # copy RIF libraries
-        rif_libs_dir = hydrarpr_repo_dir / (
-            'deps/RIF/Windows/Dynamic' if OS == 'Windows' else 'deps/RIF/Ubuntu20/Dynamic')
-        for f in rif_libs_dir.glob("**/*"):
-            if LIBEXT in f.suffix:
+        # copy libraries
+        lib_dir = inst_dir / 'lib'
+        assert lib_dir.exists()
+        for f in lib_dir.glob("**/*"):
+            if f.suffix != DLLEXT:
                 continue
 
             yield f, libs_rel_path / f.name
-
-        # copy core libraries
-        core_libs_dir = hydrarpr_repo_dir / (
-            'deps/RPR/RadeonProRender/binWin64' if OS == 'Windows' else 'deps/RPR/RadeonProRender/binUbuntu18')
-        for f in core_libs_dir.glob("**/*"):
-            if f.suffix in EXT:
-                continue
-
-            yield f, libs_rel_path / f.name
-
-        # copy rprUsd library
-        rprusd_lib = inst_dir / ('lib/rprUsd.dll' if OS == 'Windows' else 'lib/librprUsd.so')
-        yield rprusd_lib, libs_rel_path / rprusd_lib.name
 
         # copy hdRpr library
-        hdrpr_lib = plugin_dir / ('usd/hdRpr.dll' if OS == 'Windows' else 'usd/hdRpr.so')
+        hdrpr_lib = plugin_dir / f"usd/hdRpr{DLLEXT}"
+        assert hdrpr_lib.exists()
         yield hdrpr_lib, plugin_rel_path.parent / hdrpr_lib.name
 
         # copy plugInfo.json library
         pluginfo = plugin_dir / 'plugInfo.json'
+        assert pluginfo.exists()
         yield pluginfo, plugin_rel_path.parent.parent / pluginfo.name
 
         # copy plugin/usd folders
+        assert plugin_dir.exists()
         for f in plugin_dir.glob("**/*"):
             rel_path = f.relative_to(plugin_dir.parent)
             if any(p in rel_path.parts for p in ("hdRpr", "rprUsd", 'rprUsdMetadata')):
@@ -420,54 +659,18 @@ def zip_addon(bin_dir):
 
         # copy python rpr
         pyrpr_dir = bin_dir / 'install/lib/python/rpr'
+        assert pyrpr_dir.exists()
         (pyrpr_dir / "RprUsd/__init__.py").write_text("")
         for f in (pyrpr_dir / "__init__.py", pyrpr_dir / "RprUsd/__init__.py"):
             yield f, Path("libs") / f.relative_to(pyrpr_dir.parent.parent)
-
-    def get_version():
-        # getting buid version
-        build_ver = subprocess.getoutput("git rev-parse --short HEAD")
-
-        # # getting plugin version
-        # text = (repo_dir / "src/hdusd/__init__.py").read_text()
-        # m = re.search(r'"version": \((\d+), (\d+), (\d+)\)', text)
-        # plugin_ver = m.group(1), m.group(2), m.group(3)
-        #
-        # return (*plugin_ver, build_ver)
-
-        return build_ver
-
-    def create_zip_addon(install_dir, bin_dir, name, ver):
-        """ Pack addon files to zip archive """
-        zip_addon = install_dir / name
-        if zip_addon.is_file():
-            os.remove(zip_addon)
-
-        print(f"Compressing addon files to: {zip_addon}")
-        with zipfile.ZipFile(zip_addon, 'w', compression=zipfile.ZIP_DEFLATED,
-                             compresslevel=zlib.Z_BEST_COMPRESSION) as myzip:
-            for src, package_path in enumerate_addon_data(bin_dir):
-                print(f"adding {src} --> {package_path}")
-
-                arcname = str(Path('hydrarpr') / package_path)
-
-                if str(package_path) == "__init__.py":
-                    print(f"    set version_build={ver[3]}")
-                    text = src.read_text(encoding='utf-8')
-                    text = text.replace('version_build = ""', f'version_build = "{ver[3]}"')
-                    myzip.writestr(arcname, text)
-                    continue
-
-                myzip.write(str(src), arcname=arcname)
-
-        return zip_addon
 
     # endregion
 
     repo_dir = Path(__file__).parent
     install_dir = repo_dir / "install"
     ver = get_version()
-    name = f"hydrarpr-{ver}-{OS.lower()}.zip"
+    addon_name = "hydrarpr"
+    name = f"{addon_name}-{ver}-{OS.lower()}.zip"
 
     if install_dir.is_dir():
         for file in os.listdir(install_dir):
@@ -477,7 +680,84 @@ def zip_addon(bin_dir):
     else:
         install_dir.mkdir()
 
-    zip_addon = create_zip_addon(install_dir, bin_dir / "hdrpr", name, ver)
+    zip_addon = create_zip_addon(install_dir, bin_dir / "hdrpr", name, addon_name, enumerate_addon_data,  ver)
+    print(f"Addon was compressed to: {zip_addon}")
+
+
+def zip_rs_addon(bin_dir):
+    print_start("Creating RenderStudioResolver zip Addon")
+
+    # region internal functions
+
+    def enumerate_addon_data(bin_dir):
+        libs_rel_path = Path('libs/lib')
+        plugin_rel_path = Path('libs/plugin/usd/plugin')
+        inst_dir = bin_dir / 'install'
+        plugin_dir = inst_dir / 'plugin'
+
+        # copy addon scripts
+        resolver_plugin_dir = repo_dir / 'src/resolver'
+        for f in resolver_plugin_dir.glob("**/*"):
+            if f.is_dir():
+                continue
+
+            rel_path = f.relative_to(resolver_plugin_dir)
+            rel_path_parts = rel_path.parts
+            if rel_path_parts[0] in ("libs", "configdev.py") or \
+                    "__pycache__" in rel_path_parts or ".gitignore" in rel_path_parts:
+                continue
+
+            yield f, rel_path
+
+        # copy core libraries
+        resolver_lib_dir = bin_dir / 'install/lib'
+        for f in resolver_lib_dir.glob("**/*"):
+            if f.suffix in (".dll") and f.is_file():
+                yield f, libs_rel_path / f.name
+
+
+        # copy python resolver
+        pyresolver_dir = bin_dir / 'install/lib/python'
+        for f in pyresolver_dir.glob("**/*"):
+            if f.is_file() and f.suffix not in (".py", ".pyd"):
+                continue
+            yield f, Path("libs") / f.relative_to(pyresolver_dir.parent)
+
+        # copy RenderStudioResolver library
+        resolver_lib = plugin_dir / 'usd/RenderStudioResolver.dll'
+        yield resolver_lib, plugin_rel_path.parent / resolver_lib.name
+
+        # copy Boost library
+        boost_log_lib = bin_dir.parent / 'boost/install/lib/boost_log-vc142-mt-x64-1_80.dll'
+        yield boost_log_lib, libs_rel_path / boost_log_lib.name
+
+        # copy plugInfo.json library
+        pluginfo = plugin_dir / 'plugInfo.json'
+        yield pluginfo, plugin_rel_path.parent.parent / pluginfo.name
+
+        # copy plugin/usd folders
+        for f in plugin_dir.glob("**/*"):
+            rel_path = f.relative_to(plugin_dir.parent)
+            if any(p in rel_path.parts for p in ("RenderStudioResolver",)):
+                yield f, libs_rel_path.parent / rel_path
+
+    # endregion
+
+    repo_dir = Path(__file__).parent
+    install_dir = repo_dir / "install"
+    ver = get_version()
+    addon_name = "resolver"
+    name = f"{addon_name}-{ver}-{OS.lower()}.zip"
+
+    if install_dir.is_dir():
+        for file in os.listdir(install_dir):
+            if file == name:
+                os.remove(install_dir / file)
+                break
+    else:
+        install_dir.mkdir()
+
+    zip_addon = create_zip_addon(install_dir, bin_dir / "resolver", name, addon_name, enumerate_addon_data, ver)
     print(f"Addon was compressed to: {zip_addon}")
 
 
@@ -491,17 +771,27 @@ def main():
                     help="Build MaterialX")
     ap.add_argument("-usd", required=False, action="store_true",
                     help="Build USD")
+    ap.add_argument("-boost", required=False, action="store_true",
+                    help="Build Boost")
     ap.add_argument("-hdrpr", required=False, action="store_true",
                     help="Build HdRPR")
-    ap.add_argument("-bl-libs-dir", required=False, type=str, default="",
-                    help="Path to root of Blender libs directory"),
-    ap.add_argument("-bin-dir", required=False, type=str, default="",
-                    help="Path to binary directory")
+    ap.add_argument("-rs", required=False, action="store_true",
+                    help="Build RenderStudioResolver")
+    libs_dir_default = {'Windows': r"..\lib\win64_vc15",
+                        'Darwin': "../lib/darwin",
+                        'Linux': "../lib/linux_x86_64_glibc_228"}[OS]
+    ap.add_argument("-bl-libs-dir", required=False, type=str,
+                    default=libs_dir_default,
+                    help=f"Path to root of Blender libs directory. (default: {libs_dir_default})"),
+    ap.add_argument("-bin-dir", required=False, type=str, default="bin",
+                    help="Path to binary directory. (default: bin)")
     ap.add_argument("-addon", required=False, action="store_true",
                     help="Create zip addon")
+    ap.add_argument("-rs_addon", required=False, action="store_true",
+                    help="Create RenderStudioResolver zip addon")
     ap.add_argument("-G", required=False, type=str,
                     help="Compiler for HdRPR and MaterialX in cmake. "
-                         'For example: -G "Visual Studio 16 2019"',
+                         'For example: -G "Visual Studio 16 2019" or -G "Xcode"',
                     default="Visual Studio 16 2019" if OS == 'Windows' else "")
     ap.add_argument("-j", required=False, type=int, default=0,
                     help="Number of jobs run in parallel")
@@ -528,8 +818,8 @@ def main():
         materialx(bl_libs_dir, bin_dir, args.G, args.j, args.clean, args.build_var)
 
     installed_modules = None
-    py_exe = str(f"{bl_libs_dir}/python/310/bin/python{POSTFIX}{EXT}") if OS == 'Windows' \
-        else str(f"{bl_libs_dir}/python/bin/python3.10{POSTFIX}{EXT}")
+    py_exe = f"{bl_libs_dir}/python/310/bin/python.exe" if OS == 'Windows' else\
+             f"{bl_libs_dir}/python/bin/python3.10"
 
     try:
         if args.all or args.usd or args.hdrpr:
@@ -538,8 +828,14 @@ def main():
         if args.all or args.usd:
             usd(bl_libs_dir, bin_dir, args.G, args.j, args.clean, args.build_var, not args.no_git_apply)
 
+        if args.all or args.boost:
+            boost(bin_dir, args.clean)
+
         if args.all or args.hdrpr:
             hdrpr(bl_libs_dir, bin_dir, args.G, args.j, args.clean, args.build_var, not args.no_git_apply)
+
+        if args.all or args.rs:
+            resolver(bl_libs_dir, bin_dir, args.G, args.j, args.clean, args.build_var)
 
     finally:
         if installed_modules:
@@ -547,6 +843,9 @@ def main():
 
     if args.all or args.addon:
         zip_addon(bin_dir)
+
+    if args.all or args.rs_addon:
+        zip_rs_addon(bin_dir)
 
     print_start("Finished")
 

--- a/src/resolver/__init__.py
+++ b/src/resolver/__init__.py
@@ -1,0 +1,77 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+
+bl_info = {
+    "name": "Render Studio Resolver",
+    "author": "AMD",
+    "version": (1, 0, 0),
+    "blender": (4, 0, 0),
+    "location": "Info header > Render engine menu",
+    "description": "Radeon Render Studio Resolver for Hydra render engine",
+    "tracker_url": "",
+    "doc_url": "",
+    "community": "",
+    "downloads": "",
+    "main_web": "",
+    "support": 'TESTING',
+    "category": "Render"
+}
+
+import os
+import sys
+import platform
+from pathlib import Path
+import bpy
+from pxr import Plug
+
+
+LIBS_DIR = Path(__file__).parent / "libs"
+
+
+def preload_resolver():
+    root_folder = "blender.shared" if platform.system() == 'Windows' else "lib"
+    path = os.pathsep.join([str(Path(bpy.app.binary_path).parent / f"{root_folder}")])
+    os.add_dll_directory(path)
+    os.add_dll_directory(str(LIBS_DIR / "lib"))
+    os.environ['PATH'] += ";" + str(LIBS_DIR / "lib")
+    sys.path.append(str(LIBS_DIR / "python"))
+    Plug.Registry().RegisterPlugins(str(LIBS_DIR / "plugin"))
+    usd_plugin = Plug.Registry().GetPluginWithName('RenderStudioResolver')
+    if not usd_plugin.isLoaded:
+        usd_plugin.Load()
+
+
+preload_resolver()
+
+
+from . import resolver, ui, properties, operators
+
+
+def register():
+    properties.register()
+    bpy.types.Object.resolver = bpy.props.PointerProperty(type=properties.RESOLVER_object_properties)
+    bpy.types.Collection.resolver = bpy.props.PointerProperty(type=properties.RESOLVER_collection_properties)
+    bpy.app.handlers.depsgraph_update_post.append(resolver.on_depsgraph_update_post)
+    operators.register()
+    ui.register()
+
+
+def unregister():
+    ui.unregister()
+    operators.unregister()
+    del bpy.types.Collection.resolver
+    del bpy.types.Object.resolver
+    bpy.app.handlers.depsgraph_update_post.remove(resolver.on_depsgraph_update_post)
+    properties.unregister()

--- a/src/resolver/config.py
+++ b/src/resolver/config.py
@@ -1,0 +1,17 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+
+logging_level = 'DEBUG'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'
+logging_backups = 5

--- a/src/resolver/logging.py
+++ b/src/resolver/logging.py
@@ -1,0 +1,81 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import sys
+import logging.handlers
+from pathlib import Path
+
+from . import config
+
+
+ROOT_DIR = Path(__file__).parent
+
+FORMAT_STR = "%(asctime)s %(levelname)s %(name)s [%(thread)d]:  %(message)s"
+
+# root logger for the addon
+logger = logging.getLogger('Resolver')
+logger.setLevel(config.logging_level)
+
+file_handler = logging.handlers.RotatingFileHandler(ROOT_DIR / 'resolver.log',
+                                                    mode='w', encoding='utf-8', delay=True,
+                                                    backupCount=config.logging_backups)
+file_handler.doRollover()
+file_handler.setFormatter(logging.Formatter(FORMAT_STR))
+logger.addHandler(file_handler)
+
+console_handler = logging.StreamHandler(stream=sys.stdout)
+console_handler.setFormatter(logging.Formatter(FORMAT_STR))
+logger.addHandler(console_handler)
+
+
+def msg(args):
+    return ", ".join(str(arg) for arg in args)
+
+
+class Log:
+    def __init__(self, tag):
+        self.logger = logger.getChild(tag)
+
+    def __call__(self, *args):
+        self.debug(*args)
+
+    def debug(self, *args):
+        self.logger.debug(msg(args))
+
+    def info(self, *args):
+        self.logger.info(msg(args))
+
+    def warn(self, *args):
+        self.logger.warning(msg(args))
+
+    def error(self, *args):
+        self.logger.error(msg(args))
+
+    def critical(self, *args):
+        self.logger.critical(msg(args))
+
+    def dump_args(self, func):
+        """This decorator dumps out the arguments passed to a function before calling it"""
+        arg_names = func.__code__.co_varnames[:func.__code__.co_argcount]
+
+        def echo_func(*args, **kwargs):
+            self.debug("<{}>: {}{}".format(
+                func.__name__,
+                tuple("{}={}".format(name, arg) for name, arg in zip(arg_names, args)),
+                # args if args else "",
+                " {}".format(kwargs.items()) if kwargs else "",
+            ))
+            return func(*args, **kwargs)
+
+        return echo_func

--- a/src/resolver/operators.py
+++ b/src/resolver/operators.py
@@ -1,0 +1,98 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import bpy
+
+
+class RESOLVER_OP_start_live_mode(bpy.types.Operator):
+    bl_idname = 'resolver.start_live_mode'
+    bl_label = "Connect"
+    bl_description = "Connect to Render Studio Resolver server"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        resolver.start_live_mode()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_stop_live_mode(bpy.types.Operator):
+    bl_idname = 'resolver.stop_live_mode'
+    bl_label = "Disconnect"
+    bl_description = "Disconnect Render Studio Resolver server"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        resolver.stop_live_mode()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_process_live_update(bpy.types.Operator):
+    bl_idname = 'resolver.process_live_mode'
+    bl_label = "Process Live Mode"
+    bl_description = "Run live update mode"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        resolver.process_live_updates()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_open_stage_uri(bpy.types.Operator):
+    bl_idname = 'resolver.open_stage_uri'
+    bl_label = "Open Stage Uri"
+    bl_description = "Open USD file using Render Studio Resolver"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        resolver.open_stage()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_import_stage(bpy.types.Operator):
+    bl_idname = 'resolver.import_stage'
+    bl_label = "Import Stage"
+    bl_description = "Import USD file to Blender"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        resolver.import_stage()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
+    bl_idname = 'resolver.export_stage'
+    bl_label = "Export Stage to Console"
+    bl_description = "Export current USD stage to console"
+
+    def execute(self, context):
+        resolver = context.collection.resolver
+        print(resolver.get_stage().ExportToString())
+        return {'FINISHED'}
+
+
+register_classes, unregister_classes = bpy.utils.register_classes_factory([
+    RESOLVER_OP_start_live_mode,
+    RESOLVER_OP_stop_live_mode,
+    RESOLVER_OP_process_live_update,
+    RESOLVER_OP_open_stage_uri,
+    RESOLVER_OP_import_stage,
+    RESOLVER_OP_export_stage_to_string,
+    ])
+
+def register():
+    register_classes()
+
+
+def unregister():
+    unregister_classes()

--- a/src/resolver/properties.py
+++ b/src/resolver/properties.py
@@ -1,0 +1,211 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import uuid
+import bpy
+import mathutils
+from threading import Thread
+from pxr import Usd, UsdGeom
+from . import logging
+from RenderStudioResolver import RenderStudioResolver, LiveModeInfo
+
+log = logging.Log("operators")
+stage_cache = Usd.StageCache()
+
+
+class RESOLVER_object_properties(bpy.types.PropertyGroup):
+    sdf_path: bpy.props.StringProperty(
+        name="Sdf Path",
+        description="",
+        default='',
+        )
+
+
+class RESOLVER_collection_properties(bpy.types.PropertyGroup):
+    liveUrl: bpy.props.StringProperty(
+        name="Live Url",
+        description="",
+        default='',
+    )
+    storageUrl: bpy.props.StringProperty(
+        name="Storage Url",
+        description="",
+        default='',
+        )
+    channelId: bpy.props.EnumProperty(
+        name="Channel Id",
+        items=(
+            ('BLENDER', "Blender", "Blender", 0),
+            ('MAYA', "Maya", "Maya", 1),
+            ('RENDERSTUDIO', "RenderStudio", "RenderStudio", 2),
+            ),
+        default=0,
+        )
+    userId: bpy.props.StringProperty(
+        name="User Id",
+        default='BlenderUser',
+        )
+
+    stageId: bpy.props.IntProperty(
+        name="Stage Id",
+        default=-1,
+        )
+    usd_path: bpy.props.StringProperty(
+        subtype='FILE_PATH',
+        name="USD Stage",
+        default=""
+        )
+    is_live_mode: bpy.props.BoolProperty(
+        name="Is Live Mode",
+        default=False
+        )
+    is_live_update: bpy.props.BoolProperty(
+        name="Is Live Update",
+        default=False
+        )
+    is_depsgraph_update: bpy.props.BoolProperty(
+        name="Is Depsgraph Update",
+        description="",
+        default=True
+        )
+
+    def get_info(self):
+        return LiveModeInfo(self.liveUrl, self.storageUrl, self.channelId, self.get_user_id())
+
+    def get_resolver_path(self):
+        path = self.usd_path
+        if not RenderStudioResolver.IsRenderStudioPath(path):
+            if RenderStudioResolver.IsUnresovableToRenderStudioPath(path):
+                path = RenderStudioResolver.Unresolve(path)
+            else:
+                return False
+        log.debug("Resolved Path: ", path)
+        return path
+
+    def start_live_mode(self):
+        if self.is_live_mode:
+            return
+
+        stage = self.get_stage()
+        if not stage:
+            stage = self.open_stage()
+
+        if stage:
+            info = self.get_info()
+            RenderStudioResolver.StartLiveMode(info)
+            self.is_live_mode = True
+            log.debug("Start Live Mode: ", info.liveUrl, info.storageUrl, info.channelId, info.userId)
+
+        else:
+            log.debug("Failed Start Live Mode: ")
+
+    def stop_live_mode(self):
+        if self.is_live_mode:
+            RenderStudioResolver.StopLiveMode()
+            self.is_live_mode = False
+            self.is_live_update = False
+
+        log.debug("Stop Live Mode")
+
+    def process_live_updates(self):
+        log.debug(self.is_live_mode, self.is_live_update)
+        if self.is_live_mode and not self.is_live_update:
+            log.debug("Process Start Live Updates")
+            self.is_live_update = True
+            thread = Thread(target=self._sync, daemon=True)
+            thread.start()
+
+        else:
+            log.debug("Process Stop Live Updates")
+            self.is_live_update = False
+
+    def _sync(self):
+        while (self.is_live_update and self.is_live_mode):
+            if RenderStudioResolver.ProcessLiveUpdates():
+                self.is_depsgraph_update = False
+                stage = self.get_stage()
+                for prim in stage.GetPseudoRoot().GetAllChildren():
+                    xform = UsdGeom.Xform(prim)
+                    transform = get_xform_transform(xform)
+                    obj = bpy.context.collection.objects.get(prim.GetName())
+                    if obj:
+                        obj.matrix_local = transform
+                        log.debug("Updated: ", obj)
+
+            self.is_depsgraph_update = True
+
+    def get_user_id(self):
+        return f"{self.userId}_{uuid.uuid4()}"
+
+    def get_stage(self):
+        stage = stage_cache.Find(Usd.StageCache.Id.FromLongInt(self.stageId))
+        log.debug("Stage: ", stage)
+        return stage
+
+    def add_prim(self):
+        stage = self.get_stage()
+        prim, sphere = self.prim_name.split('/')
+        UsdGeom.Xform.Define(stage, f'/{prim}')
+        UsdGeom.Sphere.Define(stage, f'/{prim}/{sphere}')
+
+    def import_stage(self, filepath=None):
+        self.is_depsgraph_update = False
+        filepath = self.usd_path if filepath is None else filepath
+        bpy.ops.wm.usd_import(filepath=filepath)
+        self.is_depsgraph_update = True
+        log.debug("Import stage: ", filepath)
+
+    def open_stage(self):
+        path = self.get_resolver_path()
+        if not path:
+            log.warn("Failed USD Path")
+            return False
+
+        stage = Usd.Stage.Open(path)
+        self.stageId = stage_cache.Insert(stage).ToLongInt()
+        self.link_objects_to_usd()
+
+        log.debug("Open stage: ", self.usd_path, path, stage)
+        return stage
+
+    def link_objects_to_usd(self):
+        stage = self.get_stage()
+        objects = bpy.context.collection.objects
+        self.is_depsgraph_update = False
+        for prim in stage.GetPseudoRoot().GetAllChildren():
+            name = prim.GetName()
+            obj = objects.get(name)
+            if obj:
+                obj.resolver.sdf_path = str(prim.GetPrimPath())
+                log.debug("Link: ", obj, "<->", prim)
+
+        self.is_depsgraph_update = True
+
+
+def get_xform_transform(xform):
+    transform = mathutils.Matrix(xform.GetLocalTransformation())
+    return transform.transposed()
+
+register_classes, unregister_classes = bpy.utils.register_classes_factory([
+    RESOLVER_object_properties,
+    RESOLVER_collection_properties,
+    ])
+
+
+def register():
+    register_classes()
+
+
+def unregister():
+    unregister_classes()

--- a/src/resolver/resolver.py
+++ b/src/resolver/resolver.py
@@ -1,0 +1,50 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import bpy
+from pxr import UsdGeom, Gf
+from . import logging
+
+
+log = logging.Log("updates")
+
+
+def get_transform_local(obj: bpy.types.Object):
+    return obj.matrix_local.transposed()
+
+
+def on_depsgraph_update_post(scene, depsgraph):
+    resolver = bpy.context.collection.resolver
+    if not resolver.is_depsgraph_update:
+        return
+    for update in depsgraph.updates:
+        if isinstance(update.id, bpy.types.Object):
+            obj = update.id
+            stage = bpy.context.collection.resolver.get_stage()
+            if not obj.resolver.sdf_path:
+                return
+
+            prim = stage.GetPrimAtPath(obj.resolver.sdf_path)
+            if not prim:
+                return
+
+            xform = UsdGeom.XformCommonAPI(prim)
+            if update.is_updated_transform:
+                xform.SetTranslate(Gf.Vec3d(tuple(obj.location)))
+                xform.SetRotate(Gf.Vec3f(tuple(obj.rotation_euler)))
+                xform.SetScale(Gf.Vec3f(tuple(obj.scale)))
+                log.debug("Updated: ", prim, update.id)
+
+            else:
+                log.debug("Unsupported updates: ", prim, update.id)

--- a/src/resolver/ui.py
+++ b/src/resolver/ui.py
@@ -1,0 +1,67 @@
+# **********************************************************************
+# Copyright 2023 Advanced Micro Devices, Inc
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ********************************************************************
+import bpy
+
+
+class RESOLVER_PT_object(bpy.types.Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = 'object'
+    bl_label = "RenderStudio Connector"
+
+    @classmethod
+    def poll(cls, context):
+        return context.object
+
+    def draw(self, context):
+        resolver = context.object.resolver
+        layout = self.layout
+        layout.prop(resolver, 'sdf_path')
+
+
+class RESOLVER_PT_collection(bpy.types.Panel):
+    bl_space_type = 'PROPERTIES'
+    bl_region_type = 'WINDOW'
+    bl_context = 'collection'
+    bl_label = "RenderStudio Connector"
+
+    def draw(self, context):
+        resolver = context.collection.resolver
+        layout = self.layout
+        layout.prop(resolver, 'usd_path')
+        layout.prop(resolver, 'liveUrl')
+        layout.prop(resolver, 'storageUrl')
+        layout.prop(resolver, 'channelId')
+        layout.prop(resolver, 'userId')
+        layout.operator("resolver.import_stage")
+        layout.operator("resolver.open_stage_uri")
+        layout.operator("resolver.start_live_mode")
+        layout.operator("resolver.stop_live_mode")
+        layout.operator("resolver.process_live_mode")
+        layout.separator()
+        layout.operator("resolver.export_stage")
+
+
+register_classes, unregister_classes = bpy.utils.register_classes_factory([
+    RESOLVER_PT_collection,
+    RESOLVER_PT_object,
+    ])
+
+def register():
+    register_classes()
+
+
+def unregister():
+    unregister_classes()


### PR DESCRIPTION
### PURPOSE
Initial implementation
Move code from ResolverBlenderAddon to BlenderUSDHydraAddon

### TECHNICAL STEPS
Only `Windows` support at this point.
* Added submodules `deps/Boost`, `deps/RenderStudioKit`.
* Added ResolverBlenderAddon source code to `src/resolver'.
* Updated build script with methods `resolver`, `zip_rs_addon`, `boost` and flags `-rs`, `-rs-addon`, `-boost` respectively:
    * `-rs` - building RenderStudioKit libs,
    * `-rs_addon` - Creating zip addon,
    * `-boost` - building Boost 1.80.0 libs, it's required only `boost::python` and  `boost::log`, we build our own `boost` as far as    `boost::log` (mandatory for RenderStudioKit ) is not provided within Blender libs.

We can build RenderStudioResolver addon using flags:
`-all` or `-materialx -usd -boost -rs -rs-addon`

RenderStudioKit also requires dependency `OpenSSL` which is currently linked from `%ProgramFiles% / OpenSSL-Win64`.
