### PR TITLE
BLEN-582: Add scene update handlers: Live sync mode

### DIFF
--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -294,11 +294,18 @@ class RenderSettings(bpy.types.PropertyGroup):
     denoise: PointerProperty(type=DenoiseSettings)
 
 
+def live_sync_update(self, context):
+    from .render_studio.resolver import rs_resolver
+    if not self.live_sync and rs_resolver.is_syncing:
+        rs_resolver.stop_live_sync()
+
+
 class RenderStudioSettings(bpy.types.PropertyGroup):
     live_sync: BoolProperty(
         name="Live Sync",
         description="Enable live syncing mode",
         default=False,
+        update=live_sync_update,
     )
 
 

--- a/src/hydrarpr/render_studio/__init__.py
+++ b/src/hydrarpr/render_studio/__init__.py
@@ -21,7 +21,6 @@ def register():
 
     from . import resolver, ui, operators
 
-    resolver.register()
     operators.register()
     ui.register()
 

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -53,12 +53,12 @@ class Resolver:
         update_button()
 
     def start_live_sync(self):
-        # TODO: Implement start live sync
+        bpy.app.handlers.depsgraph_update_post.append(on_depsgraph_update_post)
         self.is_syncing = True
         self.status = "Syncing..."
 
     def stop_live_sync(self):
-        # TODO: Implement stop live sync
+        bpy.app.handlers.depsgraph_update_post.remove(on_depsgraph_update_post)
         self.is_syncing = False
         self.status = "Connected"
 
@@ -86,13 +86,9 @@ def on_depsgraph_update_post(scene, depsgraph):
     rs_resolver.sync_scene()
 
 
-def register():
-    bpy.app.handlers.depsgraph_update_post.append(on_depsgraph_update_post)
-
-
 def unregister():
-    if on_depsgraph_update_post in bpy.app.handlers.depsgraph_update_post:
-        bpy.app.handlers.depsgraph_update_post.remove(on_depsgraph_update_post)
+    if rs_resolver.is_syncing:
+        rs_resolver.stop_live_sync()
 
     if rs_resolver.is_connected:
         rs_resolver.disconnect()


### PR DESCRIPTION
### TECHNICAL STEPS
* Moved handlers to `start_live_mode` and `stop_live_mode` methods respectively.
* Removed `register` method and improved `unregister`.
* Fixed: if disable `Live Sync` it still performs sync, now it stops live sync.