### PR TITLE
BLEN-611: Add support for RenderStudioWatchdog service

### DIFF
--- a/build.py
+++ b/build.py
@@ -824,7 +824,11 @@ def main():
         materialx()
 
     if args.all or args.usd:
-        usd()
+        installed_modules = install_requirements(["jinja2"])
+        try:
+            usd()
+        finally:
+            uninstall_requirements(installed_modules)
 
     if OS == 'Windows' and (args.all or args.boost):
         boost()
@@ -837,7 +841,11 @@ def main():
             uninstall_requirements(installed_modules)
 
     if OS == 'Windows' and (args.all or args.rs):
-        installed_modules = install_requirements(["uvicorn==0.22.0", "pyinstaller==5.13.2", "websockets==10.4"])
+        # deps/RenderStudioKit/Watchdog/requirements.txt
+        installed_modules = install_requirements(["uvicorn==0.22.0",
+                                                  "pyinstaller==5.13.2",
+                                                  "websockets==10.4",
+                                                  "httpx==0.24.1"])
         try:
             render_studio()
         finally:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,5 @@
 jinja2
+fastapi==0.103.2
+uvicorn==0.22.0
+pyinstaller==5.13.2
+websockets==10.4

--- a/src/hydrarpr/__init__.py
+++ b/src/hydrarpr/__init__.py
@@ -42,8 +42,7 @@ LIBS_DIR = Path(__file__).parent / "libs"
 
 def register():
     if platform.system() == 'Windows':
-        os.environ['PATH'] = os.environ['PATH'] + \
-            os.pathsep + str(LIBS_DIR / "lib")
+        os.environ['PATH'] = os.environ['PATH'] + os.pathsep + str(LIBS_DIR / "lib")
 
     sys.path.append(str(LIBS_DIR / "python"))
     Plug.Registry().RegisterPlugins(str(LIBS_DIR / "plugin"))

--- a/src/hydrarpr/preferences.py
+++ b/src/hydrarpr/preferences.py
@@ -54,7 +54,7 @@ class RPR_HYDRA_ADDON_PT_preferences(bpy.types.AddonPreferences):
         name="Workspace Dir",
         description="Set directory which would be synchronized for all connected users",
         subtype='DIR_PATH',
-        default=str(Path(os.path.expandvars('%appdata%')) / "AMD RenderStudio"),
+        default=str(Path(os.path.expandvars('%programdata%')) / "AMD/AMD RenderStudio/Workspace"),
     )
     rs_workspace_url: bpy.props.StringProperty(
         name="Workspace Url",

--- a/src/hydrarpr/render_studio/__init__.py
+++ b/src/hydrarpr/render_studio/__init__.py
@@ -16,8 +16,7 @@ from pxr import Plug
 
 
 def register():
-    usd_plugin = Plug.Registry().GetPluginWithName('RenderStudioResolver')
-    usd_plugin.Load()
+    Plug.Registry().GetPluginWithName('RenderStudioResolver').Load()
 
     from . import resolver, ui, operators
 


### PR DESCRIPTION
### TECHNICAL STEPS
* Added Python deps to `requirements.txt`.
* Adjusted and improved the build script.
* Changed default `workspacedir` to `%ProgramData%/AMD/AMD RenderStudio/Workspace`.
* Updated `RenderStudioKit` SDK.
