### PR TITLE
BLEN-579: Use USD stage exported from Blender

### DIFF
--- a/src/resolver/__init__.py
+++ b/src/resolver/__init__.py
@@ -70,6 +70,5 @@ def register():
 def unregister():
     ui.unregister()
     operators.unregister()
-    del bpy.types.Collection.resolver
     bpy.app.handlers.depsgraph_update_post.remove(resolver.on_depsgraph_update_post)
     properties.unregister()

--- a/src/resolver/__init__.py
+++ b/src/resolver/__init__.py
@@ -61,7 +61,6 @@ from . import resolver, ui, properties, operators
 
 def register():
     properties.register()
-    bpy.types.Object.resolver = bpy.props.PointerProperty(type=properties.RESOLVER_object_properties)
     bpy.types.Collection.resolver = bpy.props.PointerProperty(type=properties.RESOLVER_collection_properties)
     bpy.app.handlers.depsgraph_update_post.append(resolver.on_depsgraph_update_post)
     operators.register()
@@ -72,6 +71,5 @@ def unregister():
     ui.unregister()
     operators.unregister()
     del bpy.types.Collection.resolver
-    del bpy.types.Object.resolver
     bpy.app.handlers.depsgraph_update_post.remove(resolver.on_depsgraph_update_post)
     properties.unregister()

--- a/src/resolver/config.py
+++ b/src/resolver/config.py
@@ -12,6 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ********************************************************************
+from pathlib import Path
+import uuid
 
 logging_level = 'DEBUG'     # available levels: 'DEBUG', 'INFO', 'WARN', 'ERROR', 'CRITICAL'
 logging_backups = 5
+render_studio_dir = Path.home() / "Documents/AMD RenderStudio Home"
+user_id = f"BlenderUser_{uuid.uuid4()}"

--- a/src/resolver/operators.py
+++ b/src/resolver/operators.py
@@ -15,58 +15,27 @@
 import bpy
 
 
-class RESOLVER_OP_start_live_mode(bpy.types.Operator):
-    bl_idname = 'resolver.start_live_mode'
+class RESOLVER_OP_connect(bpy.types.Operator):
+    bl_idname = 'resolver.connect'
     bl_label = "Connect"
     bl_description = "Connect to Render Studio Resolver server"
 
     def execute(self, context):
         resolver = context.collection.resolver
-        resolver.start_live_mode()
+        resolver.connect()
+        resolver.open_usd()
+
         return {'FINISHED'}
 
 
-class RESOLVER_OP_stop_live_mode(bpy.types.Operator):
-    bl_idname = 'resolver.stop_live_mode'
+class RESOLVER_OP_disconnect(bpy.types.Operator):
+    bl_idname = 'resolver.disconnect'
     bl_label = "Disconnect"
     bl_description = "Disconnect Render Studio Resolver server"
 
     def execute(self, context):
         resolver = context.collection.resolver
-        resolver.stop_live_mode()
-        return {'FINISHED'}
-
-
-class RESOLVER_OP_process_live_update(bpy.types.Operator):
-    bl_idname = 'resolver.process_live_mode'
-    bl_label = "Process Live Mode"
-    bl_description = "Run live update mode"
-
-    def execute(self, context):
-        resolver = context.collection.resolver
-        resolver.process_live_updates()
-        return {'FINISHED'}
-
-
-class RESOLVER_OP_open_stage_uri(bpy.types.Operator):
-    bl_idname = 'resolver.open_stage_uri'
-    bl_label = "Open Stage Uri"
-    bl_description = "Open USD file using Render Studio Resolver"
-
-    def execute(self, context):
-        resolver = context.collection.resolver
-        resolver.open_stage()
-        return {'FINISHED'}
-
-
-class RESOLVER_OP_import_stage(bpy.types.Operator):
-    bl_idname = 'resolver.import_stage'
-    bl_label = "Import Stage"
-    bl_description = "Import USD file to Blender"
-
-    def execute(self, context):
-        resolver = context.collection.resolver
-        resolver.import_stage()
+        resolver.disconnect()
         return {'FINISHED'}
 
 
@@ -82,11 +51,8 @@ class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
 
 
 register_classes, unregister_classes = bpy.utils.register_classes_factory([
-    RESOLVER_OP_start_live_mode,
-    RESOLVER_OP_stop_live_mode,
-    RESOLVER_OP_process_live_update,
-    RESOLVER_OP_open_stage_uri,
-    RESOLVER_OP_import_stage,
+    RESOLVER_OP_connect,
+    RESOLVER_OP_disconnect,
     RESOLVER_OP_export_stage_to_string,
     ])
 

--- a/src/resolver/properties.py
+++ b/src/resolver/properties.py
@@ -133,11 +133,6 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         return res
 
 
-register_classes, unregister_classes = bpy.utils.register_classes_factory([
-    RESOLVER_collection_properties,
-    ])
-
-
 def register():
     bpy.utils.register_class(RESOLVER_collection_properties)
 

--- a/src/resolver/properties.py
+++ b/src/resolver/properties.py
@@ -12,24 +12,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 # ********************************************************************
-import uuid
+from pathlib import Path
 import bpy
-import mathutils
-from threading import Thread
-from pxr import Usd, UsdGeom
+from pxr import Usd
 from . import logging
+from . import config
 from RenderStudioResolver import RenderStudioResolver, LiveModeInfo
+
 
 log = logging.Log("operators")
 stage_cache = Usd.StageCache()
-
-
-class RESOLVER_object_properties(bpy.types.PropertyGroup):
-    sdf_path: bpy.props.StringProperty(
-        name="Sdf Path",
-        description="",
-        default='',
-        )
 
 
 class RESOLVER_collection_properties(bpy.types.PropertyGroup):
@@ -52,11 +44,6 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
             ),
         default=0,
         )
-    userId: bpy.props.StringProperty(
-        name="User Id",
-        default='BlenderUser',
-        )
-
     stageId: bpy.props.IntProperty(
         name="Stage Id",
         default=-1,
@@ -66,12 +53,8 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         name="USD Stage",
         default=""
         )
-    is_live_mode: bpy.props.BoolProperty(
+    is_connected: bpy.props.BoolProperty(
         name="Is Live Mode",
-        default=False
-        )
-    is_live_update: bpy.props.BoolProperty(
-        name="Is Live Update",
         default=False
         )
     is_depsgraph_update: bpy.props.BoolProperty(
@@ -79,9 +62,6 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         description="",
         default=True
         )
-
-    def get_info(self):
-        return LiveModeInfo(self.liveUrl, self.storageUrl, self.channelId, self.get_user_id())
 
     def get_resolver_path(self):
         path = self.usd_path
@@ -93,119 +73,74 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         log.debug("Resolved Path: ", path)
         return path
 
-    def start_live_mode(self):
-        if self.is_live_mode:
-            return
-
-        stage = self.get_stage()
-        if not stage:
-            stage = self.open_stage()
-
-        if stage:
-            info = self.get_info()
+    def connect_server(self):
+        info = LiveModeInfo(self.liveUrl, self.storageUrl, self.channelId, config.user_id)
+        try:
             RenderStudioResolver.StartLiveMode(info)
-            self.is_live_mode = True
-            log.debug("Start Live Mode: ", info.liveUrl, info.storageUrl, info.channelId, info.userId)
+            self.is_connected = True
 
-        else:
-            log.debug("Failed Start Live Mode: ")
+            log.debug("Connected: ", self.liveUrl, self.storageUrl, self.channelId, config.user_id)
 
-    def stop_live_mode(self):
-        if self.is_live_mode:
-            RenderStudioResolver.StopLiveMode()
-            self.is_live_mode = False
-            self.is_live_update = False
+        except Exception as err:
+            log.error("Failed to connect: ", err)
 
-        log.debug("Stop Live Mode")
+    def connect(self):
+        self.export_scene()
+        self.open_usd()
+        self.connect_server()
 
-    def process_live_updates(self):
-        log.debug(self.is_live_mode, self.is_live_update)
-        if self.is_live_mode and not self.is_live_update:
-            log.debug("Process Start Live Updates")
-            self.is_live_update = True
-            thread = Thread(target=self._sync, daemon=True)
-            thread.start()
+        if self.is_connected:
+            self.sync()
 
-        else:
-            log.debug("Process Stop Live Updates")
-            self.is_live_update = False
 
-    def _sync(self):
-        while (self.is_live_update and self.is_live_mode):
-            if RenderStudioResolver.ProcessLiveUpdates():
-                self.is_depsgraph_update = False
-                stage = self.get_stage()
-                for prim in stage.GetPseudoRoot().GetAllChildren():
-                    xform = UsdGeom.Xform(prim)
-                    transform = get_xform_transform(xform)
-                    obj = bpy.context.collection.objects.get(prim.GetName())
-                    if obj:
-                        obj.matrix_local = transform
-                        log.debug("Updated: ", obj)
+    def disconnect(self):
+        RenderStudioResolver.StopLiveMode()
+        self.is_connected = False
 
-            self.is_depsgraph_update = True
-
-    def get_user_id(self):
-        return f"{self.userId}_{uuid.uuid4()}"
+        log.debug("Disconnected")
 
     def get_stage(self):
         stage = stage_cache.Find(Usd.StageCache.Id.FromLongInt(self.stageId))
+
         log.debug("Stage: ", stage)
         return stage
 
-    def add_prim(self):
-        stage = self.get_stage()
-        prim, sphere = self.prim_name.split('/')
-        UsdGeom.Xform.Define(stage, f'/{prim}')
-        UsdGeom.Sphere.Define(stage, f'/{prim}/{sphere}')
-
-    def import_stage(self, filepath=None):
-        self.is_depsgraph_update = False
-        filepath = self.usd_path if filepath is None else filepath
-        bpy.ops.wm.usd_import(filepath=filepath)
-        self.is_depsgraph_update = True
-        log.debug("Import stage: ", filepath)
-
-    def open_stage(self):
+    def open_usd(self):
         path = self.get_resolver_path()
-        if not path:
-            log.warn("Failed USD Path")
-            return False
-
         stage = Usd.Stage.Open(path)
         self.stageId = stage_cache.Insert(stage).ToLongInt()
-        self.link_objects_to_usd()
 
         log.debug("Open stage: ", self.usd_path, path, stage)
         return stage
 
-    def link_objects_to_usd(self):
-        stage = self.get_stage()
-        objects = bpy.context.collection.objects
-        self.is_depsgraph_update = False
-        for prim in stage.GetPseudoRoot().GetAllChildren():
-            name = prim.GetName()
-            obj = objects.get(name)
-            if obj:
-                obj.resolver.sdf_path = str(prim.GetPrimPath())
-                log.debug("Link: ", obj, "<->", prim)
+    def export_scene(self):
+        if not Path(self.usd_path).exists() or not self.usd_path:
+            filename = bpy.path.ensure_ext(
+                str(Path(f"{config.user_id}_{Path(bpy.data.filepath).stem}")), ".usda"
+            )
+            self.usd_path = str(config.render_studio_dir / filename)
 
+        self.is_depsgraph_update = False
+        log.debug("Export usd", self.usd_path)
+        bpy.ops.wm.usd_export(filepath=self.usd_path)
         self.is_depsgraph_update = True
 
+    def sync(self):
+        res = False
+        if self.is_connected:
+            res = RenderStudioResolver.ProcessLiveUpdates()
 
-def get_xform_transform(xform):
-    transform = mathutils.Matrix(xform.GetLocalTransformation())
-    return transform.transposed()
+        return res
+
 
 register_classes, unregister_classes = bpy.utils.register_classes_factory([
-    RESOLVER_object_properties,
     RESOLVER_collection_properties,
     ])
 
 
 def register():
-    register_classes()
+    bpy.utils.register_class(RESOLVER_collection_properties)
 
 
 def unregister():
-    unregister_classes()
+    bpy.utils.unregister_class(RESOLVER_collection_properties)

--- a/src/resolver/resolver.py
+++ b/src/resolver/resolver.py
@@ -13,38 +13,19 @@
 # limitations under the License.
 # ********************************************************************
 import bpy
-from pxr import UsdGeom, Gf
 from . import logging
 
 
 log = logging.Log("updates")
 
 
-def get_transform_local(obj: bpy.types.Object):
-    return obj.matrix_local.transposed()
-
-
 def on_depsgraph_update_post(scene, depsgraph):
     resolver = bpy.context.collection.resolver
+    if not resolver.is_connected:
+        return
+
     if not resolver.is_depsgraph_update:
         return
-    for update in depsgraph.updates:
-        if isinstance(update.id, bpy.types.Object):
-            obj = update.id
-            stage = bpy.context.collection.resolver.get_stage()
-            if not obj.resolver.sdf_path:
-                return
 
-            prim = stage.GetPrimAtPath(obj.resolver.sdf_path)
-            if not prim:
-                return
-
-            xform = UsdGeom.XformCommonAPI(prim)
-            if update.is_updated_transform:
-                xform.SetTranslate(Gf.Vec3d(tuple(obj.location)))
-                xform.SetRotate(Gf.Vec3f(tuple(obj.rotation_euler)))
-                xform.SetScale(Gf.Vec3f(tuple(obj.scale)))
-                log.debug("Updated: ", prim, update.id)
-
-            else:
-                log.debug("Unsupported updates: ", prim, update.id)
+    resolver.export_scene()
+    resolver.sync()

--- a/src/resolver/ui.py
+++ b/src/resolver/ui.py
@@ -15,22 +15,6 @@
 import bpy
 
 
-class RESOLVER_PT_object(bpy.types.Panel):
-    bl_space_type = 'PROPERTIES'
-    bl_region_type = 'WINDOW'
-    bl_context = 'object'
-    bl_label = "RenderStudio Connector"
-
-    @classmethod
-    def poll(cls, context):
-        return context.object
-
-    def draw(self, context):
-        resolver = context.object.resolver
-        layout = self.layout
-        layout.prop(resolver, 'sdf_path')
-
-
 class RESOLVER_PT_collection(bpy.types.Panel):
     bl_space_type = 'PROPERTIES'
     bl_region_type = 'WINDOW'
@@ -44,19 +28,18 @@ class RESOLVER_PT_collection(bpy.types.Panel):
         layout.prop(resolver, 'liveUrl')
         layout.prop(resolver, 'storageUrl')
         layout.prop(resolver, 'channelId')
-        layout.prop(resolver, 'userId')
-        layout.operator("resolver.import_stage")
-        layout.operator("resolver.open_stage_uri")
-        layout.operator("resolver.start_live_mode")
-        layout.operator("resolver.stop_live_mode")
-        layout.operator("resolver.process_live_mode")
+        if resolver.is_connected:
+            layout.operator("resolver.disconnect")
+
+        else:
+            layout.operator("resolver.connect")
+
         layout.separator()
         layout.operator("resolver.export_stage")
 
 
 register_classes, unregister_classes = bpy.utils.register_classes_factory([
     RESOLVER_PT_collection,
-    RESOLVER_PT_object,
     ])
 
 def register():


### PR DESCRIPTION
### PURPOSE
Use USD stage exported from Blender.

### EFFECT OF CHANGE
Added Connect/Disconnect button to UI.
Removed User ID from UI.

### TECHNICAL STEPS
Usd filename is generated using `used_id` and blender filepath and is saved at `render_studio_dir` (~/Documents/AMD RenderStudion Nome)
* Removed `RESOLVER_object_properties`. And made code adjustments.
* Removed `user_id` from UI and its property as well.
* Removed operators: `RESOLVER_OP_process_live_update`, `RESOLVER_OP_open_stage_uri`, `RESOLVER_OP_import_stage` and adjusted ui.
* Removed redundant function `get_transform_local`.
* Added `render_studio_dir` and `user_id` to config.
* Added operators: `RESOLVER_OP_connect`, `RESOLVER_OP_disconnect`.
* Added methods `connect`, `disconnect`, `connect_server`, `export_scene`, `open_usd`, property `is_connected`.
* Removed redundant code.
