### PR TITLE
BLEN-585: Update RenderStudiKit submodule to enable file synchronization

### DIFF
--- a/src/hydrarpr/render_studio/properties.py
+++ b/src/hydrarpr/render_studio/properties.py
@@ -52,15 +52,12 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         path = self.usd_path
         if RenderStudioKit.IsUnresovableToRenderStudioPath(path):
             path = RenderStudioKit.UnresolveToRenderStudioPath(path)
-        else:
-            return False
         log("Resolved Path: ", path)
         return path
 
     def connect_server(self):
         info = RenderStudioKit.LiveSessionInfo(config.server_url, config.storage_url, config.channel_id, config.user_id)
         try:
-            RenderStudioKit.SetWorkspacePath(str(config.render_studio_dir))
             RenderStudioKit.LiveSessionConnect(info)
             self.is_connected = True
 
@@ -87,6 +84,7 @@ class RESOLVER_collection_properties(bpy.types.PropertyGroup):
         return stage
 
     def open_usd(self):
+        RenderStudioKit.SetWorkspacePath(str(config.render_studio_dir))
         path = self.get_resolver_path()
         stage = Usd.Stage.Open(path)
         self.stageId = stage_cache.Insert(stage).ToLongInt()

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -27,4 +27,3 @@ def on_depsgraph_update_post(scene, depsgraph):
         return
 
     resolver.export_scene()
-    resolver.sync()


### PR DESCRIPTION
### PURPOSE
Update RenderStudiKit submodule to enable file synchronization

### TECHNICAL STEPS
* Update RenderStudioKit submodule.
* Adjusted code according to the RenderStudioKit API
* Removed redundant sync method.

### NOTES FOR REVIEWERS
RenderStudioKit issue
error | Asset resolver does nothing in Resolve() (pxrInternal_v0_23__pxrReserved__::RenderStudioResolver::_Resolve:218)
warn  | Can't find layer with id: studio:/BlenderUser_10bfa785-e4fb-4d31-a596-bef0cc332608_.usda (pxrInternal_v0_23__pxrReserved__::RenderStudioLayerRegistry::GetByIdentifier:69)


