### PR TITLE
BLEN-602: Make file sync path more human readable. Add more sync settings

### DIFF
--- a/src/hydrarpr/__init__.py
+++ b/src/hydrarpr/__init__.py
@@ -53,13 +53,13 @@ def register():
     properties.register()
     ui.register()
 
-    if platform.system() == 'Windows':
+    if platform.system() == 'Windows' and preferences.preferences().rs_enable:
         from . import render_studio
         render_studio.register()
 
 
 def unregister():
-    if platform.system() == 'Windows':
+    if platform.system() == 'Windows' and preferences.preferences().rs_enable:
         from . import render_studio
         render_studio.unregister()
 

--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -29,23 +29,21 @@ except ImportError:
     pass
 
 
-def rs_enable(self, context):
-    from . import render_studio
-    if self.rs_enable:
-        render_studio.register()
-
-    else:
-        render_studio.unregister()
-
-
 class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
     bl_idname = "hydrarpr"
+
+    def rs_enable_update(self, context):
+        from . import render_studio
+        if self.rs_enable:
+            render_studio.register()
+        else:
+            render_studio.unregister()
 
     rs_enable: bpy.props.BoolProperty(
         name="AMD RenderStudio",
         description="Enable AMD RenderStudio",
         default=False,
-        update=rs_enable,
+        update=rs_enable_update,
     )
     rs_server_url: bpy.props.StringProperty(
         name="Server Address",
@@ -65,10 +63,10 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
     )
     rs_file_format: bpy.props.EnumProperty(
         name="Usd File Format",
-        items=(('USD', "usd", "Either of the usda or usdc"),
-               ('USDA', "usda", "Human-readable UTF-8 text"),
-               ('USDC', "usdc", "Random-access “Crate” binary")),
-        default='USD',
+        items=(('.usd', "usd", "Either of the usda or usdc"),
+               ('.usda', "usda", "Human-readable UTF-8 text"),
+               ('.usdc', "usdc", "Random-access “Crate” binary")),
+        default='.usd',
     )
 
     def draw(self, context):

--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -21,7 +21,7 @@ import bpy
 
 RS_SERVER_URL = ""
 RS_STORAGE_URL = ""
-RS_USER_ID = f"BlenderUser_{uuid.uuid4()}"
+RS_STORAGE_DIR = Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio"
 
 try:
     from . import configdev
@@ -41,11 +41,11 @@ def rs_enable(self, context):
 class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
     bl_idname = "hydrarpr"
 
-    rs_storage_dir: bpy.props.StringProperty(
-        name="Storage Dir",
-        description="Set directory which would be synchronized for all connected users",
-        subtype='DIR_PATH',
-        default=str(Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio Home"),
+    rs_enable: bpy.props.BoolProperty(
+        name="AMD RenderStudio",
+        description="Enable AMD RenderStudio",
+        default=False,
+        update=rs_enable,
     )
     rs_server_url: bpy.props.StringProperty(
         name="Server Address",
@@ -57,30 +57,18 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         description="Set address of remote assets storage",
         default=RS_STORAGE_URL,
     )
-    rs_user_id: bpy.props.StringProperty(
-        name="User ID",
-        description="Set unique user identifier",
-        default=RS_USER_ID,
-    )
-    rs_channel_id: bpy.props.StringProperty(
-        name="Channel ID",
-        description="Set channel identifier",
-        default="Blender",
+    rs_storage_dir: bpy.props.StringProperty(
+        name="Storage Dir",
+        description="Set directory which would be synchronized for all connected users",
+        subtype='DIR_PATH',
+        default=str(RS_STORAGE_DIR),
     )
     rs_file_format: bpy.props.EnumProperty(
         name="Usd File Format",
-        items=(
-            ('USD', "usd", "Either of the usda or usdc", 1),
-            ('USDA', "usda", "Human-readable UTF-8 text", 2),
-            ('USDC', "usdc", "Random-access “Crate” binary", 3),
-        ),
-        default=1,
-    )
-    rs_enable: bpy.props.BoolProperty(
-        name="AMD RenderStudio",
-        description="Enable AMD RenderStudio",
-        default=False,
-        update=rs_enable,
+        items=(('USD', "usd", "Either of the usda or usdc"),
+               ('USDA', "usda", "Human-readable UTF-8 text"),
+               ('USDC', "usdc", "Random-access “Crate” binary")),
+        default='USD',
     )
 
     def draw(self, context):
@@ -90,12 +78,9 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         row.prop(self, "rs_enable")
         if self.rs_enable:
             col = box.column(align=True)
+            # col.prop(self, "rs_server_url", icon='NONE')
             col.prop(self, "rs_storage_dir")
             col.prop(self, "rs_file_format")
-
-            # col.prop(self, "rs_server_url", icon='NONE')
-            # col.prop(self, "rs_user_id", icon='NONE')
-            # col.prop(self, "rs_channel_id", icon='NONE')
 
 
 def preferences():

--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ********************************************************************
 import uuid
+import os
 from pathlib import Path
 
 import bpy
@@ -28,6 +29,15 @@ except ImportError:
     pass
 
 
+def rs_enable(self, context):
+    from . import render_studio
+    if self.rs_enable:
+        render_studio.register()
+
+    else:
+        render_studio.unregister()
+
+
 class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
     bl_idname = "hydrarpr"
 
@@ -35,7 +45,7 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         name="Storage Dir",
         description="Set directory which would be synchronized for all connected users",
         subtype='DIR_PATH',
-        default=str(Path.home() / "Documents/AMD RenderStudio Home"),
+        default=str(Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio Home"),
     )
     rs_server_url: bpy.props.StringProperty(
         name="Server Address",
@@ -57,16 +67,35 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         description="Set channel identifier",
         default="Blender",
     )
+    rs_file_format: bpy.props.EnumProperty(
+        name="Usd File Format",
+        items=(
+            ('USD', "usd", "Either of the usda or usdc", 1),
+            ('USDA', "usda", "Human-readable UTF-8 text", 2),
+            ('USDC', "usdc", "Random-access “Crate” binary", 3),
+        ),
+        default=1,
+    )
+    rs_enable: bpy.props.BoolProperty(
+        name="AMD RenderStudio",
+        description="Enable AMD RenderStudio",
+        default=False,
+        update=rs_enable,
+    )
 
     def draw(self, context):
         layout = self.layout
         box = layout.box()
-        box.label(text="AMD RenderStudio Settings")
-        col = box.column(align=True)
-        col.prop(self, "rs_storage_dir", icon='NONE')
-        # col.prop(self, "rs_server_url", icon='NONE')
-        # col.prop(self, "rs_user_id", icon='NONE')
-        # col.prop(self, "rs_channel_id", icon='NONE')
+        row = box.row(align=True)
+        row.prop(self, "rs_enable")
+        if self.rs_enable:
+            col = box.column(align=True)
+            col.prop(self, "rs_storage_dir")
+            col.prop(self, "rs_file_format")
+
+            # col.prop(self, "rs_server_url", icon='NONE')
+            # col.prop(self, "rs_user_id", icon='NONE')
+            # col.prop(self, "rs_channel_id", icon='NONE')
 
 
 def preferences():

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -307,9 +307,9 @@ class RenderStudioSettings(bpy.types.PropertyGroup):
         default=False,
         update=live_sync_update,
     )
-    project_dir: StringProperty(
-        name="Project Directory",
-        description="The directory to which the files will be synchronized",
+    channel: StringProperty(
+        name="Channel",
+        description="Syncing Channel: directory to which the files will be synchronized",
         default=platform.node(),
     )
     filename: StringProperty(

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -228,10 +228,8 @@ class RenderSettings(bpy.types.PropertyGroup):
     render_quality: EnumProperty(
         name="Render Quality",
         description="Render Quality",
-        items=(
-            ('Northstar', "Full", "Full render quality"),
-            ('HybridPro', "Interactive", "Interactive render quality"),
-        ),
+        items=(('Northstar', "Full", "Full render quality"),
+               ('HybridPro', "Interactive", "Interactive render quality")),
         default='Northstar',
     )
     render_mode: EnumProperty(
@@ -375,9 +373,9 @@ class RenderStudioSettings(bpy.types.PropertyGroup):
     )
     evaluation_mode: EnumProperty(
         name="Use Settings for",
-        items=(('RENDER', "Render", "", 1),
-               ('VIEWPORT', "Viewport", "", 2)),
-        default=1,
+        items=(('RENDER', "Render", "Render evaluation mode"),
+               ('VIEWPORT', "Viewport", "Viewport evaluation mode")),
+        default='RENDER',
     )
 
 

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ********************************************************************
 import math
+import platform
 
 import bpy
 from bpy.props import (
@@ -21,6 +22,7 @@ from bpy.props import (
     FloatProperty,
     BoolProperty,
     IntProperty,
+    StringProperty,
 )
 
 
@@ -299,6 +301,76 @@ class RenderStudioSettings(bpy.types.PropertyGroup):
         name="Live Sync",
         description="Enable live syncing mode",
         default=False,
+    )
+    project_dir: StringProperty(
+        name="Project Directory",
+        description="The directory to which the files will be synchronized",
+        default=platform.node(),
+    )
+    filename: StringProperty(
+        name="Custom File Name",
+        description="The name of the synced Usd file: live empty to use current scene name",
+        default="",
+    )
+
+    # Blender Usd export settings
+    selected_objects_only: BoolProperty(
+        name="Selection Only",
+        default=False,
+    )
+    visible_objects_only: BoolProperty(
+        name="Visible Only",
+        default=True,
+    )
+    export_animation: BoolProperty(
+        name="Animation",
+        default=False,
+    )
+    export_hair: BoolProperty(
+        name="Hair",
+        default=False,
+    )
+    export_uvmaps: BoolProperty(
+        name="UV Maps",
+        default=True,
+    )
+    export_normals: BoolProperty(
+        name="Normals",
+        default=True,
+    )
+    export_materials: BoolProperty(
+        name="Materials",
+        default=True,
+    )
+    root_prim_path: StringProperty(
+        name="Root Prim",
+        default="",
+    )
+    generate_preview_surface: BoolProperty(
+        name="To Usd Preview",
+        default=True,
+    )
+    export_textures: BoolProperty(
+        name="Export Textures",
+        default=True,
+    )
+    overwrite_textures: BoolProperty(
+        name="Overwrite Textures",
+        default=False,
+    )
+    relative_paths: BoolProperty(
+        name="Relative Paths",
+        default=True,
+    )
+    use_instancing: BoolProperty(
+        name="Instancing",
+        default=False,
+    )
+    evaluation_mode: EnumProperty(
+        name="Use Settings for",
+        items=(('RENDER', "Render", "", 1),
+               ('VIEWPORT', "Viewport", "", 2)),
+        default=1,
     )
 
 

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -29,6 +29,7 @@ class Resolver:
         self.is_connected = False
         self.is_depsgraph_update = True
         self.is_syncing = False
+        self.filename = ""
 
     def connect(self):
         pref = preferences()
@@ -45,6 +46,7 @@ class Resolver:
         RenderStudioKit.SharedWorkspaceDisconnect()
         self.is_connected = False
         self.is_syncing = False
+        self.filename = ""
 
         from .ui import update_button
         update_button()
@@ -60,8 +62,9 @@ class Resolver:
     def sync_scene(self):
         pref = preferences()
         settings = bpy.context.scene.hydra_rpr.render_studio
-        filename = f"{settings.filename if settings.filename else bpy.context.scene.name}.{pref.rs_file_format.lower()}"
-        usd_path = Path(pref.rs_storage_dir) / settings.project_dir / filename
+        self.filename = Path(bpy.data.filepath).stem if bpy.data.filepath else "untitled"
+        self.filename += pref.rs_file_format
+        usd_path = Path(pref.rs_storage_dir) / settings.channel / self.filename
 
         log("Syncing scene", usd_path)
         self.is_depsgraph_update = False

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -61,7 +61,7 @@ class Resolver:
         pref = preferences()
         settings = bpy.context.scene.hydra_rpr.render_studio
         filename = f"{settings.filename if settings.filename else bpy.context.scene.name}.{pref.rs_file_format.lower()}"
-        usd_path = (Path(pref.rs_storage_dir) / settings.project_dir / filename)
+        usd_path = Path(pref.rs_storage_dir) / settings.project_dir / filename
 
         log("Syncing scene", usd_path)
         self.is_depsgraph_update = False

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -35,34 +35,24 @@ class RS_RESOLVER_PT_resolver(Panel):
         col.enabled = rs_resolver.is_connected
         col.separator()
 
-        col = col.column()
+        col1 = col.column(align=True)
         if settings.live_sync:
             if rs_resolver.is_syncing:
-                col.operator("render_studio.stop_live_sync", icon='CANCEL')
+                col1.operator("render_studio.stop_live_sync", icon='CANCEL')
             else:
-                col.operator("render_studio.start_live_sync", icon='FILE_REFRESH')
+                col1.operator("render_studio.start_live_sync", icon='FILE_REFRESH')
         else:
-            col.operator("render_studio.sync_scene", icon='FILE_REFRESH')
+            col1.operator("render_studio.sync_scene", icon='FILE_REFRESH')
 
-        col.prop(settings, "live_sync")
+        col1.prop(settings, "live_sync")
 
+        col.separator()
+        col.prop(settings, "channel")
 
-class RS_RESOLVER_PT_sync_settings(Panel):
-    bl_parent_id = RS_RESOLVER_PT_resolver.bl_idname
-    bl_label = "Sync Settings"
-    bl_options = {'DEFAULT_CLOSED'}
-
-    def draw(self, context):
-        layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-
-        settings = context.scene.hydra_rpr.render_studio
-
-        col = layout.column()
-        col.enabled = rs_resolver.is_connected
-        col.prop(settings, "project_dir")
-        col.prop(settings, "filename")
+        if rs_resolver.filename:
+            col1 = col.column(align=True)
+            col1.label(text="Syncing to:")
+            col1.label(text=f"{settings.channel}/{rs_resolver.filename}")
 
 
 class RS_RESOLVER_PT_usd_settings(Panel):
@@ -80,6 +70,7 @@ class RS_RESOLVER_PT_usd_settings(Panel):
         col = layout.column()
         col.enabled = rs_resolver.is_connected
         col.separator()
+
         col.prop(settings, "selected_objects_only")
         col.prop(settings, "visible_objects_only")
         col.prop(settings, "export_animation")
@@ -90,15 +81,17 @@ class RS_RESOLVER_PT_usd_settings(Panel):
         col.prop(settings, "root_prim_path")
         col.prop(settings, "evaluation_mode")
         col.separator()
+
         col1 = col.column()
         col1.enabled = settings.export_materials
         col1.prop(settings, "generate_preview_surface")
         col1.prop(settings, "export_textures")
         col1.prop(settings, "overwrite_textures")
         col.separator()
-        col = col.column()
+
         col.prop(settings, "relative_paths")
         col.separator()
+
         col.prop(settings, "use_instancing")
 
 
@@ -121,6 +114,5 @@ def update_button():
 
 register, unregister = bpy.utils.register_classes_factory((
     RS_RESOLVER_PT_resolver,
-    RS_RESOLVER_PT_sync_settings,
     RS_RESOLVER_PT_usd_settings,
 ))

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -67,7 +67,7 @@ class RS_RESOLVER_PT_sync_settings(Panel):
 
 class RS_RESOLVER_PT_usd_settings(Panel):
     bl_parent_id = RS_RESOLVER_PT_resolver.bl_idname
-    bl_label = "Usd Settings"
+    bl_label = "USD Settings"
     bl_options = {'DEFAULT_CLOSED'}
 
     def draw(self, context):

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -19,6 +19,7 @@ from ..ui import Panel
 
 
 class RS_RESOLVER_PT_resolver(Panel):
+    bl_idname = 'RS_RESOLVER_PT_resolver'
     bl_label = "AMD RenderStudio"
 
     def draw(self, context):
@@ -44,8 +45,61 @@ class RS_RESOLVER_PT_resolver(Panel):
             col.operator("render_studio.sync_scene", icon='FILE_REFRESH')
 
         col.prop(settings, "live_sync")
+
+
+class RS_RESOLVER_PT_sync_settings(Panel):
+    bl_parent_id = RS_RESOLVER_PT_resolver.bl_idname
+    bl_label = "Sync Settings"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        settings = context.scene.hydra_rpr.render_studio
+
+        col = layout.column()
+        col.enabled = rs_resolver.is_connected
+        col.prop(settings, "project_dir")
+        col.prop(settings, "filename")
+
+
+class RS_RESOLVER_PT_usd_settings(Panel):
+    bl_parent_id = RS_RESOLVER_PT_resolver.bl_idname
+    bl_label = "Usd Settings"
+    bl_options = {'DEFAULT_CLOSED'}
+
+    def draw(self, context):
+        layout = self.layout
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+
+        settings = context.scene.hydra_rpr.render_studio
+
+        col = layout.column()
+        col.enabled = rs_resolver.is_connected
         col.separator()
-        layout.label(text=f"Status: {rs_resolver.status}")
+        col.prop(settings, "selected_objects_only")
+        col.prop(settings, "visible_objects_only")
+        col.prop(settings, "export_animation")
+        col.prop(settings, "export_hair")
+        col.prop(settings, "export_uvmaps")
+        col.prop(settings, "export_normals")
+        col.prop(settings, "export_materials")
+        col.prop(settings, "root_prim_path")
+        col.prop(settings, "evaluation_mode")
+        col.separator()
+        col1 = col.column()
+        col1.enabled = settings.export_materials
+        col1.prop(settings, "generate_preview_surface")
+        col1.prop(settings, "export_textures")
+        col1.prop(settings, "overwrite_textures")
+        col.separator()
+        col = col.column()
+        col.prop(settings, "relative_paths")
+        col.separator()
+        col.prop(settings, "use_instancing")
 
 
 def draw_button(self, context):
@@ -65,9 +119,8 @@ def update_button():
                         region.tag_redraw()
 
 
-def register():
-    bpy.utils.register_class(RS_RESOLVER_PT_resolver)
-
-
-def unregister():
-    bpy.utils.unregister_class(RS_RESOLVER_PT_resolver)
+register, unregister = bpy.utils.register_classes_factory((
+    RS_RESOLVER_PT_resolver,
+    RS_RESOLVER_PT_sync_settings,
+    RS_RESOLVER_PT_usd_settings,
+))


### PR DESCRIPTION
### TECHNICAL STEPS
* Added property `rs_enable` to register/unregister `render_studio`.
* Added property `rs_file_format` to set extension for sync file.
* Added `Sync Settings` panel to be able to set up sync directory and sync file name.
* Added `Usd Settings` panel to expose usd export settings.
* Set the default `Storage Dir` to `../AppData/Roaming/AMD RenderStudio Home`.
* Removed Status.

![image](https://github.com/GPUOpen-LibrariesAndSDKs/BlenderUSDHydraAddon/assets/42581166/7d82b359-04d7-41a5-8604-d84473182a6d)

