### PR TITLE
BLEN-606: Add support for workspace URL

### DIFF
--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -19,9 +19,8 @@ from pathlib import Path
 import bpy
 
 
-RS_SERVER_URL = ""
-RS_STORAGE_URL = ""
-RS_STORAGE_DIR = Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio"
+RS_WORKSPACE_URL = ""
+RS_WORKSPACE_DIR = Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio"
 
 try:
     from . import configdev
@@ -45,21 +44,16 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         default=False,
         update=rs_enable_update,
     )
-    rs_server_url: bpy.props.StringProperty(
-        name="Server Address",
-        description="Set address of remote live server",
-        default=RS_SERVER_URL,
-    )
-    rs_storage_url: bpy.props.StringProperty(
-        name="Storage Address",
-        description="Set address of remote assets storage",
-        default=RS_STORAGE_URL,
-    )
-    rs_storage_dir: bpy.props.StringProperty(
-        name="Storage Dir",
+    rs_workspace_dir: bpy.props.StringProperty(
+        name="Workspace Dir",
         description="Set directory which would be synchronized for all connected users",
         subtype='DIR_PATH',
-        default=str(RS_STORAGE_DIR),
+        default=str(RS_WORKSPACE_DIR),
+    )
+    rs_workspace_url: bpy.props.StringProperty(
+        name="Workspace Url",
+        description="Set directory which would be synchronized for all connected users",
+        default=RS_WORKSPACE_URL,
     )
     rs_file_format: bpy.props.EnumProperty(
         name="Usd File Format",
@@ -76,8 +70,8 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         row.prop(self, "rs_enable")
         if self.rs_enable:
             col = box.column(align=True)
-            # col.prop(self, "rs_server_url", icon='NONE')
-            col.prop(self, "rs_storage_dir")
+            col.prop(self, "rs_workspace_url")
+            col.prop(self, "rs_workspace_dir")
             col.prop(self, "rs_file_format")
 
 

--- a/src/hydrarpr/properties.py
+++ b/src/hydrarpr/properties.py
@@ -363,10 +363,6 @@ class RenderStudioSettings(bpy.types.PropertyGroup):
         name="Overwrite Textures",
         default=False,
     )
-    relative_paths: BoolProperty(
-        name="Relative Paths",
-        default=True,
-    )
     use_instancing: BoolProperty(
         name="Instancing",
         default=False,

--- a/src/hydrarpr/render_studio/operators.py
+++ b/src/hydrarpr/render_studio/operators.py
@@ -35,6 +35,7 @@ class RESOLVER_OP_disconnect(bpy.types.Operator):
 
     def execute(self, context):
         rs_resolver.disconnect()
+
         return {'FINISHED'}
 
 
@@ -45,6 +46,7 @@ class RESOLVER_OP_sync_scene(bpy.types.Operator):
 
     def execute(self, context):
         rs_resolver.sync_scene()
+
         return {'FINISHED'}
 
 
@@ -55,6 +57,7 @@ class RESOLVER_OP_start_live_sync(bpy.types.Operator):
 
     def execute(self, context):
         rs_resolver.start_live_sync()
+
         return {'FINISHED'}
 
 
@@ -65,6 +68,7 @@ class RESOLVER_OP_stop_live_sync(bpy.types.Operator):
 
     def execute(self, context):
         rs_resolver.stop_live_sync()
+
         return {'FINISHED'}
 
 

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -33,12 +33,19 @@ class Resolver:
 
     def connect(self):
         pref = preferences()
-        if pref.rs_workspace_url:
-            RenderStudioKit.SetWorkspaceUrl(pref.rs_workspace_url)
+        if not pref.rs_workspace_url:
+            log("Remote server URL is empty")
+            return
 
+        RenderStudioKit.SetWorkspaceUrl(pref.rs_workspace_url)
         RenderStudioKit.SetWorkspacePath(pref.rs_workspace_dir)
-        RenderStudioKit.SharedWorkspaceConnect()
-        self.is_connected = True
+
+        try:
+            RenderStudioKit.SharedWorkspaceConnect()
+            self.is_connected = True
+
+        except RuntimeError:
+            log("Failed connect to remote server", pref.rs_workspace_url)
 
         from .ui import update_button
         update_button()
@@ -78,7 +85,6 @@ class Resolver:
                 visible_objects_only=settings.visible_objects_only,
                 export_animation=settings.export_animation,
                 export_hair=settings.export_hair,
-                # export_mesh_colors=settings.export_mesh_colors,
                 export_normals=settings.export_normals,
                 export_materials=settings.export_materials,
                 use_instancing=settings.use_instancing,
@@ -86,7 +92,6 @@ class Resolver:
                 generate_preview_surface=settings.generate_preview_surface,
                 export_textures=settings.export_textures,
                 overwrite_textures=settings.overwrite_textures,
-                relative_paths=settings.relative_paths,
                 root_prim_path=settings.root_prim_path,
             )
         finally:

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -48,7 +48,7 @@ class Resolver:
             log.info("Connected")
 
         except RuntimeError:
-            log.warn("Failed connect to remote server", pref.rs_workspace_url)
+            log.error("Failed connect to remote server", pref.rs_workspace_url)
 
     def disconnect(self):
         from rs import RenderStudioKit

--- a/src/hydrarpr/render_studio/resolver.py
+++ b/src/hydrarpr/render_studio/resolver.py
@@ -33,7 +33,10 @@ class Resolver:
 
     def connect(self):
         pref = preferences()
-        RenderStudioKit.SetWorkspacePath(pref.rs_storage_dir)
+        if pref.rs_workspace_url:
+            RenderStudioKit.SetWorkspaceUrl(pref.rs_workspace_url)
+
+        RenderStudioKit.SetWorkspacePath(pref.rs_workspace_dir)
         RenderStudioKit.SharedWorkspaceConnect()
         self.is_connected = True
 
@@ -64,7 +67,7 @@ class Resolver:
         settings = bpy.context.scene.hydra_rpr.render_studio
         self.filename = Path(bpy.data.filepath).stem if bpy.data.filepath else "untitled"
         self.filename += pref.rs_file_format
-        usd_path = Path(pref.rs_storage_dir) / settings.channel / self.filename
+        usd_path = Path(pref.rs_workspace_dir) / settings.channel / self.filename
 
         log("Syncing scene", usd_path)
         self.is_depsgraph_update = False

--- a/src/hydrarpr/render_studio/ui.py
+++ b/src/hydrarpr/render_studio/ui.py
@@ -62,37 +62,36 @@ class RS_RESOLVER_PT_usd_settings(Panel):
 
     def draw(self, context):
         layout = self.layout
-        layout.use_property_split = True
-        layout.use_property_decorate = False
-
         settings = context.scene.hydra_rpr.render_studio
 
-        col = layout.column()
-        col.enabled = rs_resolver.is_connected
-        col.separator()
+        layout.use_property_split = True
+        layout.use_property_decorate = False
+        layout.enabled = rs_resolver.is_connected
 
+        col = layout.column(align=True)
         col.prop(settings, "selected_objects_only")
         col.prop(settings, "visible_objects_only")
+
+        col = layout.column(align=True)
         col.prop(settings, "export_animation")
         col.prop(settings, "export_hair")
+        col.prop(settings, "use_instancing")
+
+        col = layout.column(align=True)
         col.prop(settings, "export_uvmaps")
         col.prop(settings, "export_normals")
-        col.prop(settings, "export_materials")
-        col.prop(settings, "root_prim_path")
-        col.prop(settings, "evaluation_mode")
-        col.separator()
 
-        col1 = col.column()
+        col = layout.column(align=True)
+        col.prop(settings, "export_materials")
+        col1 = col.column(align=True)
         col1.enabled = settings.export_materials
         col1.prop(settings, "generate_preview_surface")
         col1.prop(settings, "export_textures")
         col1.prop(settings, "overwrite_textures")
-        col.separator()
 
-        col.prop(settings, "relative_paths")
-        col.separator()
-
-        col.prop(settings, "use_instancing")
+        col = layout.column()
+        col.prop(settings, "root_prim_path")
+        col.prop(settings, "evaluation_mode")
 
 
 def draw_button(self, context):


### PR DESCRIPTION
### EFFECT OF CHANGE
* Added ability to set up Workspace URL (remote server address)
* Update `RenderStudioKit` submodule with https://github.com/Radeon-Pro/RenderStudioKit/pull/19.
* UI alignment improvements.
* Removed `Relative Paths`, it is `True` by default.