### PR TITLE
BLEN-588: Update RenderStudio panel design

### DIFF
--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -61,7 +61,7 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
     def draw(self, context):
         layout = self.layout
         box = layout.box()
-        box.label(text="RenderStudio Settings")
+        box.label(text="AMD RenderStudio Settings")
         col = box.column(align=True)
         col.prop(self, "rs_storage_dir", icon='NONE')
         col.prop(self, "rs_server_url", icon='NONE')

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -295,9 +295,9 @@ class RenderSettings(bpy.types.PropertyGroup):
 
 
 class RenderStudioSettings(bpy.types.PropertyGroup):
-    live_export: BoolProperty(
-        name="Live Export",
-        description="Toggle between export modes",
+    live_sync: BoolProperty(
+        name="Live Sync",
+        description="Toggle between sync modes",
         default=False,
     )
 

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -294,11 +294,20 @@ class RenderSettings(bpy.types.PropertyGroup):
     denoise: PointerProperty(type=DenoiseSettings)
 
 
+class RenderStudioSettings(bpy.types.PropertyGroup):
+    live_export: BoolProperty(
+        name="Live Export",
+        description="Toggle between export modes",
+        default=False,
+    )
+
+
 class SceneProperties(Properties):
     bl_type = bpy.types.Scene
 
     final: bpy.props.PointerProperty(type=RenderSettings)
     viewport: bpy.props.PointerProperty(type=RenderSettings)
+    render_studio: bpy.props.PointerProperty(type=RenderStudioSettings)
 
 
 register, unregister = bpy.utils.register_classes_factory((
@@ -307,5 +316,6 @@ register, unregister = bpy.utils.register_classes_factory((
     InteractiveQualitySettings,
     QualitySettings,
     RenderSettings,
+    RenderStudioSettings,
     SceneProperties,
 ))

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -297,7 +297,7 @@ class RenderSettings(bpy.types.PropertyGroup):
 class RenderStudioSettings(bpy.types.PropertyGroup):
     live_sync: BoolProperty(
         name="Live Sync",
-        description="Toggle between sync modes",
+        description="Enable live syncing mode",
         default=False,
     )
 

--- a/src/hydrarpr/render_studio/operators.py
+++ b/src/hydrarpr/render_studio/operators.py
@@ -31,7 +31,7 @@ class RESOLVER_OP_connect(bpy.types.Operator):
 class RESOLVER_OP_disconnect(bpy.types.Operator):
     bl_idname = 'render_studio.disconnect'
     bl_label = "Disconnect"
-    bl_description = "Disconnect AMD RenderStudio"
+    bl_description = "Disconnect from AMD RenderStudio"
 
     def execute(self, context):
         rs_resolver.disconnect()
@@ -41,7 +41,7 @@ class RESOLVER_OP_disconnect(bpy.types.Operator):
 class RESOLVER_OP_sync_scene(bpy.types.Operator):
     bl_idname = 'render_studio.sync_scene'
     bl_label = "Sync Scene"
-    bl_description = "Sync scene to Usd file"
+    bl_description = "Sync scene to AMD RenderStudio"
 
     def execute(self, context):
         rs_resolver.sync_scene()
@@ -51,7 +51,7 @@ class RESOLVER_OP_sync_scene(bpy.types.Operator):
 class RESOLVER_OP_start_live_sync(bpy.types.Operator):
     bl_idname = 'render_studio.start_live_sync'
     bl_label = "Start Live Sync"
-    bl_description = "Start syncing scene every update"
+    bl_description = "Start live syncing: scene will be synced on every scene update"
 
     def execute(self, context):
         rs_resolver.start_live_sync()
@@ -61,20 +61,10 @@ class RESOLVER_OP_start_live_sync(bpy.types.Operator):
 class RESOLVER_OP_stop_live_sync(bpy.types.Operator):
     bl_idname = 'render_studio.stop_live_sync'
     bl_label = "Stop Live Sync"
-    bl_description = "Stop syncing scene every update"
+    bl_description = "Stop live syncing scene"
 
     def execute(self, context):
         rs_resolver.stop_live_sync()
-        return {'FINISHED'}
-
-
-class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
-    bl_idname = 'render_studio.export_stage'
-    bl_label = "Export Stage to Console"
-    bl_description = "Export current USD stage to console"
-
-    def execute(self, context):
-        print(rs_resolver.stage.ExportToString())
         return {'FINISHED'}
 
 
@@ -84,7 +74,6 @@ register_classes, unregister_classes = bpy.utils.register_classes_factory([
     RESOLVER_OP_sync_scene,
     RESOLVER_OP_start_live_sync,
     RESOLVER_OP_stop_live_sync,
-    # RESOLVER_OP_export_stage_to_string,
 ])
 
 

--- a/src/hydrarpr/render_studio/operators.py
+++ b/src/hydrarpr/render_studio/operators.py
@@ -18,9 +18,9 @@ from .resolver import rs_resolver
 
 
 class RESOLVER_OP_connect(bpy.types.Operator):
-    bl_idname = 'rs_resolver.connect'
+    bl_idname = 'render_studio.connect'
     bl_label = "Connect"
-    bl_description = "Connect to Render Studio Resolver server"
+    bl_description = "Connect to AMD RenderStudio"
 
     def execute(self, context):
         rs_resolver.connect()
@@ -29,17 +29,47 @@ class RESOLVER_OP_connect(bpy.types.Operator):
 
 
 class RESOLVER_OP_disconnect(bpy.types.Operator):
-    bl_idname = 'rs_resolver.disconnect'
+    bl_idname = 'render_studio.disconnect'
     bl_label = "Disconnect"
-    bl_description = "Disconnect Render Studio Resolver server"
+    bl_description = "Disconnect AMD RenderStudio"
 
     def execute(self, context):
         rs_resolver.disconnect()
         return {'FINISHED'}
 
 
+class RESOLVER_OP_export_scene(bpy.types.Operator):
+    bl_idname = 'render_studio.export_scene'
+    bl_label = "Export Scene"
+    bl_description = "Export scene to Usd file"
+
+    def execute(self, context):
+        rs_resolver.export_scene()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_start_live_export(bpy.types.Operator):
+    bl_idname = 'render_studio.start_live_export'
+    bl_label = "Start Live Export"
+    bl_description = "Start exporting scene every update"
+
+    def execute(self, context):
+        rs_resolver.start_live_export()
+        return {'FINISHED'}
+
+
+class RESOLVER_OP_stop_live_export(bpy.types.Operator):
+    bl_idname = 'render_studio.stop_live_export'
+    bl_label = "Stop Live Export"
+    bl_description = "Stop exporting scene every update"
+
+    def execute(self, context):
+        rs_resolver.stop_live_export()
+        return {'FINISHED'}
+
+
 class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
-    bl_idname = 'rs_resolver.export_stage'
+    bl_idname = 'render_studio.export_stage'
     bl_label = "Export Stage to Console"
     bl_description = "Export current USD stage to console"
 
@@ -51,7 +81,10 @@ class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
 register_classes, unregister_classes = bpy.utils.register_classes_factory([
     RESOLVER_OP_connect,
     RESOLVER_OP_disconnect,
-    RESOLVER_OP_export_stage_to_string,
+    RESOLVER_OP_export_scene,
+    RESOLVER_OP_start_live_export,
+    RESOLVER_OP_stop_live_export,
+    # RESOLVER_OP_export_stage_to_string,
 ])
 
 

--- a/src/hydrarpr/render_studio/operators.py
+++ b/src/hydrarpr/render_studio/operators.py
@@ -38,33 +38,33 @@ class RESOLVER_OP_disconnect(bpy.types.Operator):
         return {'FINISHED'}
 
 
-class RESOLVER_OP_export_scene(bpy.types.Operator):
-    bl_idname = 'render_studio.export_scene'
-    bl_label = "Export Scene"
-    bl_description = "Export scene to Usd file"
+class RESOLVER_OP_sync_scene(bpy.types.Operator):
+    bl_idname = 'render_studio.sync_scene'
+    bl_label = "Sync Scene"
+    bl_description = "Sync scene to Usd file"
 
     def execute(self, context):
-        rs_resolver.export_scene()
+        rs_resolver.sync_scene()
         return {'FINISHED'}
 
 
-class RESOLVER_OP_start_live_export(bpy.types.Operator):
-    bl_idname = 'render_studio.start_live_export'
-    bl_label = "Start Live Export"
-    bl_description = "Start exporting scene every update"
+class RESOLVER_OP_start_live_sync(bpy.types.Operator):
+    bl_idname = 'render_studio.start_live_sync'
+    bl_label = "Start Live Sync"
+    bl_description = "Start syncing scene every update"
 
     def execute(self, context):
-        rs_resolver.start_live_export()
+        rs_resolver.start_live_sync()
         return {'FINISHED'}
 
 
-class RESOLVER_OP_stop_live_export(bpy.types.Operator):
-    bl_idname = 'render_studio.stop_live_export'
-    bl_label = "Stop Live Export"
-    bl_description = "Stop exporting scene every update"
+class RESOLVER_OP_stop_live_sync(bpy.types.Operator):
+    bl_idname = 'render_studio.stop_live_sync'
+    bl_label = "Stop Live Sync"
+    bl_description = "Stop syncing scene every update"
 
     def execute(self, context):
-        rs_resolver.stop_live_export()
+        rs_resolver.stop_live_sync()
         return {'FINISHED'}
 
 
@@ -81,9 +81,9 @@ class RESOLVER_OP_export_stage_to_string(bpy.types.Operator):
 register_classes, unregister_classes = bpy.utils.register_classes_factory([
     RESOLVER_OP_connect,
     RESOLVER_OP_disconnect,
-    RESOLVER_OP_export_scene,
-    RESOLVER_OP_start_live_export,
-    RESOLVER_OP_stop_live_export,
+    RESOLVER_OP_sync_scene,
+    RESOLVER_OP_start_live_sync,
+    RESOLVER_OP_stop_live_sync,
     # RESOLVER_OP_export_stage_to_string,
 ])
 

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -19,6 +19,8 @@ import bpy
 from pxr import Usd
 import RenderStudioKit
 
+from ..preferences import preferences
+
 from .. import logging
 log = logging.Log("rs.resolver")
 
@@ -29,9 +31,10 @@ class Resolver:
         self.is_depsgraph_update = True
         self.usd_path = ""
         self.stage = None
+        self.status = "Disconnected"
+        self.is_exporting = False
 
     def connect(self):
-        from ..preferences import preferences
         pref = preferences()
         RenderStudioKit.SetWorkspacePath(pref.rs_storage_dir)
         self.export_scene()
@@ -51,6 +54,7 @@ class Resolver:
         info = RenderStudioKit.LiveSessionInfo(pref.rs_server_url, pref.rs_storage_url, pref.rs_channel_id, pref.rs_user_id)
         RenderStudioKit.LiveSessionConnect(info)
         self.is_connected = True
+        self.status = "Connected"
 
         from .ui import update_button
         update_button()
@@ -62,12 +66,23 @@ class Resolver:
         self.is_connected = False
         self.stage = None
         self.usd_path = ""
+        self.status = "Disconnected"
+        self.is_exporting = False
 
         from .ui import update_button
         update_button()
 
+    def start_live_export(self):
+        # TODO: Implement start live export
+        self.is_exporting = True
+        self.status = "Exporting..."
+
+    def stop_live_export(self):
+        # TODO: Implement stop live export
+        self.is_exporting = False
+        self.status = "Connected"
+
     def export_scene(self):
-        from ..preferences import preferences
         pref = preferences()
         if not Path(self.usd_path).exists() or not self.usd_path:
             filename = bpy.path.ensure_ext(
@@ -79,6 +94,7 @@ class Resolver:
 
         self.is_depsgraph_update = False
         bpy.ops.wm.usd_export(filepath=self.usd_path)
+        self.status = "Exported"
         self.is_depsgraph_update = True
 
 

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -32,12 +32,12 @@ class Resolver:
         self.usd_path = ""
         self.stage = None
         self.status = "Disconnected"
-        self.is_exporting = False
+        self.is_syncing = False
 
     def connect(self):
         pref = preferences()
         RenderStudioKit.SetWorkspacePath(pref.rs_storage_dir)
-        self.export_scene()
+        self.sync_scene()
 
         if not RenderStudioKit.IsUnresovableToRenderStudioPath(self.usd_path):
             log.warn("No resolved path", self.usd_path)
@@ -67,22 +67,22 @@ class Resolver:
         self.stage = None
         self.usd_path = ""
         self.status = "Disconnected"
-        self.is_exporting = False
+        self.is_syncing = False
 
         from .ui import update_button
         update_button()
 
-    def start_live_export(self):
-        # TODO: Implement start live export
-        self.is_exporting = True
-        self.status = "Exporting..."
+    def start_live_sync(self):
+        # TODO: Implement start live sync
+        self.is_syncing = True
+        self.status = "Syncing..."
 
-    def stop_live_export(self):
-        # TODO: Implement stop live export
-        self.is_exporting = False
+    def stop_live_sync(self):
+        # TODO: Implement stop live sync
+        self.is_syncing = False
         self.status = "Connected"
 
-    def export_scene(self):
+    def sync_scene(self):
         pref = preferences()
         if not Path(self.usd_path).exists() or not self.usd_path:
             filename = bpy.path.ensure_ext(
@@ -90,11 +90,11 @@ class Resolver:
             )
             self.usd_path = str(Path(pref.rs_storage_dir) / filename)
 
-        log("Exported scene", self.usd_path)
+        log("Synced scene", self.usd_path)
 
         self.is_depsgraph_update = False
         bpy.ops.wm.usd_export(filepath=self.usd_path)
-        self.status = "Exported"
+        self.status = "Synced"
         self.is_depsgraph_update = True
 
 
@@ -105,7 +105,7 @@ def on_depsgraph_update_post(scene, depsgraph):
     if not rs_resolver.is_connected or not rs_resolver.is_depsgraph_update:
         return
 
-    rs_resolver.export_scene()
+    rs_resolver.sync_scene()
 
 
 def register():

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -32,16 +32,16 @@ class RS_RESOLVER_PT_resolver(Panel):
 
         col = layout.column()
         col.enabled = rs_resolver.is_connected
-        col.prop(settings, "live_export")
+        col.prop(settings, "live_sync")
 
         col = col.column()
-        if settings.live_export:
-            if rs_resolver.is_exporting:
-                col.operator("render_studio.stop_live_export", icon='CANCEL')
+        if settings.live_sync:
+            if rs_resolver.is_syncing:
+                col.operator("render_studio.stop_live_sync", icon='CANCEL')
             else:
-                col.operator("render_studio.start_live_export", icon='EXPORT')
+                col.operator("render_studio.start_live_sync", icon='FILE_REFRESH')
         else:
-            col.operator("render_studio.export_scene", icon='EXPORT')
+            col.operator("render_studio.sync_scene", icon='FILE_REFRESH')
         col.separator()
         layout.label(text=f"Status: {rs_resolver.status}")
 

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -32,7 +32,7 @@ class RS_RESOLVER_PT_resolver(Panel):
 
         col = layout.column()
         col.enabled = rs_resolver.is_connected
-        col.prop(settings, "live_sync")
+        col.separator()
 
         col = col.column()
         if settings.live_sync:
@@ -42,6 +42,8 @@ class RS_RESOLVER_PT_resolver(Panel):
                 col.operator("render_studio.start_live_sync", icon='FILE_REFRESH')
         else:
             col.operator("render_studio.sync_scene", icon='FILE_REFRESH')
+
+        col.prop(settings, "live_sync")
         col.separator()
         layout.label(text=f"Status: {rs_resolver.status}")
 


### PR DESCRIPTION
### PURPOSE
Update RenderStudio panel design to fit file synchronization needs.

### EFFECT OF CHANGE
Renamed titles of preferences and panel to AMD RenderStudio.
Added checkbox Live Sync to toggle between manual and automatic Usd export.
Added button Sync Scene, Start Live Sync, Stop Live Sync.
Removed button `Export Stage to Console`
Removed Connect/Disconnect button from Outliner header.

![AMD_Render_Studio_UI](https://github.com/GPUOpen-LibrariesAndSDKs/BlenderUSDHydraAddon/assets/42581166/90fdce9d-d97e-4ee2-945c-cd01b6a02d19)



### TECHNICAL STEPS
Renamed operator's `bl_idname` "rs_resolver." -> "render_studio."
Added operator `RESOLVER_OP_sync_scene`.
Added operator `RESOLVER_OP_start_live_sync`.
Added operator `RESOLVER_OP_stop_live_sync`.
Resolver class added properties `self.status`, `self.is_syncing`.
Added RenderStudio properties class `RenderStudioSettings`, `live_sync` in particular.
Moved rename ui name of `RS_RESOLVER_PT_resolver` panel to `AMD RenderStudio`.
Renamed Preferences to `AMD RenderStudio`.
Turned off operator `RESOLVER_OP_export_stage_to_string`.
Removed Connect/Disconnect button from Outliner header.
