### PR TITLE
Fix build of the addon for Linux and MacOS

### DIFF
--- a/build.py
+++ b/build.py
@@ -563,12 +563,15 @@ def render_studio(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
     openssl_dir = Path(os.environ["OPENSSL_ROOT_DIR"])
     libdir = bl_libs_dir.as_posix()
     usd_monolitic_path = f'{usd_dir / "lib" / (f"{LIBPREFIX}usd_ms_d{LIBEXT}" if build_var == "debug" else f"{LIBPREFIX}usd_ms{LIBEXT}")}'
-
+    py_exe = f"{libdir}/python/310/bin/python.exe" if OS == 'Windows' else f"{libdir}/python/bin/python3.10"
     os.environ['PXR_PLUGINPATH_NAME'] = str(usd_dir / "lib/usd")
 
     # Boost flags
     args = [
         "-DPXR_ENABLE_PYTHON_SUPPORT=ON",
+        f"-DPYTHON_INCLUDE_DIR={libdir}/python/310/include",
+        f"-DPYTHON_LIBRARY={libdir}/python/310/libs/python310.lib",
+        f"-DPYTHON_EXECUTABLE={py_exe}",
 
         "-DCMAKE_CXX_FLAGS=/Zc:inline- /EHsc /bigobj /DBOOST_ALL_NO_LIB",
         f"-DBoost_COMPILER:STRING=-vc142",

--- a/build.py
+++ b/build.py
@@ -283,6 +283,9 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
 
 def boost(bin_dir, clean):
     print_start("Building Boost")
+    if OS != 'Windows':
+        print(f"{OS} is currently unsupported  for RenderStudio")
+        return
 
     BOOST_URL = "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.zip"
 
@@ -549,6 +552,9 @@ ctypes.CDLL(r"{bl_libs_dir / 'openexr/lib/libOpenEXRCore.dylib'}")
 
 def render_studio(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
     print_start("Building RenderStudioKit")
+    if OS != 'Windows':
+        print(f"{OS} is currently unsupported for RenderStudio")
+        return
 
     deps_dir = repo_dir / "deps"
     rs_dir = deps_dir / "RenderStudioKit"
@@ -700,8 +706,10 @@ def zip_addon(bin_dir):
 
         print("-------------------------------------------------------------")
         yield from enumerate_hdrpr_data(bin_dir / "hdrpr")
-        print("-------------------------------------------------------------")
-        yield from enumerate_rs_data(bin_dir / "render_studio")
+
+        if OS == 'Windows':
+            print("-------------------------------------------------------------")
+            yield from enumerate_rs_data(bin_dir / "render_studio")
 
     install_dir = repo_dir / "install"
     if not install_dir.is_dir():

--- a/build.py
+++ b/build.py
@@ -283,9 +283,6 @@ def usd(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var, git_apply):
 
 def boost(bin_dir, clean):
     print_start("Building Boost")
-    if OS != 'Windows':
-        print(f"{OS} is currently unsupported  for RenderStudio")
-        return
 
     BOOST_URL = "https://boostorg.jfrog.io/artifactory/main/release/1.80.0/source/boost_1_80_0.zip"
 
@@ -552,9 +549,6 @@ ctypes.CDLL(r"{bl_libs_dir / 'openexr/lib/libOpenEXRCore.dylib'}")
 
 def render_studio(bl_libs_dir, bin_dir, compiler, jobs, clean, build_var):
     print_start("Building RenderStudioKit")
-    if OS != 'Windows':
-        print(f"{OS} is currently unsupported for RenderStudio")
-        return
 
     deps_dir = repo_dir / "deps"
     rs_dir = deps_dir / "RenderStudioKit"
@@ -754,12 +748,14 @@ def main():
                     help="Build MaterialX")
     ap.add_argument("-usd", required=False, action="store_true",
                     help="Build USD")
-    ap.add_argument("-boost", required=False, action="store_true",
-                    help="Build Boost")
+    if OS == 'Windows':
+        ap.add_argument("-boost", required=False, action="store_true",
+                        help="Build Boost")
     ap.add_argument("-hdrpr", required=False, action="store_true",
                     help="Build HdRPR")
-    ap.add_argument("-rs", required=False, action="store_true",
-                    help="Build RenderStudioKit")
+    if OS == 'Windows':
+        ap.add_argument("-rs", required=False, action="store_true",
+                        help="Build RenderStudioKit")
     ap.add_argument("-addon", required=False, action="store_true",
                     help="Create zip addon")
 

--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 # ********************************************************************
 import os
+import platform
 from pathlib import Path
 
 import bpy
@@ -73,6 +74,9 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         layout = self.layout
 
         layout.prop(self, "log_level")
+
+        if platform.system() == 'Windows':
+            return
 
         box = layout.box()
         row = box.row(align=True)


### PR DESCRIPTION
### TECHNICAL STEPS
* Hide RenderStudio preferences for Linux and MacOS.
* Disabled RenderStudioKit and Boost build for Linux And MacOS.
* Fixed Python dependency.
